### PR TITLE
Remove unused CFRoute.Port

### DIFF
--- a/apis/networking/v1alpha1/cfroute_types.go
+++ b/apis/networking/v1alpha1/cfroute_types.go
@@ -51,8 +51,6 @@ type CFRouteSpec struct {
 	Path string `json:"path,omitempty"`
 	// Protocol is optional, defaults to http. Dependent on allow-listed protocols on domain.
 	Protocol Protocol `json:"protocol,omitempty"`
-	// Port is optional, CF Routes only allow port info on TCP routes.
-	Port int `json:"port,omitempty"`
 	// Domain ref is required, provides base domain name and allowed protocol info.
 	DomainRef v1.LocalObjectReference `json:"domainRef"`
 	// Destinations are optional, a route can exist independently of being mapped to apps.

--- a/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
+++ b/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
@@ -68,9 +68,6 @@ spec:
               path:
                 description: Path is optional, defaults to empty.
                 type: string
-              port:
-                description: Port is optional, CF Routes only allow port info on TCP routes.
-                type: integer
               protocol:
                 description: Protocol is optional, defaults to http. Dependent on allow-listed protocols on domain.
                 enum:


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: [#23](https://github.com/cloudfoundry/cf-k8s-api/issues/23)

## What is this change about?
Remove the unused CFRoute.Port as our initial implementation only supports HTTP routing, which does not allow users to specify a port.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Describe a CFRoute resource and see that it no longer includes a port.

## Tag your pair, your PM, and/or team
@acosta11 