### PR TITLE
Update manifests from CRD changes.

### DIFF
--- a/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
@@ -35,22 +35,9 @@ spec:
               currentDropletRef:
                 description: CurrentDropletRef provides reference to the droplet currently assigned (active) for the app
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               desiredState:

--- a/config/crd/bases/workloads.cloudfoundry.org_cfbuilds.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfbuilds.yaml
@@ -35,22 +35,9 @@ spec:
               appRef:
                 description: Specifies the CFApp associated with this build
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               lifecycle:
@@ -82,22 +69,9 @@ spec:
               packageRef:
                 description: Specifies the CFPackage associated with this build
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
             required:
@@ -155,22 +129,9 @@ spec:
               dropletRef:
                 description: ResourceReference defines a reference to an instance of a resource in Kubernetes
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
             required:

--- a/config/crd/bases/workloads.cloudfoundry.org_cfdroplets.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfdroplets.yaml
@@ -35,43 +35,17 @@ spec:
               appRef:
                 description: Specifies the App associated with this Droplet
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               buildRef:
                 description: Specifies the Build associated with this Droplet
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               ports:
@@ -81,10 +55,18 @@ spec:
                   type: integer
                 type: array
               processTypes:
-                additionalProperties:
-                  type: string
                 description: Specifies the process types and associated start commands for the Droplet
-                type: object
+                items:
+                  properties:
+                    command:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - command
+                  - type
+                  type: object
+                type: array
               registry:
                 description: Specifies the Container registry image, and secrets to access
                 properties:

--- a/config/crd/bases/workloads.cloudfoundry.org_cfpackages.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfpackages.yaml
@@ -35,22 +35,9 @@ spec:
               appRef:
                 description: AppRef reference to the CFApp that owns this package
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               source:

--- a/config/crd/bases/workloads.cloudfoundry.org_cfprocesses.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfprocesses.yaml
@@ -35,22 +35,9 @@ spec:
               appRef:
                 description: Specifies the App that owns this process
                 properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    description: CFKind defines allowed value for Kind in ResourceReference
-                    enum:
-                    - CFApp
-                    - CFBuild
-                    - CFPackage
-                    - CFDroplet
-                    - CFProcess
-                    type: string
                   name:
                     type: string
                 required:
-                - apiVersion
-                - kind
                 - name
                 type: object
               command:


### PR DESCRIPTION
Running `make manifests` caused diffs to appear. This aligns the bases with the CRD code.

Co-authored-by: Akira Wong <wakira@vmware.com>