### PR TITLE
Fixes a typo in the readme for the Eirini secret.

### DIFF
--- a/controllers/README.md
+++ b/controllers/README.md
@@ -94,7 +94,7 @@ openssl req -x509 -newkey rsa:4096 \
 
 Once you have created a certificate, use it to create the secret required by eirini-controller:
 ```
-kubectl create secret -n eirini-controller generic eirini-webhooks-cert --from-file=tls.crt=./tls.crt --from-file=tls.ca=./tls.crt --from-file=tls.key=./tls.key
+kubectl create secret -n eirini-controller generic eirini-webhooks-certs --from-file=tls.crt=./tls.crt --from-file=tls.ca=./tls.crt --from-file=tls.key=./tls.key
 ```
 
 #### Install


### PR DESCRIPTION
## Is there a related GitHub Issue?
#119 

## What is this change about?
Fixes a typo in the readme that sets the eirini-webhooks-certs secret name incorrectly.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the readme to install the eirini-controller and validate that the line below matches the create secret line in the readme.
```
kubectl create secret -n eirini-controller generic eirini-webhooks-certs --from-file=tls.crt=./tls.crt --from-file=tls.ca=./tls.crt --from-file=tls.key=./tls.key
```

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s