### PR TITLE
Add docker and github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "docker"
+  directory: "/api"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "docker"
+  directory: "/controllers"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR adds docker and github-actions sections to the dependabot config

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Wait for PRs to be created to bump dependencies in the Dockerfiles and github workflow actions.