### PR TITLE
Add TLS configuration for API endpoint

### DIFF
--- a/api/config/base/ingress.yaml
+++ b/api/config/base/ingress.yaml
@@ -4,10 +4,11 @@ metadata:
   labels:
     app: cf-k8s-api
   name: proxy
-  namespace: default
 spec:
   virtualhost:
     fqdn: API_URL
+    tls:
+      secretName: cf-k8s-api-ingress-cert
   routes:
   - conditions:
     - prefix: /

--- a/api/config/overlays/kind/kustomization.yaml
+++ b/api/config/overlays/kind/kustomization.yaml
@@ -20,3 +20,5 @@ patches:
     - op: replace
       path: /spec/virtualhost/fqdn
       value: "localhost"
+    - op: remove
+      path: /spec/virtualhost/tls

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -271,3 +271,5 @@ spec:
       port: 80
   virtualhost:
     fqdn: ""
+    tls:
+      secretName: cf-k8s-api-ingress-cert

--- a/controllers/Makefile
+++ b/controllers/Makefile
@@ -85,6 +85,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 build-reference: manifests kustomize ## Generate reference yaml and output to ./reference/cf-k8s-controllers.yaml
+	cd config/manager && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-controllers=${IMG}
 	$(KUSTOMIZE) build config/default -o reference/cf-k8s-controllers.yaml
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/controllers/config/manager/kustomization.yaml
+++ b/controllers/config/manager/kustomization.yaml
@@ -8,9 +8,10 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- name: cloudfoundry/cf-k8s-controllers
   newName: cloudfoundry/cf-k8s-controllers
   newTag: latest

--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: cloudfoundry/cf-k8s-controllers:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Is there a related GitHub Issue?
#136 

## What is this change about?
This PR adds configuration for a TLS certificate for the API endpoint and updates the README to tell the user how to create the required certificate and secret.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #136 

## Tag your pair, your PM, and/or team
@acosta11 

Note: This is the same PR as https://github.com/cloudfoundry/cf-k8s-api/pull/202, just moved to the new mono-repo.