### PR TITLE
Make the GCP Service Account JSON Arg Optional When Running the Install-Dependencies Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
 ```
 Or
 ```
-kubectl apply -f dependencies/contour-1.18.1.yaml
+kubectl apply -f dependencies/contour-1.18.2.yaml
 
 ```
 

--- a/dependencies/contour-1.18.2.yaml
+++ b/dependencies/contour-1.18.2.yaml
@@ -2709,7 +2709,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.18.1
+  name: contour-certgen-v1.18.2
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -2720,7 +2720,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: docker.io/projectcontour/contour:v1.18.2
         imagePullPolicy: Always
         command:
         - contour
@@ -2993,7 +2993,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: docker.io/projectcontour/contour:v1.18.2
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -3082,7 +3082,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: docker.io/projectcontour/contour:v1.18.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3166,7 +3166,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.18.1
+        image: docker.io/projectcontour/contour:v1.18.2
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pivotal/kpack v0.3.1
-	github.com/projectcontour/contour v1.18.1
+	github.com/projectcontour/contour v1.18.2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -362,9 +362,9 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -709,8 +709,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
-github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -764,8 +764,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/projectcontour/contour v1.18.1 h1:J1MmqchDFuou066Gkr13eYtPaBnfb5j7h5ETH9OfIfQ=
-github.com/projectcontour/contour v1.18.1/go.mod h1:prL5IyPK2ek6MUWwm8C5S1pHsWOE/2Y8Ym7ak3feVpo=
+github.com/projectcontour/contour v1.18.2 h1:q16Q0f8mb14DATpCus/qBONawBy1Zn4vrvBj1bXh3hc=
+github.com/projectcontour/contour v1.18.2/go.mod h1:prL5IyPK2ek6MUWwm8C5S1pHsWOE/2Y8Ym7ak3feVpo=
 github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/hack/install-dependencies.sh
+++ b/hack/install-dependencies.sh
@@ -16,10 +16,6 @@ EOF
   exit 1
 }
 
-if [[ $# -lt 1 ]]; then
-  usage_text >&2
-fi
-
 while [[ $# -gt 0 ]]; do
   i=$1
   case $i in
@@ -57,14 +53,16 @@ echo "*******************"
 echo "Configuring Kpack"
 echo "*******************"
 
-# For GCR with a json key, DOCKER_USERNAME is `_json_key`
-DOCKER_USERNAME=${DOCKER_USERNAME:-"_json_key"}
-DOCKER_PASSWORD=${DOCKER_PASSWORD:-"$(cat $GCP_SERVICE_ACCOUNT_JSON_FILE)"}
-DOCKER_SERVER=${DOCKER_SERVER:-"gcr.io"}
+if [[ -n "${GCP_SERVICE_ACCOUNT_JSON_FILE}" ]]; then
+  # For GCR with a json key, DOCKER_USERNAME is `_json_key`
+  DOCKER_USERNAME=${DOCKER_USERNAME:-"_json_key"}
+  DOCKER_PASSWORD=${DOCKER_PASSWORD:-"$(cat $GCP_SERVICE_ACCOUNT_JSON_FILE)"}
+  DOCKER_SERVER=${DOCKER_SERVER:-"gcr.io"}
 
-kubectl create secret docker-registry image-registry-credentials \
-    --docker-username=$DOCKER_USERNAME --docker-password="$DOCKER_PASSWORD" --docker-server=$DOCKER_SERVER --namespace default || true
-# kubectl create secret docker-registry image-registry-credentials --docker-username="_json_key" --docker-password="$(cat /home/birdrock/workspace/credentials/cf-relint-greengrass-2826975617b2.json)" --docker-server=gcr.io --namespace default
+  kubectl create secret docker-registry image-registry-credentials \
+      --docker-username=$DOCKER_USERNAME --docker-password="$DOCKER_PASSWORD" --docker-server=$DOCKER_SERVER --namespace default || true
+  # kubectl create secret docker-registry image-registry-credentials --docker-username="_json_key" --docker-password="$(cat /home/birdrock/workspace/credentials/cf-relint-greengrass-2826975617b2.json)" --docker-server=gcr.io --namespace default
+fi
 
 kubectl apply -f config/kpack/service_account.yaml \
     -f config/kpack/cluster_stack.yaml \
@@ -80,5 +78,3 @@ kubectl apply -f dependencies/contour-1.18.1.yaml
 echo "******"
 echo "Done"
 echo "******"
-
-

--- a/hack/install-dependencies.sh
+++ b/hack/install-dependencies.sh
@@ -73,7 +73,7 @@ echo "*******************"
 echo "Installing Contour"
 echo "*******************"
 
-kubectl apply -f dependencies/contour-1.18.1.yaml
+kubectl apply -f dependencies/contour-1.18.2.yaml
 
 echo "******"
 echo "Done"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Make the GCP service account JSON arg optional when running the install-dependencies script so that it can be used in the setup step for the API's e2e tests. Also, bump Contour to 1.18.2.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy and run tests.

## Tag your pair, your PM, and/or team
@acosta11 