### PR TITLE
Issue 59

### DIFF
--- a/webhooks/workloads/cf_workloads_validation_errors.go
+++ b/webhooks/workloads/cf_workloads_validation_errors.go
@@ -1,0 +1,44 @@
+package workloads
+
+import "encoding/json"
+
+type ValidationErrorCode int
+
+type ValidationError struct {
+	Code    ValidationErrorCode `json:"code"`
+	Message string              `json:"message"`
+}
+
+const (
+	UnknownError = ValidationErrorCode(iota)
+	DuplicateAppError
+)
+
+func (w ValidationErrorCode) Marshal() string {
+	bytes, err := json.Marshal(ValidationError{
+		Code:    w,
+		Message: w.GetMessage(),
+	})
+	if err != nil {
+		return err.Error()
+	}
+	return string(bytes)
+}
+
+func (w *ValidationErrorCode) Unmarshall(payload string) {
+	validationErr := new(ValidationError)
+	err := json.Unmarshal([]byte(payload), validationErr)
+	if err != nil {
+		*w = UnknownError
+	}
+	*w = validationErr.Code
+}
+
+func (w ValidationErrorCode) GetMessage() string {
+	switch w {
+	case DuplicateAppError:
+		return "CFApp with the same spec.name exists"
+	default:
+		return "An unknown error has occured"
+	}
+}

--- a/webhooks/workloads/cf_workloads_validation_errors_test.go
+++ b/webhooks/workloads/cf_workloads_validation_errors_test.go
@@ -1,0 +1,46 @@
+package workloads_test
+
+import (
+	. "code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"testing"
+)
+
+func TestCFWorkloadsValidationErrors(t *testing.T) {
+	spec.Run(t, "CFWorkload Errors lib", testCFWorkloadsErrors, spec.Report(report.Terminal{}))
+
+}
+
+func testCFWorkloadsErrors(t *testing.T, when spec.G, it spec.S) {
+	g := NewWithT(t)
+
+	it("Marshals a payload", func() {
+		e := DuplicateAppError
+		g.Expect(e.Marshal()).To(Equal(`{"code":1,"message":"CFApp with the same spec.name exists"}`))
+	})
+
+	it("Unmarshals UnknownError", func() {
+		e := new(ValidationErrorCode)
+		p := `{"code":0}`
+		e.Unmarshall(p)
+		g.Expect(*e).To(Equal(UnknownError))
+	})
+
+	it("Unmarshals DuplicateAppError", func() {
+		e := new(ValidationErrorCode)
+		p := `{"code":1}`
+		e.Unmarshall(p)
+		g.Expect(*e).To(Equal(DuplicateAppError))
+	})
+
+	it("Handles malformed json payloads", func() {
+		e := new(ValidationErrorCode)
+		p := `{"code":1`
+		e.Unmarshall(p)
+		g.Expect(*e).To(Equal(UnknownError))
+	})
+}

--- a/webhooks/workloads/cfapp_validation.go
+++ b/webhooks/workloads/cfapp_validation.go
@@ -64,16 +64,16 @@ func (v *CFAppValidation) Handle(ctx context.Context, req admission.Request) adm
 
 	if req.Operation == v1.Create {
 		if len(foundApps.Items) > 0 {
-			errMessage := "CFApp with the same spec.name exists"
-			cfapplog.Info(errMessage, "name", req.Name)
-			return admission.Denied(errMessage)
+			e := DuplicateAppError
+			cfapplog.Info(e.GetMessage(), "name", req.Name)
+			return admission.Denied(e.Marshal())
 		}
 	} else if req.Operation == v1.Update {
 		for _, foundCfApp := range foundApps.Items {
 			if foundCfApp.Name != cfApp.Name {
-				errMessage := "CFApp with the same spec.name exists"
-				cfapplog.Info(errMessage, "name", req.Name)
-				return admission.Denied(errMessage)
+				e := DuplicateAppError
+				cfapplog.Info(e.GetMessage(), "name", req.Name)
+				return admission.Denied(e.Marshal())
 			}
 		}
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-api/issues/59

## What is this change about?
Created webhook validator helpers for CF centric errors.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run tests as normal

## Tag your pair, your PM, and/or team
@davewalter @matt-royal 
