### PR TITLE
Set Stack used for building Image on BuildDropletStatus

### DIFF
--- a/apis/workloads/v1alpha1/cfbuild_types.go
+++ b/apis/workloads/v1alpha1/cfbuild_types.go
@@ -49,6 +49,9 @@ type BuildDropletStatus struct {
 	// Specifies the Container registry image, and secrets to access
 	Registry Registry `json:"registry"`
 
+	// Specifies the stack used to build the Droplet
+	Stack string `json:"stack"`
+
 	// Specifies the process types and associated start commands for the Droplet
 	ProcessTypes []ProcessType `json:"processTypes"`
 

--- a/config/crd/bases/workloads.cloudfoundry.org_cfbuilds.yaml
+++ b/config/crd/bases/workloads.cloudfoundry.org_cfbuilds.yaml
@@ -173,10 +173,14 @@ spec:
                     required:
                     - image
                     type: object
+                  stack:
+                    description: Specifies the stack used to build the Droplet
+                    type: string
                 required:
                 - ports
                 - processTypes
                 - registry
+                - stack
                 type: object
             required:
             - conditions

--- a/config/samples/cfbuild.yaml
+++ b/config/samples/cfbuild.yaml
@@ -39,6 +39,7 @@ spec:
 #      reason: Buildpack
 #      message: ""
 #  droplet:
+#    stack: cflinuxfs3
 #    ports: [80, 443] # spec.ports is the set of ports exposed on the Processes of the Droplet
 #    processTypes:
 #      - type: web

--- a/controllers/workloads/cfbuild_controller.go
+++ b/controllers/workloads/cfbuild_controller.go
@@ -288,8 +288,8 @@ func (r *CFBuildReconciler) generateBuildDropletStatus(ctx context.Context, kpac
 			ImagePullSecrets: imagePullSecrets,
 		},
 
-		// ProcessTypes & Ports are required fields. Hence, populating with dummy values
-		// Populating with real values will be handled in a future story
+		Stack: kpackImage.Status.LatestStack,
+
 		ProcessTypes: dropletProcessTypes,
 		Ports:        dropletPorts,
 	}, nil

--- a/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -250,7 +250,8 @@ var _ = Describe("CFBuildReconciler", func() {
 
 		When("kpack image has built successfully", func() {
 			const (
-				kpackBuildImageRef = "some-org/my-image@sha256:some-sha"
+				kpackBuildImageRef    = "some-org/my-image@sha256:some-sha"
+				kpackImageLatestStack = "cflinuxfs3"
 			)
 
 			var (
@@ -278,6 +279,7 @@ var _ = Describe("CFBuildReconciler", func() {
 				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
 				setKpackImageStatus(createdKpackImage, kpackReadyConditionType, "True")
 				createdKpackImage.Status.LatestImage = kpackBuildImageRef
+				createdKpackImage.Status.LatestStack = kpackImageLatestStack
 				Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
 			})
 
@@ -309,7 +311,8 @@ var _ = Describe("CFBuildReconciler", func() {
 					return createdCFBuild.Status.BuildDropletStatus
 				}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeNil(), "BuildStatusDroplet was nil on CFBuild")
 				Expect(fakeImageProcessFetcher.CallCount()).To(Equal(1), "Build Controller imageProcessFetcher was not called just once")
-				Expect(createdCFBuild.Status.BuildDropletStatus.Registry.Image).To(Equal(kpackBuildImageRef))
+				Expect(createdCFBuild.Status.BuildDropletStatus.Registry.Image).To(Equal(kpackBuildImageRef), "droplet registry image does not match kpack image latestImage")
+				Expect(createdCFBuild.Status.BuildDropletStatus.Stack).To(Equal(kpackImageLatestStack), "droplet stack does not match kpack image latestStack")
 				Expect(createdCFBuild.Status.BuildDropletStatus.Registry.ImagePullSecrets).To(Equal(desiredCFPackage.Spec.Source.Registry.ImagePullSecrets))
 				Expect(createdCFBuild.Status.BuildDropletStatus.ProcessTypes).To(Equal(returnedProcessTypes))
 				Expect(createdCFBuild.Status.BuildDropletStatus.Ports).To(Equal(returnedPorts))


### PR DESCRIPTION

## Is there a related GitHub Issue?
resolves https://github.com/cloudfoundry/cf-k8s-controllers/issues/77

## What is this change about?
Set Stack used for building Image on BuildDropletStatus
- modified the CFBuild CR to add a new status field droplet.stack
- enhanced CFBuild controller to take the Status.latestStack from the kpack image and add it to the CFBuild.Status.droplet

## Does this PR introduce a breaking change?
no

## Acceptance Steps
Follow README instructions to install dependencies and controllers.
kubectl apply -f config/samples/cfapp.yaml
kubectl apply -f config/samples/cfpackage.yaml
kubectl apply -f config/samples/cfbuild.yaml
monitor the kpack images until the build is successful
watch kubectl get images
Then pull the cfbuild and confirm that processTypes and ports are set
k get cfbuilds 1591ee05-e208-4cf3-a662-1c2da42f20a7 -o yaml

## Tag your pair, your PM, and/or team
@akrishna90 

