### PR TITLE
Fix RBAC issues with CFBuild Controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  - serviceaccounts/status
+  verbs:
+  - get
+- apiGroups:
   - kpack.io
   resources:
   - images

--- a/config/samples/cfbuild.yaml
+++ b/config/samples/cfbuild.yaml
@@ -20,7 +20,7 @@ spec:
     data:
       buildpacks: []
       stack: cflinuxfs3
-#status:
+status:
 #  conditions:
 #    - type: Succeeded
 #      status: "True"
@@ -29,14 +29,6 @@ spec:
 #    - type: Staging
 #      status: "False"
 #      reason: Succeeded
-#      message: ""
-#    - type: BuildReady
-#      status: "True"
-#      reason: Buildpack
-#      message: ""
-#    - type: DropletReady
-#      status: "True"
-#      reason: Buildpack
 #      message: ""
 #  droplet:
 #    stack: cflinuxfs3

--- a/controllers/workloads/cfbuild_controller.go
+++ b/controllers/workloads/cfbuild_controller.go
@@ -97,6 +97,9 @@ type CFBuildReconciler struct {
 //+kubebuilder:rbac:groups=kpack.io,resources=images/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kpack.io,resources=images/finalizers,verbs=update
 
+//+kubebuilder:rbac:groups="",resources=serviceaccounts;secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts/status;secrets/status,verbs=get
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by

--- a/reference/cf-k8s-controllers.yaml
+++ b/reference/cf-k8s-controllers.yaml
@@ -418,10 +418,14 @@ spec:
                     required:
                     - image
                     type: object
+                  stack:
+                    description: Specifies the stack used to build the Droplet
+                    type: string
                 required:
                 - ports
                 - processTypes
                 - registry
+                - stack
                 type: object
             required:
             - conditions
@@ -1007,6 +1011,79 @@ spec:
             type: object
           status:
             description: CFRouteStatus defines the observed state of CFRoute
+            properties:
+              conditions:
+                description: Conditions capture the current status of the Build
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
             type: object
         type: object
     served: true
@@ -1070,6 +1147,22 @@ metadata:
   creationTimestamp: null
   name: cf-k8s-controllers-manager-role
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  - serviceaccounts/status
+  verbs:
+  - get
 - apiGroups:
   - kpack.io
   resources:
@@ -1148,6 +1241,30 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - httpproxies/status
+  verbs:
+  - get
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:


### PR DESCRIPTION

## Is there a related GitHub Issue?
Fixes rejection from https://github.com/cloudfoundry/cf-k8s-controllers/issues/44

## What is this change about?
Adds RBAC to CFBuild controller to fix issues with the deployment version of the controllers

## Does this PR introduce a breaking change?
no

## Acceptance Steps
Follow README instructions to install dependencies and controllers.
`kubectl apply -f config/samples/cfapp.yaml`
`kubectl apply -f config/samples/cfpackage.yaml`
`kubectl apply -f config/samples/cfbuild.yaml`
monitor the kpack images until the build is successful
`watch kubectl get images`
Then pull the cfbuild and confirm that processTypes and ports are set
`k get cfbuilds 1591ee05-e208-4cf3-a662-1c2da42f20a7 -o yaml`

## Tag your pair, your PM, and/or team
@Birdrock 

