### PR TITLE
Update suite setup script for mutating webhooks to run once per package

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -27,6 +27,9 @@ resources:
   kind: CFPackage
   path: code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -66,7 +69,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: false
   controller: true
   domain: cloudfoundry.org
   group: networking

--- a/apis/workloads/v1alpha1/cfapp_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/cfapp_webhook_integration_test.go
@@ -1,7 +1,6 @@
 package v1alpha1_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -18,12 +17,10 @@ func integrationTestCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 	when("a CFApp record is created", func() {
 		const (
-			cfAppGUID     = "test-app-guid"
-			namespace     = "default"
-			cfAppLabelKey = "apps.cloudfoundry.org/appGuid"
+			cfAppGUID = "test-app-guid"
+			namespace = "default"
 		)
 		it(" should add a metadata label on it and it matches metadata.name", func() {
-			ctx := context.Background()
 			//Creating a CFApp resource
 			cfApp := &v1alpha1.CFApp{
 				TypeMeta: metav1.TypeMeta{
@@ -56,7 +53,7 @@ func integrationTestCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 				return createdCFApp.ObjectMeta.Labels
 			}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty())
 
-			g.Expect(createdCFApp.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfAppGUID))
+			g.Expect(createdCFApp.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
 
 		})
 	})

--- a/apis/workloads/v1alpha1/cfapp_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/cfapp_webhook_integration_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -20,6 +21,10 @@ func integrationTestCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 			cfAppGUID = "test-app-guid"
 			namespace = "default"
 		)
+		var ctx context.Context
+		it.Before(func() {
+			ctx = context.Background()
+		})
 		it(" should add a metadata label on it and it matches metadata.name", func() {
 			//Creating a CFApp resource
 			cfApp := &v1alpha1.CFApp{

--- a/apis/workloads/v1alpha1/cfapp_webhook_test.go
+++ b/apis/workloads/v1alpha1/cfapp_webhook_test.go
@@ -19,9 +19,8 @@ func testCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 
 	const (
-		cfAppGUID     = "test-app-guid"
-		namespace     = "default"
-		cfAppLabelKey = "apps.cloudfoundry.org/appGuid"
+		cfAppGUID = "test-app-guid"
+		namespace = "default"
 	)
 
 	when("there are no existing labels on the CFAPP record", func() {
@@ -45,7 +44,7 @@ func testCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			cfApp.Default()
-			g.Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfAppGUID))
+			g.Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
 		})
 	})
 
@@ -74,6 +73,7 @@ func testCFAppWebhook(t *testing.T, when spec.G, it spec.S) {
 
 			cfApp.Default()
 			g.Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue("anotherLabel", "app-label"))
+			g.Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
 		})
 	})
 }

--- a/apis/workloads/v1alpha1/cfpackage_webhook.go
+++ b/apis/workloads/v1alpha1/cfpackage_webhook.go
@@ -23,9 +23,9 @@ import (
 )
 
 // log is for logging in this package.
-var cfapplog = logf.Log.WithName("cfapp-resource")
+var cfpackagelog = logf.Log.WithName("cfpackage-resource")
 
-func (r *CFApp) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (r *CFPackage) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
@@ -33,17 +33,17 @@ func (r *CFApp) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-workloads-cloudfoundry-org-v1alpha1-cfapp,mutating=true,failurePolicy=fail,sideEffects=None,groups=workloads.cloudfoundry.org,resources=cfapps,verbs=create;update,versions=v1alpha1,name=mcfapp.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-workloads-cloudfoundry-org-v1alpha1-cfpackage,mutating=true,failurePolicy=fail,sideEffects=None,groups=workloads.cloudfoundry.org,resources=cfpackages,verbs=create;update,versions=v1alpha1,name=mcfpackage.kb.io,admissionReviewVersions={v1,v1beta1}
 
