### PR TITLE
Add Ingress Configuration and Domain Management Instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## Installation
-### Clone this repo
+# Installation
+## Clone this repo
 
 ```
 cd ~/workspace
@@ -7,7 +7,7 @@ git clone git@github.com:cloudfoundry/cf-k8s-controllers.git
 cd cf-k8s-controllers/
 ```
 
-### Prerequisites
+## Prerequisites
 
 ### Install Cert-Manager
 To deploy cf-k8s-controller and run it in a cluster, you must first [install cert-manager](https://cert-manager.io/docs/installation/) 
@@ -19,7 +19,7 @@ Or
 kubectl apply -f dependencies/cert-manager.yaml
 ```
 
-### Install kpack
+### Install Kpack
 
 Edit the file: `config/kpack/cluster_builder.yaml` and set the `tag` field to be the registry location you want your ClusterBuilder image to be uploaded to.
 
@@ -49,21 +49,45 @@ kubectl apply -f dependencies/contour-1.18.2.yaml
 
 ```
 
----
-## Development workflow
+### Configure Ingress
+To enable external access to workloads running on the cluster, you must configure ingress. Generally, a load balancer service will route traffic to the cluster with an external IP and an ingress controller will route the traffic based on domain name or the Host header.
 
-### Install dependencies with hack script
+Provisioning a load balancer service is generally handled automatically by Contour, given the cluster infrastructure provider supports load balancer services. When a load balancer service is reconciled, it is assigned an external IP by the infrastructure provider. The external IP is visible on the Service resource itself via `kubectl get service envoy -n projectcontour -o wide`. You can use that external IP to define a DNS A record to route traffic based on your desired domain name.
+
+With the load balancer provisioned, you must configure the ingress controller to route traffic based on your desired domain/host name. For Contour, this configuration goes on an HTTPProxy, for which we have a default resource defined to route traffic to the [CF API](https://github.com/cloudfoundry/cf-k8s-api).
+
+### Domain management
+To be able to create workload routes via the [CF API](https://github.com/cloudfoundry/cf-k8s-api) in the absence of the domain management endpoints, you must first create the appropriate `CFDomain` resource(s) for your cluster. Each desired domain name should be specified via the `spec.name` property of a distinct resource. The `metadata.name` for the resource can be set to any unique value (the API will use a GUID). See `config/samples/cfdomain.yaml` for an example.
+
+---
+# Development Workflow
+
+## Running the unit tests
+```
+go test ./...
+```
+
+## Running the integration tests
+```
+# First time (pulls kube-apiserver and etcd for envtest):
+make test
+
+# Afterwards
+export KUBEBUILDER_ASSETS=~/workspace/cf-k8s-controllers/testbin/bin/
+go test ./... -tags=integration
+```
+## Install all dependencies with hack script
 ```
 # modify kpack dependency files to point towards your registry
 hack/install-dependencies.sh -g "<PATH_TO_GCR_CREDENTIALS>"
 ```
 
-### Configure cf-k8s-controllers
+## Configure cf-k8s-controllers
 Configuration file for cf-k8s-controllers is at `config/cf/cf_k8s_controllers_k8s.yaml`
 
 Note: Edit this file and set the `kpackImageTag` to be the registry location you want for storing the images. 
 
-### Build, Install and Deploy to K8s cluster
+## Build, Install and Deploy to K8s cluster
 Set the $IMG environment variable to a location you have push/pull access. For example 
 ```
 export IMG=foo/cf-k8s-controllers:bar #Replace this with your image ref
@@ -115,19 +139,3 @@ kubectl apply -f reference/cf-k8s-controllers.yaml
 ```
 kubectl apply -f config/samples/. --recursive
 ```
-
-Running the unit tests
-```
-go test ./...
-```
-
-Running integration tests
-```
-# First time (pulls kube-apiserver and etcd for envtest):
-make test
-
-# Afterwards
-export KUBEBUILDER_ASSETS=~/workspace/cf-k8s-controllers/testbin/bin/
-go test ./... -tags=integration
-```
-


### PR DESCRIPTION
## Is there a related GitHub Issue?
#59 

## What is this change about?
Add Ingress Configuration and Domain Management Instructions to the README.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the steps in the README to configure ingress and manually create CFDomain resources.

## Tag your pair, your PM, and/or team
@acosta11 