### PR TITLE
Separate int tests

### DIFF
--- a/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
@@ -1,4 +1,4 @@
-package v1alpha1_test
+package integration_test
 
 import (
 	"context"

--- a/apis/workloads/v1alpha1/integration/cfbuild_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/integration/cfbuild_webhook_integration_test.go
@@ -1,4 +1,4 @@
-package v1alpha1_test
+package integration_test
 
 import (
 	"context"

--- a/apis/workloads/v1alpha1/integration/cfpackage_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/integration/cfpackage_webhook_integration_test.go
@@ -1,4 +1,4 @@
-package v1alpha1_test
+package integration_test
 
 import (
 	"context"

--- a/apis/workloads/v1alpha1/integration/cfprocess_webhook_integration_test.go
+++ b/apis/workloads/v1alpha1/integration/cfprocess_webhook_integration_test.go
@@ -1,4 +1,4 @@
-package v1alpha1_test
+package integration_test
 
 import (
 	"context"

--- a/apis/workloads/v1alpha1/integration/webhook_suite_integration_test.go
+++ b/apis/workloads/v1alpha1/integration/webhook_suite_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -54,7 +53,7 @@ func TestWorkloadsMutatingWebhooks(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancelFunc := context.WithCancel(context.TODO())
 	cancel = cancelFunc

--- a/apis/workloads/v1alpha1/webhook_suite_test.go
+++ b/apis/workloads/v1alpha1/webhook_suite_test.go
@@ -1,132 +1,13 @@
-/*
-
-Copyright 2021.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package v1alpha1_test
 
 import (
-	"context"
-	"crypto/tls"
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
-
-	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
-	"code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
 )
 
-var (
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	k8sClient client.Client
-)
-
-func TestWorkloadsValidatingWebhooks(t *testing.T) {
+func TestWorkloadsMutatingWebhooks(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Workloads Mutating Webhooks Suite")
+	RunSpecs(t, "Networking Controllers Unit Test Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
-
-	ctx, cancelFunc := context.WithCancel(context.TODO())
-	cancel = cancelFunc
-
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-		WebhookInstallOptions: envtest.WebhookInstallOptions{
-			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
-		},
-	}
-
-	cfg, err := testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	scheme := runtime.NewScheme()
-	Expect(workloadsv1alpha1.AddToScheme(scheme)).To(Succeed())
-
-	Expect(admissionv1beta1.AddToScheme(scheme)).To(Succeed())
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// start webhook server using Manager
-	webhookInstallOptions := &testEnv.WebhookInstallOptions
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme,
-		Host:               webhookInstallOptions.LocalServingHost,
-		Port:               webhookInstallOptions.LocalServingPort,
-		CertDir:            webhookInstallOptions.LocalServingCertDir,
-		LeaderElection:     false,
-		MetricsBindAddress: "0",
-	})
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect((&workloadsv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-	cfAppValidatingWebhook := &workloads.CFAppValidation{Client: mgr.GetClient()}
-	Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
-
-	Expect((&workloadsv1alpha1.CFPackage{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-	Expect((&workloadsv1alpha1.CFProcess{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-	Expect((&workloadsv1alpha1.CFBuild{}).SetupWebhookWithManager(mgr)).To(Succeed())
-
-	//+kubebuilder:scaffold:webhook
-
-	go func() {
-		err = mgr.Start(ctx)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
-	}()
-
-	// wait for the webhook server to get ready
-	dialer := &net.Dialer{Timeout: time.Second}
-	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
-		if err != nil {
-			return err
-		}
-		conn.Close()
-		return nil
-	}).Should(Succeed())
-})
-
-var _ = AfterSuite(func() {
-	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})

--- a/controllers/networking/cfroute_controller_test.go
+++ b/controllers/networking/cfroute_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var _ = Describe("CFRouteReconciler Unit Tests", func() {
+var _ = Describe("CFRouteReconciler", func() {
 	const (
 		defaultNamespace          = "default"
 		proxyCreatedConditionType = "ProxyCreated"

--- a/controllers/networking/integration/suite_integration_test.go
+++ b/controllers/networking/integration/suite_integration_test.go
@@ -1,0 +1,79 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
+	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/networking"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.Client
+)
+
+func TestNetworkingControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Networking Controllers Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(networkingv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&CFRouteReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CFRoute"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&CFDomainReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// TODO: Add the other reconcilers
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})

--- a/controllers/networking/integration/suite_integration_test.go
+++ b/controllers/networking/integration/suite_integration_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestNetworkingControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},

--- a/controllers/networking/suite_test.go
+++ b/controllers/networking/suite_test.go
@@ -1,76 +1,13 @@
-/*
-Copyright 2021.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package networking
 
 import (
-	"path/filepath"
 	"testing"
-
-	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
-	//+kubebuilder:scaffold:imports
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var (
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
-)
-
-func TestAPIs(t *testing.T) {
+func TestNetworkingControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Networking Controllers Suite")
+	RunSpecs(t, "Networking Controllers Unit Test Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	By("bootstrapping the test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	cfg, err := testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = networkingv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-}, 60)
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})

--- a/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/workloads/cfapp_controller_test.go
@@ -26,7 +26,7 @@ const (
 	statusUpdateErrorMessage = "Update fails on purpose!"
 )
 
-var _ = Describe("CFAppReconciler Unit Tests", func() {
+var _ = Describe("CFAppReconciler", func() {
 	var (
 		fakeClient      *fake.CFClient
 		cfAppReconciler *CFAppReconciler

--- a/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/workloads/cfbuild_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var _ = Describe("CFBuildReconciler Unit Tests", func() {
+var _ = Describe("CFBuildReconciler", func() {
 	const (
 		defaultNamespace        = "default"
 		stagingConditionType    = "Staging"

--- a/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -1,4 +1,4 @@
-package workloads_test
+package integration_test
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("CFAppReconciler Integration Tests", func() {
+var _ = Describe("CFAppReconciler", func() {
 	When("a new CFApp resource is created", func() {
 		const (
 			cfAppGUID = "test-app-guid"

--- a/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -1,4 +1,4 @@
-package workloads_test
+package integration_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
 	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/workloads/testutils"
 	buildv1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	"github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo"
@@ -16,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("CFBuildReconciler Integration Tests", func() {
+var _ = Describe("CFBuildReconciler", func() {
 	const (
 		succeededConditionType  = "Succeeded"
 		kpackReadyConditionType = "Ready"
@@ -264,3 +265,10 @@ var _ = Describe("CFBuildReconciler Integration Tests", func() {
 		})
 	})
 })
+
+func setKpackImageStatus(kpackImage *buildv1alpha1.Image, conditionType string, conditionStatus string) {
+	kpackImage.Status.Conditions = append(kpackImage.Status.Conditions, v1alpha1.Condition{
+		Type:   v1alpha1.ConditionType(conditionType),
+		Status: corev1.ConditionStatus(conditionStatus),
+	})
+}

--- a/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/workloads/integration/suite_integration_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestWorkloadsControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},

--- a/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/workloads/integration/suite_integration_test.go
@@ -1,4 +1,4 @@
-package workloads_test
+package integration_test
 
 import (
 	"os"
@@ -28,17 +28,17 @@ var (
 
 func TestWorkloadsControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Workloads Controllers Suite")
+	RunSpecs(t, "Workloads Controllers Integration Suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
 
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		CRDInstallOptions: envtest.CRDInstallOptions{
-			Paths: []string{filepath.Join("..", "..", "dependencies", "kpack-release-0.3.1.yaml")},
+			Paths: []string{filepath.Join("..", "..", "..", "dependencies", "kpack-release-0.3.1.yaml")},
 		},
 	}
 

--- a/controllers/workloads/suite_test.go
+++ b/controllers/workloads/suite_test.go
@@ -1,0 +1,13 @@
+package workloads_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorkloadsControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workloads Controllers Unit Test Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/pivotal/kpack v0.3.1
 	github.com/projectcontour/contour v1.18.1
-	github.com/sclevine/spec v1.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/webhooks/workloads/cf_workloads_validation_errors_test.go
+++ b/webhooks/workloads/cf_workloads_validation_errors_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("CFWorkloadsWebhookValidationError Unit Tests", func() {
+var _ = Describe("CFWorkloadsWebhookValidationError", func() {
 	It("Marshals a payload", func() {
 		e := DuplicateAppError
 		Expect(e.Marshal()).To(Equal(`{"code":1,"message":"CFApp with the same spec.name exists"}`))

--- a/webhooks/workloads/cfapp_validation_test.go
+++ b/webhooks/workloads/cfapp_validation_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-var _ = Describe("CFAppValidatingWebhook Unit Tests", func() {
+var _ = Describe("CFAppValidatingWebhook", func() {
 	const (
 		testAppGUID      = "test-app-guid"
 		testAppName      = "test-app"

--- a/webhooks/workloads/integration/cfapp_validation_integration_test.go
+++ b/webhooks/workloads/integration/cfapp_validation_integration_test.go
@@ -1,4 +1,4 @@
-package workloads_test
+package integration_test
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("CFAppValidatingWebhook Integration Tests", func() {
+var _ = Describe("CFAppValidatingWebhook", func() {
 	const (
 		testAppGUID        = "test-app-guid"
 		anotherTestAppGUID = "another-test-app-guid"

--- a/webhooks/workloads/integration/suite_integration_test.go
+++ b/webhooks/workloads/integration/suite_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -38,7 +37,7 @@ func TestWorkloadsValidatingWebhooks(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancelFunc := context.WithCancel(context.TODO())
 	cancel = cancelFunc

--- a/webhooks/workloads/integration/suite_integration_test.go
+++ b/webhooks/workloads/integration/suite_integration_test.go
@@ -1,0 +1,114 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	. "code.cloudfoundry.org/cf-k8s-controllers/webhooks/workloads"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+var (
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	k8sClient client.Client
+)
+
+func TestWorkloadsValidatingWebhooks(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workloads Validating Webhooks Integration Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+
+	ctx, cancelFunc := context.WithCancel(context.TODO())
+	cancel = cancelFunc
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(admissionv1beta1.AddToScheme(scheme)).To(Succeed())
+
+	Expect(v1.AddToScheme(scheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect((&v1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
+
+	cfAppValidatingWebhook := &CFAppValidation{Client: mgr.GetClient()}
+	Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		err = mgr.Start(ctx)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel() // call the cancel function to stop the controller context
+	Expect(testEnv.Stop()).To(Succeed())
+})

--- a/webhooks/workloads/suite_test.go
+++ b/webhooks/workloads/suite_test.go
@@ -1,0 +1,13 @@
+package workloads_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorkloadsValidatingWebhooks(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workloads Validating Webhooks Unit Test Suite")
+}


### PR DESCRIPTION
After converting tests from spec to ginkgo, this PR separates unit and integration tests by moving integration tests to a separate package.

Acceptance:
make test