### PR TITLE
Set CFDroplet fields on CFBuild.Status when Kpack Image succeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Edit the file: `config/kpack/cluster_builder.yaml` and set the `tag` field to be
 
 Run the commands below substituting the values for the Docker credentials to the registry where images will be uploaded to.
 ```
-kubectl create secret docker-registry kpack-registry-credentials \
+kubectl create secret docker-registry image-registry-credentials \
     --docker-username="<DOCKER_USERNAME>" \
     --docker-password="<DOCKER_PASSWORD>" \
      --docker-server="<DOCKER_SERVER>" --namespace default

--- a/apis/workloads/v1alpha1/shared_types.go
+++ b/apis/workloads/v1alpha1/shared_types.go
@@ -5,11 +5,14 @@ import (
 )
 
 const (
-	CFAppGUIDLabelKey     = "workloads.cloudfoundry.org/app-guid"
-	CFPackageGUIDLabelKey = "workloads.cloudfoundry.org/package-guid"
-	CFBuildGUIDLabelKey   = "workloads.cloudfoundry.org/build-guid"
-	CFProcessGUIDLabelKey = "workloads.cloudfoundry.org/process-guid"
-	CFProcessTypeLabelKey = "workloads.cloudfoundry.org/process-type"
+	CFAppGUIDLabelKey      = "workloads.cloudfoundry.org/app-guid"
+	CFPackageGUIDLabelKey  = "workloads.cloudfoundry.org/package-guid"
+	CFBuildGUIDLabelKey    = "workloads.cloudfoundry.org/build-guid"
+	CFProcessGUIDLabelKey  = "workloads.cloudfoundry.org/process-guid"
+	CFProcessTypeLabelKey  = "workloads.cloudfoundry.org/process-type"
+	StagingConditionType   = "Staging"
+	ReadyConditionType     = "Ready"
+	SucceededConditionType = "Succeeded"
 )
 
 type Lifecycle struct {

--- a/config/cf/cf_k8s_controllers_config.yaml
+++ b/config/cf/cf_k8s_controllers_config.yaml
@@ -1,1 +1,1 @@
-"kpackImageTag": "gcr.io/cf-relint-greengrass/cf-crd-staging-spike/"
+"kpackImageTag": "gcr.io/cf-relint-greengrass/cf-crd-staging-spike"

--- a/config/cf/cf_k8s_controllers_config.yaml
+++ b/config/cf/cf_k8s_controllers_config.yaml
@@ -1,1 +1,1 @@
-"kpackImageTag": "gcr.io/cf-relint-greengrass/cf-crd-staging-spike"
+kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta

--- a/config/cf/config.go
+++ b/config/cf/config.go
@@ -1,12 +1,13 @@
 package cf
 
 import (
-	"gopkg.in/yaml.v3"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 type ControllerConfig struct {
-	KpackImageTag string `yaml:"kpack_image_tag"`
+	KpackImageTag string `yaml:"kpackImageTag"`
 }
 
 func LoadConfigFromPath(path string) (*ControllerConfig, error) {

--- a/config/kpack/service_account.yaml
+++ b/config/kpack/service_account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   name: default-kpack-service-account
 secrets:
-- name: kpack-registry-credentials
+- name: image-registry-credentials
 imagePullSecrets:
-  - name: kpack-registry-credentials
+  - name: image-registry-credentials

--- a/config/samples/cfbuild.yaml
+++ b/config/samples/cfbuild.yaml
@@ -8,7 +8,6 @@ metadata: #workloads.cloudfoundry.org/* labels are managed by a mutating webhook
   #  workloads.cloudfoundry.org/app-guid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
   #  workloads.cloudfoundry.org/package-guid: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
   name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
-  namespace: default
 spec:
   appRef:
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a

--- a/config/samples/cfpackage.yaml
+++ b/config/samples/cfpackage.yaml
@@ -10,6 +10,6 @@ spec:
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a # Enforced via a Validating Webhook to reject empty or non-valid appRefs/appGUID
   source: # keeping this source block above registry gives us flexibility to support other kpack source types: https://github.com/pivotal/kpack/blob/main/docs/image.md#source-configuration
     registry:
-      image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/packages/ac85ad52-f52f-48e3-8c99-5e7badbe79c5:latest
+      image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/packages/665a78f8-ed97-47e6-85b2-60cbcc21d5e2
       imagePullSecrets:
-        - name: app-registry-credentials
+        - name: image-registry-credentials

--- a/controllers/workloads/cfbuild_controller.go
+++ b/controllers/workloads/cfbuild_controller.go
@@ -95,11 +95,9 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	stagingStatus := getConditionOrSetAsUnknown(&cfBuild.Status.Conditions, workloadsv1alpha1.StagingConditionType)
-	readyStatus := getConditionOrSetAsUnknown(&cfBuild.Status.Conditions, workloadsv1alpha1.ReadyConditionType)
 	succeededStatus := getConditionOrSetAsUnknown(&cfBuild.Status.Conditions, workloadsv1alpha1.SucceededConditionType)
 
 	if stagingStatus == metav1.ConditionUnknown &&
-		readyStatus == metav1.ConditionUnknown &&
 		succeededStatus == metav1.ConditionUnknown {
 		// Scenario: CFBuild newly created and all status conditions are unknown, it
 		// Creates a KpackImage resource to trigger staging.
@@ -109,7 +107,6 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 	} else if stagingStatus == metav1.ConditionTrue &&
-		readyStatus == metav1.ConditionUnknown &&
 		succeededStatus == metav1.ConditionUnknown {
 		// Scenario: CFBuild reconciles when Type staging is True and Type ready is False, it
 		// Retrieves and Checks Kpack Image Status Condition for Type "Succeeded"
@@ -127,7 +124,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		kpackReadyStatusCondition := kpackImage.Status.GetCondition(kpackReadyConditionType)
 		if kpackReadyStatusCondition.IsFalse() {
 			// Set CFBuild status Conditions on local copy - Staging and Succeeded to False
-			failureStatusConditionMessage := r.concatinateStrings(":", kpackReadyStatusCondition.Reason, kpackReadyStatusCondition.Message)
+			failureStatusConditionMessage := r.concatenateStrings(":", kpackReadyStatusCondition.Reason, kpackReadyStatusCondition.Message)
 			setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.StagingConditionType, metav1.ConditionFalse, "kpack", "kpack")
 			setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.SucceededConditionType, metav1.ConditionFalse, "kpack", failureStatusConditionMessage)
 			if err := r.Client.Status().Update(ctx, &cfBuild); err != nil {
@@ -152,7 +149,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *CFBuildReconciler) createKpackImageAndUpdateStatus(ctx context.Context, cfBuild *workloadsv1alpha1.CFBuild, cfApp *workloadsv1alpha1.CFApp, cfPackage *workloadsv1alpha1.CFPackage) error {
 	serviceAccountName := cfBuild.Namespace + kpackServiceAccountSuffix
-	kpackImageTag := r.concatinateStrings("/", r.ControllerConfig.KpackImageTag, cfBuild.Name)
+	kpackImageTag := r.concatenateStrings("/", r.ControllerConfig.KpackImageTag, cfBuild.Name)
 	kpackImageName := cfBuild.Name
 	kpackImageNamespace := cfBuild.Namespace
 	desiredKpackImage := buildv1alpha1.Image{
@@ -234,7 +231,7 @@ func (r *CFBuildReconciler) generateBuildDropletStatus(kpackImage *buildv1alpha1
 	}
 }
 
-func (r *CFBuildReconciler) concatinateStrings(separator string, text ...string) string {
+func (r *CFBuildReconciler) concatenateStrings(separator string, text ...string) string {
 	return strings.Join(text, separator)
 }
 

--- a/controllers/workloads/cfbuild_controller.go
+++ b/controllers/workloads/cfbuild_controller.go
@@ -40,11 +40,11 @@ import (
 )
 
 const (
-	kpackSucceededConditionType = "Ready"
-	clusterBuilderKind          = "ClusterBuilder"
-	clusterBuilderAPIVersion    = "kpack.io/v1alpha1"
-	kpackServiceAccountSuffix   = "-kpack-service-account"
-	cfKpackClusterBuilderName   = "cf-kpack-cluster-builder"
+	kpackReadyConditionType   = "Ready"
+	clusterBuilderKind        = "ClusterBuilder"
+	clusterBuilderAPIVersion  = "kpack.io/v1alpha1"
+	kpackServiceAccountSuffix = "-kpack-service-account"
+	cfKpackClusterBuilderName = "cf-kpack-cluster-builder"
 )
 
 // CFBuildReconciler reconciles a CFBuild object
@@ -124,7 +124,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			//Ignore Image NotFound errors to account for eventual consistency
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		kpackSucceededStatusCondition := kpackImage.Status.GetCondition(kpackSucceededConditionType)
+		kpackSucceededStatusCondition := kpackImage.Status.GetCondition(kpackReadyConditionType)
 		if kpackSucceededStatusCondition.IsFalse() {
 			// Set CFBuild status Conditions on local copy - Staging and Succeeded to False
 			setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.StagingConditionType, metav1.ConditionFalse, "kpack", "kpack")

--- a/controllers/workloads/cfbuild_controller.go
+++ b/controllers/workloads/cfbuild_controller.go
@@ -151,8 +151,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *CFBuildReconciler) createKpackImageAndUpdateStatus(ctx context.Context, cfBuild *workloadsv1alpha1.CFBuild, cfApp *workloadsv1alpha1.CFApp, cfPackage *workloadsv1alpha1.CFPackage) error {
 	serviceAccountName := cfBuild.Namespace + kpackServiceAccountSuffix
-	//TODO kpackImageTag := r.concatImageTagValue(r.ControllerConfig.KpackImageTag, cfBuild.Namespace, cfBuild.Name)
-	kpackImageTag := r.concatImageTagValue("gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta", cfBuild.Name)
+	kpackImageTag := r.generateImageTag(r.ControllerConfig.KpackImageTag, cfBuild.Name)
 	kpackImageName := cfBuild.Name
 	kpackImageNamespace := cfBuild.Namespace
 	desiredKpackImage := buildv1alpha1.Image{
@@ -187,7 +186,6 @@ func (r *CFBuildReconciler) createKpackImageAndUpdateStatus(ctx context.Context,
 	}
 
 	setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.StagingConditionType, metav1.ConditionTrue, "kpack", "kpack")
-	//setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.ReadyConditionType, metav1.ConditionFalse, "", "")
 
 	// Update CFBuild record based on changes made to local copy
 	if err := r.Client.Status().Update(ctx, cfBuild); err != nil {
@@ -235,7 +233,7 @@ func (r *CFBuildReconciler) generateBuildDropletStatus(kpackImage *buildv1alpha1
 	}
 }
 
-func (r *CFBuildReconciler) concatImageTagValue(imageTagElements ...string) string {
+func (r *CFBuildReconciler) generateImageTag(imageTagElements ...string) string {
 	return strings.Join(imageTagElements, "/")
 }
 

--- a/controllers/workloads/cfbuild_controller_integration_test.go
+++ b/controllers/workloads/cfbuild_controller_integration_test.go
@@ -23,8 +23,8 @@ var _ = AddToTestSuite("CFBuildReconciler", testCFBuildReconcilerIntegration)
 func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 	const (
-		succeededConditionType      = "Succeeded"
-		kpackSucceededConditionType = "Ready"
+		succeededConditionType  = "Succeeded"
+		kpackReadyConditionType = "Ready"
 	)
 	when("CFBuild status conditions are missing or unknown", func() {
 		var (
@@ -214,7 +214,7 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 					err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
 					return err == nil
 				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
-				setKpackImageStatus(createdKpackImage, kpackSucceededConditionType, "False")
+				setKpackImageStatus(createdKpackImage, kpackReadyConditionType, "False")
 				g.Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
 			})
 			it("should eventually set the status condition for Type Succeeded on CFBuild to False", func() {
@@ -239,7 +239,7 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 					err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
 					return err == nil
 				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
-				setKpackImageStatus(createdKpackImage, kpackSucceededConditionType, "True")
+				setKpackImageStatus(createdKpackImage, kpackReadyConditionType, "True")
 				g.Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
 			})
 			it("should eventually set the status condition for Type Succeeded on CFBuild to True", func() {

--- a/controllers/workloads/cfbuild_controller_integration_test.go
+++ b/controllers/workloads/cfbuild_controller_integration_test.go
@@ -97,8 +97,8 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 						err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
 						return err == nil
 					}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
-					//TODO kpackImageTag := "image/registry/tag/" + namespaceGUID + "/" + cfBuildGUID
-					//TODO g.Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
+					kpackImageTag := "image/registry/tag" + "/" + cfBuildGUID
+					g.Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
 					g.Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
 				})
 				it("eventually sets the status conditions on CFBuild", func() {

--- a/controllers/workloads/cfbuild_controller_integration_test.go
+++ b/controllers/workloads/cfbuild_controller_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/workloads/testutils"
 	buildv1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
@@ -20,7 +22,10 @@ var _ = AddToTestSuite("CFBuildReconciler", testCFBuildReconcilerIntegration)
 
 func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
-
+	const (
+		succeededConditionType      = "Succeeded"
+		kpackSucceededConditionType = "Ready"
+	)
 	when("CFBuild status conditions are missing or unknown", func() {
 		var (
 			namespaceGUID    string
@@ -40,13 +45,13 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 
 			beforeCtx := context.Background()
 
-			newNamespace = InitializeK8sNamespace(namespaceGUID)
+			newNamespace = MockK8sNamespaceObject(namespaceGUID)
 			g.Expect(k8sClient.Create(beforeCtx, newNamespace)).To(Succeed())
 
-			desiredCFApp = InitializeAppCR(cfAppGUID, namespaceGUID)
+			desiredCFApp = MockAppCRObject(cfAppGUID, namespaceGUID)
 			g.Expect(k8sClient.Create(beforeCtx, desiredCFApp)).To(Succeed())
 
-			desiredCFPackage = InitializePackageCR(cfPackageGUID, namespaceGUID, cfAppGUID)
+			desiredCFPackage = MockPackageCRObject(cfPackageGUID, namespaceGUID, cfAppGUID)
 			g.Expect(k8sClient.Create(beforeCtx, desiredCFPackage)).To(Succeed())
 
 			desiredCFBuild = &workloadsv1alpha1.CFBuild{
@@ -92,8 +97,8 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 						err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
 						return err == nil
 					}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
-					kpackImageTag := "image/registry/tag/" + namespaceGUID + "/" + cfBuildGUID
-					g.Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
+					//TODO kpackImageTag := "image/registry/tag/" + namespaceGUID + "/" + cfBuildGUID
+					//TODO g.Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
 					g.Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
 				})
 				it("eventually sets the status conditions on CFBuild", func() {
@@ -138,7 +143,7 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 						},
 					}
 					g.Expect(k8sClient.Create(beforeCtx, existingKpackImage)).To(Succeed())
-					newCFBuild = InitializeCFBuild(newCFBuildGUID, namespaceGUID, cfPackageGUID, cfAppGUID)
+					newCFBuild = MockCFBuildObject(newCFBuildGUID, namespaceGUID, cfPackageGUID, cfAppGUID)
 					g.Expect(k8sClient.Create(beforeCtx, newCFBuild)).To(Succeed())
 				})
 				it.After(func() {
@@ -158,6 +163,108 @@ func testCFBuildReconcilerIntegration(t *testing.T, when spec.G, it spec.S) {
 						return createdCFBuild.Status.Conditions
 					}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFBuild status conditions were empty")
 				})
+			})
+		})
+	})
+	when("CFBuild status conditions for Staging is True and others are unknown", func() {
+		var (
+			namespaceGUID    string
+			cfAppGUID        string
+			cfPackageGUID    string
+			cfBuildGUID      string
+			newNamespace     *corev1.Namespace
+			desiredCFApp     *workloadsv1alpha1.CFApp
+			desiredCFPackage *workloadsv1alpha1.CFPackage
+			desiredCFBuild   *workloadsv1alpha1.CFBuild
+		)
+		it.Before(func() {
+			namespaceGUID = GenerateGUID()
+			cfAppGUID = GenerateGUID()
+			cfPackageGUID = GenerateGUID()
+			cfBuildGUID = GenerateGUID()
+
+			beforeCtx := context.Background()
+
+			newNamespace = MockK8sNamespaceObject(namespaceGUID)
+			g.Expect(k8sClient.Create(beforeCtx, newNamespace)).To(Succeed())
+
+			desiredCFApp = MockAppCRObject(cfAppGUID, namespaceGUID)
+			g.Expect(k8sClient.Create(beforeCtx, desiredCFApp)).To(Succeed())
+
+			desiredCFPackage = MockPackageCRObject(cfPackageGUID, namespaceGUID, cfAppGUID)
+			g.Expect(k8sClient.Create(beforeCtx, desiredCFPackage)).To(Succeed())
+
+			desiredCFBuild = MockCFBuildObject(cfBuildGUID, namespaceGUID, cfPackageGUID, cfAppGUID)
+			g.Expect(k8sClient.Create(beforeCtx, desiredCFBuild)).To(Succeed())
+		})
+		it.After(func() {
+			afterCtx := context.Background()
+			g.Expect(k8sClient.Delete(afterCtx, desiredCFApp)).To(Succeed())
+			g.Expect(k8sClient.Delete(afterCtx, desiredCFPackage)).To(Succeed())
+			g.Expect(k8sClient.Delete(afterCtx, desiredCFBuild)).To(Succeed())
+			g.Expect(k8sClient.Delete(afterCtx, newNamespace)).To(Succeed())
+		})
+
+		when("kpack image status condition for Type Succeeded is False", func() {
+			it.Before(func() {
+				testCtx := context.Background()
+				kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdKpackImage := new(buildv1alpha1.Image)
+				g.Eventually(func() bool {
+					err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
+					return err == nil
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
+				setKpackImageStatus(createdKpackImage, kpackSucceededConditionType, "False")
+				g.Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
+			})
+			it("should eventually set the status condition for Type Succeeded on CFBuild to False", func() {
+				testCtx := context.Background()
+				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdCFBuild := new(workloadsv1alpha1.CFBuild)
+				g.Eventually(func() bool {
+					err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
+					if err != nil {
+						return false
+					}
+					return meta.IsStatusConditionFalse(createdCFBuild.Status.Conditions, succeededConditionType)
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+			})
+		})
+		when("kpack image status condition for Type Succeeded is True", func() {
+			it.Before(func() {
+				testCtx := context.Background()
+				kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdKpackImage := new(buildv1alpha1.Image)
+				g.Eventually(func() bool {
+					err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
+					return err == nil
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
+				setKpackImageStatus(createdKpackImage, kpackSucceededConditionType, "True")
+				g.Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
+			})
+			it("should eventually set the status condition for Type Succeeded on CFBuild to True", func() {
+				testCtx := context.Background()
+				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdCFBuild := new(workloadsv1alpha1.CFBuild)
+				g.Eventually(func() bool {
+					err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
+					if err != nil {
+						return false
+					}
+					return meta.IsStatusConditionTrue(createdCFBuild.Status.Conditions, succeededConditionType)
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+			})
+			it("should eventually set BuildStatusDroplet object", func() {
+				testCtx := context.Background()
+				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdCFBuild := new(workloadsv1alpha1.CFBuild)
+				g.Eventually(func() *workloadsv1alpha1.BuildDropletStatus {
+					err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
+					if err != nil {
+						return nil
+					}
+					return createdCFBuild.Status.BuildDropletStatus
+				}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeNil(), "BuildStatusDroplet was nil on CFBuild")
 			})
 		})
 	})

--- a/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/workloads/cfbuild_controller_test.go
@@ -39,11 +39,11 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 
 	const (
-		defaultNamespace            = "default"
-		stagingConditionType        = "Staging"
-		readyConditionType          = "Ready"
-		succeededConditionType      = "Succeeded"
-		kpackSucceededConditionType = "Ready"
+		defaultNamespace        = "default"
+		stagingConditionType    = "Staging"
+		readyConditionType      = "Ready"
+		succeededConditionType  = "Succeeded"
+		kpackReadyConditionType = "Ready"
 	)
 
 	var (
@@ -222,7 +222,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 		when("on the happy path", func() {
 			it.Before(func() {
 				kpackImageError = nil
-				setKpackImageStatus(kpackImage, kpackSucceededConditionType, "True")
+				setKpackImageStatus(kpackImage, kpackReadyConditionType, "True")
 				reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 			})
 			it("does not return an error", func() {
@@ -275,7 +275,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			when("kpack image status conditions for Type Succeeded is UNKNOWN", func() {
 				it.Before(func() {
 					kpackImageError = nil
-					setKpackImageStatus(kpackImage, kpackSucceededConditionType, "Unknown")
+					setKpackImageStatus(kpackImage, kpackReadyConditionType, "Unknown")
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("does not return an error", func() {
@@ -289,7 +289,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			when("kpack image status conditions for Type Succeeded is FALSE", func() {
 				it.Before(func() {
 					kpackImageError = nil
-					setKpackImageStatus(kpackImage, kpackSucceededConditionType, "False")
+					setKpackImageStatus(kpackImage, kpackReadyConditionType, "False")
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("does not return an error", func() {
@@ -312,7 +312,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				when("update status conditions returns an error", func() {
 					it.Before(func() {
 						kpackImageError = nil
-						setKpackImageStatus(kpackImage, kpackSucceededConditionType, "True")
+						setKpackImageStatus(kpackImage, kpackReadyConditionType, "True")
 						fakeStatusWriter.UpdateReturns(errors.New("failing on purpose"))
 						reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 					})

--- a/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/workloads/cfbuild_controller_test.go
@@ -216,7 +216,6 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 	when("CFBuild status conditions for Staging is True and others are unknown", func() {
 		it.Before(func() {
 			SetStatusCondition(&cfBuild.Status.Conditions, stagingConditionType, metav1.ConditionTrue)
-			SetStatusCondition(&cfBuild.Status.Conditions, readyConditionType, metav1.ConditionUnknown)
 			SetStatusCondition(&cfBuild.Status.Conditions, succeededConditionType, metav1.ConditionUnknown)
 		})
 		when("on the happy path", func() {

--- a/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/workloads/cfbuild_controller_test.go
@@ -71,7 +71,6 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 		reconcileErr    error
 	)
 
-	// Set up happy path
 	it.Before(func() {
 		fakeClient = new(fake.CFClient)
 

--- a/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/workloads/cfbuild_controller_test.go
@@ -1,13 +1,18 @@
 package workloads_test
 
 import (
-	cfconfig "code.cloudfoundry.org/cf-k8s-controllers/config/cf"
 	"context"
 	"errors"
+	"testing"
+
+	"github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cfconfig "code.cloudfoundry.org/cf-k8s-controllers/config/cf"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/workloads"
@@ -34,30 +39,33 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 	g := NewWithT(t)
 
 	const (
-		defaultNamespace       = "default"
-		stagingConditionType   = "Staging"
-		readyConditionType     = "Ready"
-		succeededConditionType = "Succeeded"
+		defaultNamespace            = "default"
+		stagingConditionType        = "Staging"
+		readyConditionType          = "Ready"
+		succeededConditionType      = "Succeeded"
+		kpackSucceededConditionType = "Ready"
 	)
 
 	var (
 		fakeClient       *fake.CFClient
 		fakeStatusWriter *fake.StatusWriter
 
-		cfAppGUID     string
-		cfPackageGUID string
-		cfBuildGUID   string
+		cfAppGUID      string
+		cfPackageGUID  string
+		cfBuildGUID    string
+		kpackImageGUID string
 
-		getCFBuild         *workloadsv1alpha1.CFBuild
-		getCFBuildError    error
-		getCFApp           *workloadsv1alpha1.CFApp
-		getCFAppError      error
-		getCFPackage       *workloadsv1alpha1.CFPackage
-		getCFPackageError  error
-		getKpackImageError error
-		cfBuildReconciler  *CFBuildReconciler
-		req                ctrl.Request
-		ctx                context.Context
+		cfBuild           *workloadsv1alpha1.CFBuild
+		cfBuildError      error
+		cfApp             *workloadsv1alpha1.CFApp
+		cfAppError        error
+		cfPackage         *workloadsv1alpha1.CFPackage
+		cfPackageError    error
+		kpackImage        *buildv1alpha1.Image
+		kpackImageError   error
+		cfBuildReconciler *CFBuildReconciler
+		req               ctrl.Request
+		ctx               context.Context
 
 		reconcileResult ctrl.Result
 		reconcileErr    error
@@ -70,29 +78,32 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 		cfAppGUID = "cf-app-guid"
 		cfPackageGUID = "cf-package-guid"
 		cfBuildGUID = "cf-build-guid"
+		kpackImageGUID = cfBuildGUID
 
-		getCFBuild = InitializeCFBuild(cfBuildGUID, defaultNamespace, cfPackageGUID, cfAppGUID)
-		getCFBuildError = nil
-		getCFApp = InitializeAppCR(cfAppGUID, defaultNamespace)
-		getCFAppError = nil
-		getCFPackage = InitializePackageCR(cfPackageGUID, defaultNamespace, cfAppGUID)
-		getCFPackageError = nil
-		getKpackImageError = apierrors.NewNotFound(schema.GroupResource{}, getCFBuild.Name)
+		cfBuild = MockCFBuildObject(cfBuildGUID, defaultNamespace, cfPackageGUID, cfAppGUID)
+		cfBuildError = nil
+		cfApp = MockAppCRObject(cfAppGUID, defaultNamespace)
+		cfAppError = nil
+		cfPackage = MockPackageCRObject(cfPackageGUID, defaultNamespace, cfAppGUID)
+		cfPackageError = nil
+		kpackImage = mockKpackImageObject(kpackImageGUID, defaultNamespace)
+		kpackImageError = apierrors.NewNotFound(schema.GroupResource{}, cfBuild.Name)
 
 		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object) error {
 			// cast obj to find its kind
 			switch obj.(type) {
 			case *workloadsv1alpha1.CFBuild:
-				getCFBuild.DeepCopyInto(obj.(*workloadsv1alpha1.CFBuild))
-				return getCFBuildError
+				cfBuild.DeepCopyInto(obj.(*workloadsv1alpha1.CFBuild))
+				return cfBuildError
 			case *workloadsv1alpha1.CFApp:
-				getCFApp.DeepCopyInto(obj.(*workloadsv1alpha1.CFApp))
-				return getCFAppError
+				cfApp.DeepCopyInto(obj.(*workloadsv1alpha1.CFApp))
+				return cfAppError
 			case *workloadsv1alpha1.CFPackage:
-				getCFPackage.DeepCopyInto(obj.(*workloadsv1alpha1.CFPackage))
-				return getCFPackageError
+				cfPackage.DeepCopyInto(obj.(*workloadsv1alpha1.CFPackage))
+				return cfPackageError
 			case *buildv1alpha1.Image:
-				return getKpackImageError
+				kpackImage.DeepCopyInto(obj.(*buildv1alpha1.Image))
+				return kpackImageError
 			default:
 				panic("test Client Get provided a weird obj")
 			}
@@ -140,12 +151,15 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 				_, kpackImage, _ := fakeClient.CreateArgsForCall(0)
 				g.Expect(kpackImage.GetName()).To(Equal(cfBuildGUID))
 			})
+			it("should update the status conditions on CFBuild", func() {
+				g.Expect(fakeClient.StatusCallCount()).To(Equal(1))
+			})
 
 		})
 		when("on unhappy path", func() {
 			when("fetch CFBuild returns an error", func() {
 				it.Before(func() {
-					getCFBuildError = errors.New("failing on purpose")
+					cfBuildError = errors.New("failing on purpose")
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("should return an error", func() {
@@ -154,7 +168,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			})
 			when("fetch CFBuild returns a NotFoundError", func() {
 				it.Before(func() {
-					getCFBuildError = apierrors.NewNotFound(schema.GroupResource{}, getCFBuild.Name)
+					cfBuildError = apierrors.NewNotFound(schema.GroupResource{}, cfBuild.Name)
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("should NOT return any error", func() {
@@ -163,7 +177,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			})
 			when("fetch CFApp returns an error", func() {
 				it.Before(func() {
-					getCFAppError = errors.New("failing on purpose")
+					cfAppError = errors.New("failing on purpose")
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("should return an error", func() {
@@ -172,7 +186,7 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 			})
 			when("fetch CFPackage returns an error", func() {
 				it.Before(func() {
-					getCFPackageError = errors.New("failing on purpose")
+					cfPackageError = errors.New("failing on purpose")
 					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
 				})
 				it("should return an error", func() {
@@ -202,23 +216,140 @@ func testCFBuildReconciler(t *testing.T, when spec.G, it spec.S) {
 	})
 	when("CFBuild status conditions for Staging is True and others are unknown", func() {
 		it.Before(func() {
-			SetStatusCondition(&getCFBuild.Status.Conditions, StagingConditionType, metav1.ConditionTrue)
-			SetStatusCondition(&getCFBuild.Status.Conditions, ReadyConditionType, metav1.ConditionUnknown)
-			SetStatusCondition(&getCFBuild.Status.Conditions, SucceededConditionType, metav1.ConditionUnknown)
-			reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+			SetStatusCondition(&cfBuild.Status.Conditions, stagingConditionType, metav1.ConditionTrue)
+			SetStatusCondition(&cfBuild.Status.Conditions, readyConditionType, metav1.ConditionUnknown)
+			SetStatusCondition(&cfBuild.Status.Conditions, succeededConditionType, metav1.ConditionUnknown)
 		})
+		when("on the happy path", func() {
+			it.Before(func() {
+				kpackImageError = nil
+				setKpackImageStatus(kpackImage, kpackSucceededConditionType, "True")
+				reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+			})
+			it("does not return an error", func() {
+				g.Expect(reconcileErr).NotTo(HaveOccurred())
+			})
 
-		it("does not return an error", func() {
-			g.Expect(reconcileErr).NotTo(HaveOccurred())
+			it("returns an empty result", func() {
+				g.Expect(reconcileResult).To(Equal(ctrl.Result{}))
+			})
+
+			it("does not create a new kpack image", func() {
+				g.Expect(fakeClient.CreateCallCount()).To(Equal(0), "fakeClient Create was called when it should not have been")
+			})
+
+			it("should update the status conditions on CFBuild", func() {
+				g.Expect(fakeClient.StatusCallCount()).To(Equal(1))
+			})
 		})
+		when("on the unhappy path", func() {
+			when("fetch KpackImage returns an error", func() {
+				it.Before(func() {
+					kpackImageError = errors.New("failing on purpose")
+					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+				})
+				it("should return an error", func() {
+					g.Expect(reconcileErr).To(HaveOccurred())
+				})
+			})
+			when("fetch KpackImage returns a NotFoundError", func() {
+				it.Before(func() {
+					kpackImageError = apierrors.NewNotFound(schema.GroupResource{}, cfBuild.Name)
+					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+				})
+				it("should NOT return any error", func() {
+					g.Expect(reconcileErr).NotTo(HaveOccurred())
+				})
+			})
+			when("kpack image status conditions for Type Succeeded is nil", func() {
+				it.Before(func() {
+					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+				})
+				it("does not return an error", func() {
+					g.Expect(reconcileErr).NotTo(HaveOccurred())
+				})
 
-		it("returns an empty result", func() {
-			g.Expect(reconcileResult).To(Equal(ctrl.Result{}))
-		})
+				it("returns an empty result", func() {
+					g.Expect(reconcileResult).To(Equal(ctrl.Result{}))
+				})
+			})
+			when("kpack image status conditions for Type Succeeded is UNKNOWN", func() {
+				it.Before(func() {
+					kpackImageError = nil
+					setKpackImageStatus(kpackImage, kpackSucceededConditionType, "Unknown")
+					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+				})
+				it("does not return an error", func() {
+					g.Expect(reconcileErr).NotTo(HaveOccurred())
+				})
 
-		it("does not create a new kpack image", func() {
-			g.Expect(fakeClient.CreateCallCount()).To(Equal(0), "fakeClient Create was called when it should not have been")
+				it("returns an empty result", func() {
+					g.Expect(reconcileResult).To(Equal(ctrl.Result{}))
+				})
+			})
+			when("kpack image status conditions for Type Succeeded is FALSE", func() {
+				it.Before(func() {
+					kpackImageError = nil
+					setKpackImageStatus(kpackImage, kpackSucceededConditionType, "False")
+					reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+				})
+				it("does not return an error", func() {
+					g.Expect(reconcileErr).NotTo(HaveOccurred())
+				})
+				it("updates status conditions on CFBuild", func() {
+					g.Expect(fakeClient.StatusCallCount()).To(Equal(1))
+				})
+				when("update status conditions returns an error", func() {
+					it.Before(func() {
+						fakeStatusWriter.UpdateReturns(errors.New("failing on purpose"))
+						reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+					})
+					it("should return an error", func() {
+						g.Expect(reconcileErr).To(HaveOccurred())
+					})
+				})
+			})
+			when("kpack image status conditions for Type Succeeded is True", func() {
+				when("update status conditions returns an error", func() {
+					it.Before(func() {
+						kpackImageError = nil
+						setKpackImageStatus(kpackImage, kpackSucceededConditionType, "True")
+						fakeStatusWriter.UpdateReturns(errors.New("failing on purpose"))
+						reconcileResult, reconcileErr = cfBuildReconciler.Reconcile(ctx, req)
+					})
+					it("should return an error", func() {
+						g.Expect(reconcileErr).To(HaveOccurred())
+					})
+				})
+			})
 		})
 	})
 
+}
+
+func mockKpackImageObject(guid string, namespace string) *buildv1alpha1.Image {
+	return &buildv1alpha1.Image{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      guid,
+			Namespace: namespace,
+		},
+		Spec: buildv1alpha1.ImageSpec{
+			Tag:            "test-tag",
+			Builder:        corev1.ObjectReference{},
+			ServiceAccount: "test-service-account",
+			Source: buildv1alpha1.SourceConfig{
+				Registry: &buildv1alpha1.Registry{
+					Image:            "image-path",
+					ImagePullSecrets: nil,
+				},
+			},
+		},
+	}
+}
+
+func setKpackImageStatus(kpackImage *buildv1alpha1.Image, conditionType string, conditionStatus string) {
+	kpackImage.Status.Conditions = append(kpackImage.Status.Conditions, v1alpha1.Condition{
+		Type:   v1alpha1.ConditionType(conditionType),
+		Status: corev1.ConditionStatus(conditionStatus),
+	})
 }

--- a/controllers/workloads/fake/cfclient.go
+++ b/controllers/workloads/fake/cfclient.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	controllers "code.cloudfoundry.org/cf-k8s-controllers/controllers/workloads"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/workloads"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -258,4 +258,4 @@ func (fake *CFClient) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ controllers.CFClient = new(CFClient)
+var _ workloads.CFClient = new(CFClient)

--- a/controllers/workloads/shared.go
+++ b/controllers/workloads/shared.go
@@ -2,6 +2,10 @@ package workloads
 
 import (
 	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -10,4 +14,14 @@ type CFClient interface {
 	Get(ctx context.Context, key client.ObjectKey, obj client.Object) error
 	Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 	Status() client.StatusWriter
+}
+
+// This is a helper function for updating local copy of status conditions
+func setStatusConditionOnLocalCopy(conditions *[]metav1.Condition, conditionType string, conditionStatus metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:    conditionType,
+		Status:  conditionStatus,
+		Reason:  reason,
+		Message: message,
+	})
 }

--- a/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/workloads/testutils/shared_test_utils.go
@@ -21,7 +21,7 @@ func GenerateGUID() string {
 	return newUUID.String()
 }
 
-func InitializeK8sNamespace(name string) *corev1.Namespace {
+func MockK8sNamespaceObject(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -29,7 +29,7 @@ func InitializeK8sNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func InitializeAppCR(appGUID string, spaceGUID string) *workloadsv1alpha1.CFApp {
+func MockAppCRObject(appGUID string, spaceGUID string) *workloadsv1alpha1.CFApp {
 	return &workloadsv1alpha1.CFApp{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appGUID,
@@ -49,7 +49,7 @@ func InitializeAppCR(appGUID string, spaceGUID string) *workloadsv1alpha1.CFApp 
 	}
 }
 
-func InitializePackageCR(packageGUID, namespaceGUID, appGUID string) *workloadsv1alpha1.CFPackage {
+func MockPackageCRObject(packageGUID, namespaceGUID, appGUID string) *workloadsv1alpha1.CFPackage {
 	return &workloadsv1alpha1.CFPackage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      packageGUID,
@@ -70,7 +70,7 @@ func InitializePackageCR(packageGUID, namespaceGUID, appGUID string) *workloadsv
 	}
 }
 
-func InitializeCFBuild(cfBuildGUID string, namespace string, cfPackageGUID string, cfAppGUID string) *workloadsv1alpha1.CFBuild {
+func MockCFBuildObject(cfBuildGUID string, namespace string, cfPackageGUID string, cfAppGUID string) *workloadsv1alpha1.CFBuild {
 	return &workloadsv1alpha1.CFBuild{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfBuildGUID,

--- a/hack/install-dependencies.sh
+++ b/hack/install-dependencies.sh
@@ -62,9 +62,9 @@ DOCKER_USERNAME=${DOCKER_USERNAME:-"_json_key"}
 DOCKER_PASSWORD=${DOCKER_PASSWORD:-"$(cat $GCP_SERVICE_ACCOUNT_JSON_FILE)"}
 DOCKER_SERVER=${DOCKER_SERVER:-"gcr.io"}
 
-kubectl create secret docker-registry kpack-registry-credentials \
+kubectl create secret docker-registry image-registry-credentials \
     --docker-username=$DOCKER_USERNAME --docker-password="$DOCKER_PASSWORD" --docker-server=$DOCKER_SERVER --namespace default || true
-# kubectl create secret docker-registry kpack-registry-credentials --docker-username="_json_key" --docker-password="$(cat /home/birdrock/workspace/credentials/cf-relint-greengrass-2826975617b2.json)" --docker-server=gcr.io --namespace default
+# kubectl create secret docker-registry image-registry-credentials --docker-username="_json_key" --docker-password="$(cat /home/birdrock/workspace/credentials/cf-relint-greengrass-2826975617b2.json)" --docker-server=gcr.io --namespace default
 
 kubectl apply -f config/kpack/service_account.yaml \
     -f config/kpack/cluster_stack.yaml \

--- a/reference/cf-k8s-controllers.yaml
+++ b/reference/cf-k8s-controllers.yaml
@@ -1323,7 +1323,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  cf_k8s_controllers_config.yaml: '"kpackImageTag": "gcr.io/cf-relint-greengrass/cf-crd-staging-spike/"'
+  cf_k8s_controllers_config.yaml: 'kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta'
 kind: ConfigMap
 metadata:
   name: cf-k8s-controllers-config


### PR DESCRIPTION
## Is there a related GitHub Issue?
#43 

## What is this change about?
CFBuild Controller can now watch kpack images for completion. Based on the completion status, it now updates CFDroplet fields on CFBuild's status.  

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Follow acceptance steps on issue #43 