-var _ webhook.Defaulter = &CFApp{}
+var _ webhook.Defaulter = &CFPackage{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *CFApp) Default() {
-	cfapplog.Info("Mutating CFApp webhook handler", "name", r.Name)
-	appLabels := r.ObjectMeta.GetLabels()
-	if appLabels == nil {
-		appLabels = make(map[string]string)
+func (r *CFPackage) Default() {
+	cfpackagelog.Info("Mutating CFPackage webhook handler", "name", r.Name)
+	packageLabels := r.ObjectMeta.GetLabels()
+	if packageLabels == nil {
+		packageLabels = make(map[string]string)
 	}
-	appLabels[CFAppLabelKey] = r.Name
-	r.ObjectMeta.SetLabels(appLabels)
+	packageLabels[CFAppLabelKey] = r.Spec.AppRef.Name
+	r.ObjectMeta.SetLabels(packageLabels)
 }

--- a/apis/workloads/v1alpha1/cfpackage_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/cfpackage_webhook_integration_test.go
@@ -1,0 +1,87 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = AddToTestSuite("CFPackageWebhook", integrationTestCFPackageWebhook)
+
+func integrationTestCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
+	g := NewWithT(t)
+	when("a CFApp record exists", func() {
+		var cfApp *v1alpha1.CFApp
+		const (
+			cfAppGUID     = "test-app-guid"
+			cfPackageGUID = "test-package-guid"
+			cfPackageType = "bits"
+			namespace     = "default"
+		)
+		it.Before(func() {
+			cfApp = &v1alpha1.CFApp{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CFApp",
+					APIVersion: v1alpha1.GroupVersion.Identifier(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfAppGUID,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.CFAppSpec{
+					Name:         "test-app",
+					DesiredState: "STOPPED",
+					Lifecycle: v1alpha1.Lifecycle{
+						Type: "buildpack",
+					},
+				},
+			}
+			g.Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
+		})
+		when("a CFPackage record referencing the CFAPP is created", func() {
+			it.Before(func() {
+				cfPackage := &v1alpha1.CFPackage{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CFPackage",
+						APIVersion: v1alpha1.GroupVersion.Identifier(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cfPackageGUID,
+						Namespace: namespace,
+					},
+					Spec: v1alpha1.CFPackageSpec{
+						Type: cfPackageType,
+						AppRef: v1alpha1.ResourceReference{
+							Name: cfAppGUID,
+						},
+					},
+				}
+				g.Expect(k8sClient.Create(context.Background(), cfPackage)).To(Succeed())
+			})
+
+			it("should have CFAppGUID metadata label on it and its value should matches spec.appRef", func() {
+				//Fetching the created CFPackage resource
+				cfPackageLookupKey := types.NamespacedName{Name: cfPackageGUID, Namespace: namespace}
+				createdCFPackage := new(v1alpha1.CFPackage)
+
+				g.Eventually(func() map[string]string {
+					err := k8sClient.Get(context.Background(), cfPackageLookupKey, createdCFPackage)
+					if err != nil {
+						return nil
+					}
+					return createdCFPackage.ObjectMeta.Labels
+				}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty())
+
+				g.Expect(createdCFPackage.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
+			})
+
+		})
+
+	})
+}

--- a/apis/workloads/v1alpha1/cfpackage_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/cfpackage_webhook_integration_test.go
@@ -19,12 +19,14 @@ func integrationTestCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
 	when("a CFApp record exists", func() {
 		var cfApp *v1alpha1.CFApp
 		const (
-			cfAppGUID     = "test-app-guid"
+			cfAppGUID     = "test-app-guid-2"
 			cfPackageGUID = "test-package-guid"
 			cfPackageType = "bits"
 			namespace     = "default"
 		)
+		var ctx context.Context
 		it.Before(func() {
+			ctx = context.Background()
 			cfApp = &v1alpha1.CFApp{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CFApp",
@@ -35,14 +37,14 @@ func integrationTestCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.CFAppSpec{
-					Name:         "test-app",
+					Name:         "test-app-name-2",
 					DesiredState: "STOPPED",
 					Lifecycle: v1alpha1.Lifecycle{
 						Type: "buildpack",
 					},
 				},
 			}
-			g.Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
+			g.Expect(k8sClient.Create(ctx, cfApp)).To(Succeed())
 		})
 		when("a CFPackage record referencing the CFAPP is created", func() {
 			it.Before(func() {
@@ -62,7 +64,7 @@ func integrationTestCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
 						},
 					},
 				}
-				g.Expect(k8sClient.Create(context.Background(), cfPackage)).To(Succeed())
+				g.Expect(k8sClient.Create(ctx, cfPackage)).To(Succeed())
 			})
 
 			it("should have CFAppGUID metadata label on it and its value should matches spec.appRef", func() {
@@ -71,7 +73,7 @@ func integrationTestCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
 				createdCFPackage := new(v1alpha1.CFPackage)
 
 				g.Eventually(func() map[string]string {
-					err := k8sClient.Get(context.Background(), cfPackageLookupKey, createdCFPackage)
+					err := k8sClient.Get(ctx, cfPackageLookupKey, createdCFPackage)
 					if err != nil {
 						return nil
 					}

--- a/apis/workloads/v1alpha1/cfpackage_webhook_test.go
+++ b/apis/workloads/v1alpha1/cfpackage_webhook_test.go
@@ -1,0 +1,79 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPackageWebhook(t *testing.T) {
+	spec.Run(t, "CFPackage Webhook", testCFPackageWebhook, spec.Report(report.Terminal{}))
+
+}
+
+func testCFPackageWebhook(t *testing.T, when spec.G, it spec.S) {
+	g := NewWithT(t)
+
+	const (
+		cfAppGUID     = "test-app-guid"
+		cfPackageGUID = "test-package-guid"
+		namespace     = "default"
+		cfPackageType = "bits"
+	)
+
+	when("there are no existing labels on the CFPackage record", func() {
+		it("should add a new label matching spec.AppRef.name", func() {
+			cfPackage := &v1alpha1.CFPackage{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CFPackage",
+					APIVersion: v1alpha1.GroupVersion.Identifier(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfPackageGUID,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.CFPackageSpec{
+					Type: cfPackageType,
+					AppRef: v1alpha1.ResourceReference{
+						Name: cfAppGUID,
+					},
+				},
+			}
+
+			cfPackage.Default()
+			g.Expect(cfPackage.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
+		})
+	})
+
+	when("there are other existing labels on the CFPackage record", func() {
+		it("should add a new label matching spec.AppRef.name and preserve the other labels", func() {
+			cfPackage := &v1alpha1.CFPackage{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CFPackage",
+					APIVersion: v1alpha1.GroupVersion.Identifier(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfPackageGUID,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"anotherLabel": "app-label",
+					},
+				},
+				Spec: v1alpha1.CFPackageSpec{
+					Type: cfPackageType,
+					AppRef: v1alpha1.ResourceReference{
+						Name: cfAppGUID,
+					},
+				},
+			}
+
+			cfPackage.Default()
+			g.Expect(cfPackage.ObjectMeta.Labels).To(HaveKeyWithValue("anotherLabel", "app-label"))
+			g.Expect(cfPackage.ObjectMeta.Labels).To(HaveKeyWithValue(v1alpha1.CFAppLabelKey, cfAppGUID))
+		})
+	})
+}

--- a/apis/workloads/v1alpha1/shared_types.go
+++ b/apis/workloads/v1alpha1/shared_types.go
@@ -4,6 +4,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const CFAppLabelKey = "apps.cloudfoundry.org/cf-app-guid"
+
 // ResourceReference defines a reference to an instance of a resource in Kubernetes
 type ResourceReference struct { // TODO: replace this with k8s.io/api/core/v1.LocalObjectReference
 	Name string `json:"name"`

--- a/apis/workloads/v1alpha1/shared_types.go
+++ b/apis/workloads/v1alpha1/shared_types.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const CFAppLabelKey = "apps.cloudfoundry.org/cf-app-guid"
+const CFAppLabelKey = "workloads.cloudfoundry.org/cf-app-guid"
 
 // ResourceReference defines a reference to an instance of a resource in Kubernetes
 type ResourceReference struct { // TODO: replace this with k8s.io/api/core/v1.LocalObjectReference

--- a/apis/workloads/v1alpha1/webhook_suite_test.go
+++ b/apis/workloads/v1alpha1/webhook_suite_test.go
@@ -32,8 +32,9 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,7 +55,7 @@ var (
 
 func Suite() spec.Suite {
 	if suite == nil {
-		suite = spec.New("Webhooks")
+		suite = spec.New("MutatingWebhooks")
 	}
 
 	return suite
@@ -88,8 +89,6 @@ func TestSuite(t *testing.T) {
 
 		g.Expect(admissionv1beta1.AddToScheme(scheme)).To(Succeed())
 
-		//+kubebuilder:scaffold:scheme
-
 		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(k8sClient).NotTo(BeNil())
@@ -110,6 +109,8 @@ func TestSuite(t *testing.T) {
 
 		cfAppValidatingWebhook := &workloads.CFAppValidation{Client: mgr.GetClient()}
 		g.Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
+
+		g.Expect((&workloadsv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
 
 		//+kubebuilder:scaffold:webhook
 

--- a/apis/workloads/v1alpha1/webhook_suite_test.go
+++ b/apis/workloads/v1alpha1/webhook_suite_test.go
@@ -47,10 +47,7 @@ import (
 
 var (
 	suite     spec.Suite
-	testEnv   *envtest.Environment
 	k8sClient client.Client
-	ctx       context.Context
-	cancel    context.CancelFunc
 )
 
 func Suite() spec.Suite {
@@ -66,81 +63,86 @@ func AddToTestSuite(desc string, f func(t *testing.T, when spec.G, it spec.S)) b
 }
 
 func TestSuite(t *testing.T) {
-	Suite().Before(func(t *testing.T) {
-		g := NewWithT(t)
-		logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	g := NewWithT(t)
 
-		ctx, cancel = context.WithCancel(context.TODO())
-
-		testEnv = &envtest.Environment{
-			CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-			ErrorIfCRDPathMissing: false,
-			WebhookInstallOptions: envtest.WebhookInstallOptions{
-				Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
-			},
-		}
-
-		cfg, err := testEnv.Start()
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(cfg).NotTo(BeNil())
-
-		scheme := runtime.NewScheme()
-		g.Expect(workloadsv1alpha1.AddToScheme(scheme)).To(Succeed())
-
-		g.Expect(admissionv1beta1.AddToScheme(scheme)).To(Succeed())
-
-		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(k8sClient).NotTo(BeNil())
-
-		// start webhook server using Manager
-		webhookInstallOptions := &testEnv.WebhookInstallOptions
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-			Scheme:             scheme,
-			Host:               webhookInstallOptions.LocalServingHost,
-			Port:               webhookInstallOptions.LocalServingPort,
-			CertDir:            webhookInstallOptions.LocalServingCertDir,
-			LeaderElection:     false,
-			MetricsBindAddress: "0",
-		})
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect((&workloadsv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-		cfAppValidatingWebhook := &workloads.CFAppValidation{Client: mgr.GetClient()}
-		g.Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
-
-		g.Expect((&workloadsv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-		//+kubebuilder:scaffold:webhook
-
-		go func() {
-			err = mgr.Start(ctx)
-			if err != nil {
-				g.Expect(err).NotTo(HaveOccurred())
-			}
-		}()
-
-		// wait for the webhook server to get ready
-		dialer := &net.Dialer{Timeout: time.Second}
-		addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-		g.Eventually(func() error {
-			conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
-			if err != nil {
-				return err
-			}
-			conn.Close()
-			return nil
-		}).Should(Succeed())
-
-	})
-
-	Suite().After(func(t *testing.T) {
-		cancel()
-		g := NewWithT(t)
-		err := testEnv.Stop()
-		g.Expect(err).NotTo(HaveOccurred())
-	})
+	testEnv, cancel := beforeSuite(g)
+	defer afterSuite(g, testEnv, cancel)
 
 	suite.Run(t)
+}
+
+func beforeSuite(g *WithT) (*envtest.Environment, context.CancelFunc) {
+	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = workloadsv1alpha1.AddToScheme(scheme)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(admissionv1beta1.AddToScheme(scheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect((&workloadsv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
+
+	cfAppValidatingWebhook := &workloads.CFAppValidation{Client: mgr.GetClient()}
+	g.Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
+
+	g.Expect((&workloadsv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		err = mgr.Start(ctx)
+		if err != nil {
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	g.Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+	return testEnv, cancel
+}
+
+func afterSuite(g *WithT, testEnv *envtest.Environment, cancel context.CancelFunc) {
+	cancel() // call the cancel function to stop the controller context
+	g.Expect(testEnv.Stop()).To(Succeed())
 }

--- a/config/samples/cfpackage.yaml
+++ b/config/samples/cfpackage.yaml
@@ -2,10 +2,7 @@
 # Defines the CFPackage for “Bits/SourceBased” packages
 apiVersion: workloads.cloudfoundry.org/v1alpha1
 kind: CFPackage
-metadata:
-  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook
-  labels:
-    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+metadata: #workloads.cloudfoundry.org/* labels are managed by a mutating webhook
   name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
 spec:
   type: bits

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -27,6 +27,27 @@ webhooks:
     resources:
     - cfapps
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-workloads-cloudfoundry-org-v1alpha1-cfpackage
+  failurePolicy: Fail
+  name: mcfpackage.kb.io
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cfpackages
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/main.go
+++ b/main.go
@@ -133,6 +133,10 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "CFDomain")
 		os.Exit(1)
 	}
+	if err = (&workloadsv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "CFPackage")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err = (&workloadsv1alpha1.CFApp{}).SetupWebhookWithManager(mgr); err != nil {


### PR DESCRIPTION
## Is there a related GitHub Issue?

## What is this change about?
Update the suite setup script to match the guidelines followed in other packages for setting up `envtest` by using `beforeSuite` and `afterSuite` functions`

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`make test` should succeed and `envtest` setup should execute once per package.  

## Tag your pair, your PM, and/or team
@Birdrock
