### PR TITLE
Add POST /v3/spaces/:guid/actions/apply_manifest endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+cover.out
+bin
+testbin
+.idea/
+~/.*

--- a/api/actions/apply_manifest_action.go
+++ b/api/actions/apply_manifest_action.go
@@ -1,0 +1,33 @@
+package actions
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
+)
+
+type ApplyManifest struct {
+	appRepo CFAppRepository
+}
+
+func NewApplyManifest(appRepo CFAppRepository) *ApplyManifest {
+	return &ApplyManifest{
+		appRepo: appRepo,
+	}
+}
+
+func (a *ApplyManifest) Invoke(ctx context.Context, c client.Client, spaceGUID string, manifest payloads.SpaceManifestApply) error {
+	appRecord := manifest.ToRecord(spaceGUID)
+	exists, err := a.appRepo.AppExistsWithNameAndSpace(ctx, c, appRecord.Name, appRecord.SpaceGUID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	_, err = a.appRepo.CreateApp(ctx, c, appRecord)
+	return err
+}

--- a/api/actions/apply_manifest_action_test.go
+++ b/api/actions/apply_manifest_action_test.go
@@ -1,0 +1,113 @@
+package actions_test
+
+import (
+	"context"
+	"errors"
+
+	. "code.cloudfoundry.org/cf-k8s-api/actions"
+	"code.cloudfoundry.org/cf-k8s-api/actions/fake"
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ApplyManifest", func() {
+	const (
+		spaceGUID = "test-space-guid"
+		appName   = "my-app"
+	)
+	var (
+		manifest payloads.SpaceManifestApply
+		action   *ApplyManifest
+		appRepo  *fake.CFAppRepository
+		client   *fake.Client
+	)
+
+	BeforeEach(func() {
+		appRepo = new(fake.CFAppRepository)
+		client = new(fake.Client)
+		action = NewApplyManifest(appRepo)
+		manifest = payloads.SpaceManifestApply{
+			Version: 1,
+			Applications: []payloads.SpaceManifestApplyApplication{
+				{Name: appName},
+			},
+		}
+	})
+
+	When("on the happy path", func() {
+		It("fetches the App using the correct name and space", func() {
+			Expect(
+				action.Invoke(context.Background(), client, spaceGUID, manifest),
+			).To(Succeed())
+
+			Expect(appRepo.AppExistsWithNameAndSpaceCallCount()).To(Equal(1))
+			_, _, actualAppName, actualSpaceGUID := appRepo.AppExistsWithNameAndSpaceArgsForCall(0)
+			Expect(actualAppName).To(Equal(appName))
+			Expect(actualSpaceGUID).To(Equal(spaceGUID))
+		})
+
+		When("the app in the manifest doesn't exist", func() {
+			BeforeEach(func() {
+				appRepo.AppExistsWithNameAndSpaceReturns(false, nil)
+			})
+
+			It("creates the App with the correct name", func() {
+				Expect(
+					action.Invoke(context.Background(), client, spaceGUID, manifest),
+				).To(Succeed())
+
+				Expect(appRepo.CreateAppCallCount()).To(Equal(1))
+				_, _, appRecord := appRepo.CreateAppArgsForCall(0)
+				Expect(appRecord.Name).To(Equal(appName))
+				Expect(appRecord.SpaceGUID).To(Equal(spaceGUID))
+			})
+		})
+
+		When("the app in the manifest already exists", func() {
+			BeforeEach(func() {
+				appRepo.AppExistsWithNameAndSpaceReturns(true, nil)
+			})
+
+			It("doesn't attempt to create the App", func() {
+				Expect(
+					action.Invoke(context.Background(), client, spaceGUID, manifest),
+				).To(Succeed())
+
+				Expect(appRepo.CreateAppCallCount()).To(Equal(0))
+			})
+		})
+	})
+
+	When("fetching the app errors", func() {
+		BeforeEach(func() {
+			appRepo.AppExistsWithNameAndSpaceReturns(false, errors.New("boom"))
+		})
+
+		It("returns an error", func() {
+			Expect(
+				action.Invoke(context.Background(), client, spaceGUID, manifest),
+			).To(MatchError(ContainSubstring("boom")))
+		})
+
+		It("doesn't create an App", func() {
+			_ = action.Invoke(context.Background(), client, spaceGUID, manifest)
+
+			Expect(appRepo.CreateAppCallCount()).To(Equal(0))
+		})
+	})
+
+	When("creating the app errors", func() {
+		BeforeEach(func() {
+			appRepo.CreateAppReturns(repositories.AppRecord{}, errors.New("boom"))
+		})
+
+		It("returns an error", func() {
+			Expect(
+				action.Invoke(context.Background(), client, spaceGUID, manifest),
+			).To(MatchError(ContainSubstring("boom")))
+		})
+	})
+})

--- a/api/actions/fake/cfapp_repository.go
+++ b/api/actions/fake/cfapp_repository.go
@@ -11,6 +11,22 @@ import (
 )
 
 type CFAppRepository struct {
+	AppExistsWithNameAndSpaceStub        func(context.Context, client.Client, string, string) (bool, error)
+	appExistsWithNameAndSpaceMutex       sync.RWMutex
+	appExistsWithNameAndSpaceArgsForCall []struct {
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
+		arg4 string
+	}
+	appExistsWithNameAndSpaceReturns struct {
+		result1 bool
+		result2 error
+	}
+	appExistsWithNameAndSpaceReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	CreateAppStub        func(context.Context, client.Client, repositories.AppRecord) (repositories.AppRecord, error)
 	createAppMutex       sync.RWMutex
 	createAppArgsForCall []struct {
@@ -117,6 +133,73 @@ type CFAppRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpace(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string) (bool, error) {
+	fake.appExistsWithNameAndSpaceMutex.Lock()
+	ret, specificReturn := fake.appExistsWithNameAndSpaceReturnsOnCall[len(fake.appExistsWithNameAndSpaceArgsForCall)]
+	fake.appExistsWithNameAndSpaceArgsForCall = append(fake.appExistsWithNameAndSpaceArgsForCall, struct {
+		arg1 context.Context
+		arg2 client.Client
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.AppExistsWithNameAndSpaceStub
+	fakeReturns := fake.appExistsWithNameAndSpaceReturns
+	fake.recordInvocation("AppExistsWithNameAndSpace", []interface{}{arg1, arg2, arg3, arg4})
+	fake.appExistsWithNameAndSpaceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpaceCallCount() int {
+	fake.appExistsWithNameAndSpaceMutex.RLock()
+	defer fake.appExistsWithNameAndSpaceMutex.RUnlock()
+	return len(fake.appExistsWithNameAndSpaceArgsForCall)
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpaceCalls(stub func(context.Context, client.Client, string, string) (bool, error)) {
+	fake.appExistsWithNameAndSpaceMutex.Lock()
+	defer fake.appExistsWithNameAndSpaceMutex.Unlock()
+	fake.AppExistsWithNameAndSpaceStub = stub
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpaceArgsForCall(i int) (context.Context, client.Client, string, string) {
+	fake.appExistsWithNameAndSpaceMutex.RLock()
+	defer fake.appExistsWithNameAndSpaceMutex.RUnlock()
+	argsForCall := fake.appExistsWithNameAndSpaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpaceReturns(result1 bool, result2 error) {
+	fake.appExistsWithNameAndSpaceMutex.Lock()
+	defer fake.appExistsWithNameAndSpaceMutex.Unlock()
+	fake.AppExistsWithNameAndSpaceStub = nil
+	fake.appExistsWithNameAndSpaceReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFAppRepository) AppExistsWithNameAndSpaceReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.appExistsWithNameAndSpaceMutex.Lock()
+	defer fake.appExistsWithNameAndSpaceMutex.Unlock()
+	fake.AppExistsWithNameAndSpaceStub = nil
+	if fake.appExistsWithNameAndSpaceReturnsOnCall == nil {
+		fake.appExistsWithNameAndSpaceReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.appExistsWithNameAndSpaceReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *CFAppRepository) CreateApp(arg1 context.Context, arg2 client.Client, arg3 repositories.AppRecord) (repositories.AppRecord, error) {
@@ -583,6 +666,8 @@ func (fake *CFAppRepository) SetCurrentDropletReturnsOnCall(i int, result1 repos
 func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.appExistsWithNameAndSpaceMutex.RLock()
+	defer fake.appExistsWithNameAndSpaceMutex.RUnlock()
 	fake.createAppMutex.RLock()
 	defer fake.createAppMutex.RUnlock()
 	fake.createAppEnvironmentVariablesMutex.RLock()

--- a/api/actions/scale_app_process.go
+++ b/api/actions/scale_app_process.go
@@ -9,7 +9,7 @@ import (
 )
 
 //counterfeiter:generate -o fake -fake-name ScaleProcess . ScaleProcessAction
-type ScaleProcessAction func(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScale) (repositories.ProcessRecord, error)
+type ScaleProcessAction func(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 type ScaleAppProcess struct {
 	appRepo            CFAppRepository
 	processRepo        CFProcessRepository
@@ -24,7 +24,7 @@ func NewScaleAppProcess(appRepo CFAppRepository, processRepo CFProcessRepository
 	}
 }
 
-func (a *ScaleAppProcess) Invoke(ctx context.Context, client client.Client, appGUID string, processType string, scale repositories.ProcessScale) (repositories.ProcessRecord, error) {
+func (a *ScaleAppProcess) Invoke(ctx context.Context, client client.Client, appGUID string, processType string, scale repositories.ProcessScaleMessage) (repositories.ProcessRecord, error) {
 	app, err := a.appRepo.FetchApp(ctx, client, appGUID)
 	if err != nil {
 		return repositories.ProcessRecord{}, err

--- a/api/actions/scale_app_process_test.go
+++ b/api/actions/scale_app_process_test.go
@@ -33,7 +33,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		scaleAppProcessAction *ScaleAppProcess
 
 		testClient *fake.Client
-		testScale  *repositories.ProcessScale
+		testScale  *repositories.ProcessScaleMessage
 
 		responseRecord repositories.ProcessRecord
 		responseErr    error
@@ -68,7 +68,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		var newMemoryMB int64 = 256
 		var newDiskMB int64 = 1024
 
-		testScale = &repositories.ProcessScale{
+		testScale = &repositories.ProcessScaleMessage{
 			Instances: &newInstances,
 			MemoryMB:  &newMemoryMB,
 			DiskMB:    &newDiskMB,
@@ -126,7 +126,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 			Expect(scaleProcessMessage.DiskMB).To(Equal(testScale.DiskMB))
 			Expect(scaleProcessMessage.MemoryMB).To(Equal(testScale.MemoryMB))
 		})
-		It("transparently returns a record from repositories.ProcessScale", func() {
+		It("transparently returns a record from repositories.ProcessScaleMessage", func() {
 			Expect(responseRecord).To(Equal(*updatedProcessRecord))
 		})
 	})

--- a/api/actions/scale_process.go
+++ b/api/actions/scale_process.go
@@ -18,15 +18,15 @@ func NewScaleProcess(processRepo CFProcessRepository) *ScaleProcess {
 	}
 }
 
-func (a *ScaleProcess) Invoke(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScale) (repositories.ProcessRecord, error) {
+func (a *ScaleProcess) Invoke(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScaleMessage) (repositories.ProcessRecord, error) {
 	process, err := a.processRepo.FetchProcess(ctx, client, processGUID)
 	if err != nil {
 		return repositories.ProcessRecord{}, err
 	}
 	scaleMessage := repositories.ScaleProcessMessage{
-		GUID:         process.GUID,
-		SpaceGUID:    process.SpaceGUID,
-		ProcessScale: scale,
+		GUID:                process.GUID,
+		SpaceGUID:           process.SpaceGUID,
+		ProcessScaleMessage: scale,
 	}
 	return a.processRepo.ScaleProcess(ctx, client, scaleMessage)
 }

--- a/api/actions/scale_process_test.go
+++ b/api/actions/scale_process_test.go
@@ -29,7 +29,7 @@ var _ = Describe("ScaleProcessAction", func() {
 		scaleProcessAction *ScaleProcess
 
 		testClient *fake.Client
-		testScale  *repositories.ProcessScale
+		testScale  *repositories.ProcessScaleMessage
 
 		responseRecord repositories.ProcessRecord
 		responseErr    error
@@ -72,7 +72,7 @@ var _ = Describe("ScaleProcessAction", func() {
 		var newMemoryMB int64 = 256
 		var newDiskMB int64 = 1024
 
-		testScale = &repositories.ProcessScale{
+		testScale = &repositories.ProcessScaleMessage{
 			Instances: &newInstances,
 			MemoryMB:  &newMemoryMB,
 			DiskMB:    &newDiskMB,
@@ -104,7 +104,7 @@ var _ = Describe("ScaleProcessAction", func() {
 			Expect(scaleProcessMessage.DiskMB).To(Equal(testScale.DiskMB))
 			Expect(scaleProcessMessage.MemoryMB).To(Equal(testScale.MemoryMB))
 		})
-		It("transparently returns a record from repositories.ProcessScale", func() {
+		It("transparently returns a record from repositories.ProcessScaleMessage", func() {
 			Expect(responseRecord).To(Equal(*updatedProcessRecord))
 		})
 	})

--- a/api/actions/shared.go
+++ b/api/actions/shared.go
@@ -3,8 +3,9 @@ package actions
 import (
 	"context"
 
-	"code.cloudfoundry.org/cf-k8s-api/repositories"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -21,6 +22,7 @@ type CFProcessRepository interface {
 //counterfeiter:generate -o fake -fake-name CFAppRepository . CFAppRepository
 type CFAppRepository interface {
 	FetchApp(context.Context, client.Client, string) (repositories.AppRecord, error)
+	AppExistsWithNameAndSpace(context.Context, client.Client, string, string) (bool, error)
 	FetchAppList(context.Context, client.Client) ([]repositories.AppRecord, error)
 	FetchNamespace(context.Context, client.Client, string) (repositories.SpaceRecord, error)
 	CreateAppEnvironmentVariables(context.Context, client.Client, repositories.AppEnvVarsRecord) (repositories.AppEnvVarsRecord, error)

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -49,7 +49,7 @@ type CFAppRepository interface {
 }
 
 //counterfeiter:generate -o fake -fake-name ScaleAppProcess . ScaleAppProcess
-type ScaleAppProcess func(ctx context.Context, client client.Client, appGUID string, processType string, scale repositories.ProcessScale) (repositories.ProcessRecord, error)
+type ScaleAppProcess func(ctx context.Context, client client.Client, appGUID string, processType string, scale repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 
 type AppHandler struct {
 	logger          logr.Logger
@@ -134,7 +134,7 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.AppCreate
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return
@@ -208,6 +208,7 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
 	w.Write(responseBody)
 }
 
@@ -248,7 +249,7 @@ func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.
 	appGUID := vars["guid"]
 
 	var payload payloads.AppSetCurrentDroplet
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return
@@ -522,7 +523,7 @@ func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Reque
 	processType := vars["processType"]
 
 	var payload payloads.ProcessScale
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -407,8 +407,8 @@ var _ = Describe("AppHandler", func() {
 					Expect(appRepo.CreateAppEnvironmentVariablesCallCount()).To(BeZero(), "Repo CreateAppEnvironmentVariables was invoked even though no environment vars were provided")
 				})
 
-				It("return status 200 OK", func() {
-					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				It("return status 201 Created", func() {
+					Expect(rr.Code).To(Equal(http.StatusCreated), "Matching HTTP response code:")
 				})
 
 				It("returns Content-Type as JSON in header", func() {
@@ -416,7 +416,7 @@ var _ = Describe("AppHandler", func() {
 					Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
 				})
 
-				It("returns the \"created app\"(the mock response record) in the response", func() {
+				It(`returns the "created app" (the mock response record) in the response`, func() {
 					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
 					"guid": "%[2]s",
 					"created_at": "",

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -97,7 +97,7 @@ func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.BuildCreate
-	rme := DecodeAndValidatePayload(req, &payload)
+	rme := decodeAndValidateJSONPayload(req, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return

--- a/api/apis/fake/apply_manifest_action.go
+++ b/api/apis/fake/apply_manifest_action.go
@@ -5,99 +5,94 @@ import (
 	"context"
 	"sync"
 
-	"code.cloudfoundry.org/cf-k8s-api/actions"
-	"code.cloudfoundry.org/cf-k8s-api/repositories"
+	"code.cloudfoundry.org/cf-k8s-api/apis"
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ScaleProcess struct {
-	Stub        func(context.Context, client.Client, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
+type ApplyManifestAction struct {
+	Stub        func(context.Context, client.Client, string, payloads.SpaceManifestApply) error
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
 		arg3 string
-		arg4 repositories.ProcessScaleMessage
+		arg4 payloads.SpaceManifestApply
 	}
 	returns struct {
-		result1 repositories.ProcessRecord
-		result2 error
+		result1 error
 	}
 	returnsOnCall map[int]struct {
-		result1 repositories.ProcessRecord
-		result2 error
+		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ScaleProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 repositories.ProcessScaleMessage) (repositories.ProcessRecord, error) {
+func (fake *ApplyManifestAction) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 payloads.SpaceManifestApply) error {
 	fake.mutex.Lock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
 		arg3 string
-		arg4 repositories.ProcessScaleMessage
+		arg4 payloads.SpaceManifestApply
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.Stub
 	returns := fake.returns
-	fake.recordInvocation("ScaleProcessAction", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ApplyManifestAction", []interface{}{arg1, arg2, arg3, arg4})
 	fake.mutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return returns.result1, returns.result2
+	return returns.result1
 }
 
-func (fake *ScaleProcess) CallCount() int {
+func (fake *ApplyManifestAction) CallCount() int {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return len(fake.argsForCall)
 }
 
-func (fake *ScaleProcess) Calls(stub func(context.Context, client.Client, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)) {
+func (fake *ApplyManifestAction) Calls(stub func(context.Context, client.Client, string, payloads.SpaceManifestApply) error) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *ScaleProcess) ArgsForCall(i int) (context.Context, client.Client, string, repositories.ProcessScaleMessage) {
+func (fake *ApplyManifestAction) ArgsForCall(i int) (context.Context, client.Client, string, payloads.SpaceManifestApply) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3, fake.argsForCall[i].arg4
 }
 
-func (fake *ScaleProcess) Returns(result1 repositories.ProcessRecord, result2 error) {
+func (fake *ApplyManifestAction) Returns(result1 error) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	fake.returns = struct {
-		result1 repositories.ProcessRecord
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *ScaleProcess) ReturnsOnCall(i int, result1 repositories.ProcessRecord, result2 error) {
+func (fake *ApplyManifestAction) ReturnsOnCall(i int, result1 error) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = nil
 	if fake.returnsOnCall == nil {
 		fake.returnsOnCall = make(map[int]struct {
-			result1 repositories.ProcessRecord
-			result2 error
+			result1 error
 		})
 	}
 	fake.returnsOnCall[i] = struct {
-		result1 repositories.ProcessRecord
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *ScaleProcess) Invocations() map[string][][]interface{} {
+func (fake *ApplyManifestAction) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.mutex.RLock()
@@ -109,7 +104,7 @@ func (fake *ScaleProcess) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *ScaleProcess) recordInvocation(key string, args []interface{}) {
+func (fake *ApplyManifestAction) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -121,4 +116,4 @@ func (fake *ScaleProcess) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ actions.ScaleProcessAction = new(ScaleProcess).Spy
+var _ apis.ApplyManifestAction = new(ApplyManifestAction).Spy

--- a/api/apis/fake/scale_app_process.go
+++ b/api/apis/fake/scale_app_process.go
@@ -11,14 +11,14 @@ import (
 )
 
 type ScaleAppProcess struct {
-	Stub        func(context.Context, client.Client, string, string, repositories.ProcessScale) (repositories.ProcessRecord, error)
+	Stub        func(context.Context, client.Client, string, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
 		arg3 string
 		arg4 string
-		arg5 repositories.ProcessScale
+		arg5 repositories.ProcessScaleMessage
 	}
 	returns struct {
 		result1 repositories.ProcessRecord
@@ -32,7 +32,7 @@ type ScaleAppProcess struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ScaleAppProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string, arg5 repositories.ProcessScale) (repositories.ProcessRecord, error) {
+func (fake *ScaleAppProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string, arg5 repositories.ProcessScaleMessage) (repositories.ProcessRecord, error) {
 	fake.mutex.Lock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
@@ -40,7 +40,7 @@ func (fake *ScaleAppProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 
 		arg2 client.Client
 		arg3 string
 		arg4 string
-		arg5 repositories.ProcessScale
+		arg5 repositories.ProcessScaleMessage
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.Stub
 	returns := fake.returns
@@ -61,13 +61,13 @@ func (fake *ScaleAppProcess) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *ScaleAppProcess) Calls(stub func(context.Context, client.Client, string, string, repositories.ProcessScale) (repositories.ProcessRecord, error)) {
+func (fake *ScaleAppProcess) Calls(stub func(context.Context, client.Client, string, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *ScaleAppProcess) ArgsForCall(i int) (context.Context, client.Client, string, string, repositories.ProcessScale) {
+func (fake *ScaleAppProcess) ArgsForCall(i int) (context.Context, client.Client, string, string, repositories.ProcessScaleMessage) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3, fake.argsForCall[i].arg4, fake.argsForCall[i].arg5

--- a/api/apis/fake/scale_process.go
+++ b/api/apis/fake/scale_process.go
@@ -11,13 +11,13 @@ import (
 )
 
 type ScaleProcess struct {
-	Stub        func(context.Context, client.Client, string, repositories.ProcessScale) (repositories.ProcessRecord, error)
+	Stub        func(context.Context, client.Client, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
 		arg3 string
-		arg4 repositories.ProcessScale
+		arg4 repositories.ProcessScaleMessage
 	}
 	returns struct {
 		result1 repositories.ProcessRecord
@@ -31,14 +31,14 @@ type ScaleProcess struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ScaleProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 repositories.ProcessScale) (repositories.ProcessRecord, error) {
+func (fake *ScaleProcess) Spy(arg1 context.Context, arg2 client.Client, arg3 string, arg4 repositories.ProcessScaleMessage) (repositories.ProcessRecord, error) {
 	fake.mutex.Lock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
 		arg3 string
-		arg4 repositories.ProcessScale
+		arg4 repositories.ProcessScaleMessage
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.Stub
 	returns := fake.returns
@@ -59,13 +59,13 @@ func (fake *ScaleProcess) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *ScaleProcess) Calls(stub func(context.Context, client.Client, string, repositories.ProcessScale) (repositories.ProcessRecord, error)) {
+func (fake *ScaleProcess) Calls(stub func(context.Context, client.Client, string, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *ScaleProcess) ArgsForCall(i int) (context.Context, client.Client, string, repositories.ProcessScale) {
+func (fake *ScaleProcess) ArgsForCall(i int) (context.Context, client.Client, string, repositories.ProcessScaleMessage) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
 	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3, fake.argsForCall[i].arg4

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -1,0 +1,152 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"code.cloudfoundry.org/cf-k8s-api/actions"
+	. "code.cloudfoundry.org/cf-k8s-api/apis"
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
+)
+
+var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint", func() {
+	BeforeEach(func() {
+		appRepo := new(repositories.AppRepo)
+		apiHandler := NewSpaceManifestHandler(
+			logf.Log.WithName("integration tests"),
+			*serverURL,
+			actions.NewApplyManifest(appRepo).Invoke,
+			repositories.BuildCRClient,
+			k8sConfig,
+		)
+		apiHandler.RegisterRoutes(router)
+	})
+
+	When("on the happy path", func() {
+		var (
+			namespace *corev1.Namespace
+			resp      *http.Response
+		)
+
+		const appName = "app1"
+
+		BeforeEach(func() {
+			namespaceGUID := generateGUID()
+			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceGUID}}
+			Expect(
+				k8sClient.Create(context.Background(), namespace),
+			).To(Succeed())
+
+			requestBody := fmt.Sprintf(`---
+                version: 1
+                applications:
+                - name: %s`, appName)
+
+			var err error
+			req, err = http.NewRequest(
+				"POST",
+				serverURI("/v3/spaces/", namespaceGUID, "/actions/apply_manifest"),
+				strings.NewReader(requestBody),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			req.Header.Add("Content-type", "application/x-yaml")
+		})
+
+		AfterEach(func() {
+			Expect(
+				k8sClient.Delete(context.Background(), namespace),
+			).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			resp, err = new(http.Client).Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("no app with that name exists", func() {
+			It("creates the applications in the manifest, returns 202 and a job URI", func() {
+				Expect(resp.StatusCode).To(Equal(202))
+
+				body, err := ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(body).To(BeEmpty())
+
+				Expect(resp.Header.Get("Location")).To(Equal(serverURI("/v3/jobs/sync-space.apply_manifest-", namespace.Name)))
+
+				var appList v1alpha1.CFAppList
+				Eventually(func() []v1alpha1.CFApp {
+					Expect(
+						k8sClient.List(context.Background(), &appList, client.InNamespace(namespace.Name)),
+					).To(Succeed())
+					return appList.Items
+				}).Should(HaveLen(1))
+
+				app1 := appList.Items[0]
+				Expect(app1.Spec.Name).To(Equal(appName))
+				Expect(app1.Spec.DesiredState).To(BeEquivalentTo("STOPPED"))
+				Expect(app1.Spec.Lifecycle.Type).To(BeEquivalentTo("buildpack"))
+			})
+		})
+
+		When("an app with that name already exists", func() {
+			const appGUID = "my-app-guid"
+
+			BeforeEach(func() {
+				Expect(
+					k8sClient.Create(context.Background(), &v1alpha1.CFApp{
+						ObjectMeta: metav1.ObjectMeta{Name: appGUID, Namespace: namespace.Name},
+						Spec: v1alpha1.CFAppSpec{
+							Name:         appName,
+							DesiredState: v1alpha1.StoppedState,
+							Lifecycle: v1alpha1.Lifecycle{
+								Type: v1alpha1.BuildpackLifecycle,
+							},
+						},
+					}),
+				).To(Succeed())
+
+				nsName := types.NamespacedName{Name: appGUID, Namespace: namespace.Name}
+				Eventually(func() error {
+					return k8sClient.Get(context.Background(), nsName, new(v1alpha1.CFApp))
+				}).Should(Succeed())
+			})
+
+			It("doesn't change the App, but it returns 202 with a Location", func() {
+				Expect(resp.StatusCode).To(Equal(202))
+
+				body, err := ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(body).To(BeEmpty())
+
+				Expect(resp.Header.Get("Location")).To(Equal(serverURI("/v3/jobs/sync-space.apply_manifest-", namespace.Name)))
+
+				var appList v1alpha1.CFAppList
+				Eventually(func() []v1alpha1.CFApp {
+					Expect(
+						k8sClient.List(context.Background(), &appList, client.InNamespace(namespace.Name)),
+					).To(Succeed())
+					return appList.Items
+				}).Should(HaveLen(1))
+
+				app1 := appList.Items[0]
+				Expect(app1.Spec.Name).To(Equal(appName))
+				Expect(app1.Spec.DesiredState).To(BeEquivalentTo("STOPPED"))
+				Expect(app1.Spec.Lifecycle.Type).To(BeEquivalentTo("buildpack"))
+			})
+		})
+	})
+})

--- a/api/apis/integration/create_app_test.go
+++ b/api/apis/integration/create_app_test.go
@@ -1,0 +1,152 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"code.cloudfoundry.org/cf-k8s-api/actions"
+	. "code.cloudfoundry.org/cf-k8s-api/apis"
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
+)
+
+var _ = Describe("POST /v3/apps endpoint", func() {
+	BeforeEach(func() {
+		appRepo := new(repositories.AppRepo)
+		dropletRepo := new(repositories.DropletRepo)
+		processRepo := new(repositories.ProcessRepository)
+		routeRepo := new(repositories.RouteRepo)
+		domainRepo := new(repositories.DomainRepo)
+		scaleProcess := actions.NewScaleProcess(processRepo).Invoke
+		scaleAppProcess := actions.NewScaleAppProcess(appRepo, processRepo, scaleProcess).Invoke
+
+		apiHandler := NewAppHandler(
+			logf.Log.WithName("integration tests"),
+			*serverURL,
+			appRepo,
+			dropletRepo,
+			processRepo,
+			routeRepo,
+			domainRepo,
+			scaleAppProcess,
+			repositories.BuildCRClient,
+			k8sConfig,
+		)
+		apiHandler.RegisterRoutes(router)
+	})
+
+	When("on the happy path", func() {
+		var (
+			namespace *corev1.Namespace
+			resp      *http.Response
+		)
+
+		BeforeEach(func() {
+			namespaceGUID := generateGUID()
+			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceGUID}}
+			Expect(
+				k8sClient.Create(context.Background(), namespace),
+			).To(Succeed())
+
+			testEnvironmentVariables := map[string]string{"foo": "foo", "bar": "bar"}
+			requestBody := initializeCreateAppRequestBody("my-test-app", namespace.Name, testEnvironmentVariables, nil, nil)
+
+			var err error
+			req, err = http.NewRequest("POST", serverURI("/v3/apps"), strings.NewReader(requestBody))
+			Expect(err).NotTo(HaveOccurred())
+
+			req.Header.Add("Content-type", "application/json")
+
+			resp, err = new(http.Client).Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			k8sClient.Delete(context.Background(), namespace)
+		})
+
+		It("creates a CFApp and Secret, returns 201 and an App object as JSON", func() {
+			Expect(resp.StatusCode).To(Equal(201))
+
+			var parsedBody map[string]interface{}
+			body, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(
+				json.Unmarshal(body, &parsedBody),
+			).To(Succeed())
+
+			Expect(parsedBody).To(MatchKeys(IgnoreExtras, Keys{
+				"guid":       Not(BeEmpty()),
+				"name":       Equal("my-test-app"),
+				"state":      Equal("STOPPED"),
+				"created_at": Not(BeEmpty()),
+				"relationships": Equal(map[string]interface{}{
+					"space": map[string]interface{}{
+						"data": map[string]interface{}{
+							"guid": namespace.Name,
+						},
+					},
+				}),
+			}))
+
+			appGUID := parsedBody["guid"].(string)
+			appNSName := types.NamespacedName{
+				Name:      appGUID,
+				Namespace: namespace.Name,
+			}
+			var appRecord v1alpha1.CFApp
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), appNSName, &appRecord)
+			}).Should(Succeed())
+
+			Expect(appRecord.Spec.Name).To(Equal("my-test-app"))
+			Expect(appRecord.Spec.DesiredState).To(BeEquivalentTo("STOPPED"))
+			Expect(appRecord.Spec.EnvSecretName).NotTo(BeEmpty())
+
+			secretNSName := types.NamespacedName{
+				Name:      appRecord.Spec.EnvSecretName,
+				Namespace: namespace.Name,
+			}
+			var secretRecord corev1.Secret
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), secretNSName, &secretRecord)
+			}).Should(Succeed())
+
+			// TODO: test that the secret has the correct contents
+		})
+	})
+})
+
+func initializeCreateAppRequestBody(appName, spaceGUID string, envVars, labels, annotations map[string]string) string {
+	marshaledEnvironmentVariables, _ := json.Marshal(envVars)
+	marshaledLabels, _ := json.Marshal(labels)
+	marshaledAnnotations, _ := json.Marshal(annotations)
+
+	return `{
+		"name": "` + appName + `",
+		"relationships": {
+			"space": {
+				"data": {
+					"guid": "` + spaceGUID + `"
+				}
+			}
+		},
+		"environment_variables": ` + string(marshaledEnvironmentVariables) + `,
+		"metadata": {
+			"labels": ` + string(marshaledLabels) + `,
+			"annotations": ` + string(marshaledAnnotations) + `
+		}
+	}`
+}

--- a/api/apis/integration/integration_suite_test.go
+++ b/api/apis/integration/integration_suite_test.go
@@ -1,0 +1,113 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/networking/v1alpha1"
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Suite")
+}
+
+const (
+	serverAddr = "localhost:9876"
+)
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.WithWatch
+	k8sConfig *rest.Config
+	server    *http.Server
+)
+
+var (
+	rr        *httptest.ResponseRecorder
+	req       *http.Request
+	router    *mux.Router
+	serverURL *url.URL
+	ctx       context.Context
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "controllers", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	k8sConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sConfig).NotTo(BeNil())
+
+	err = workloadsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = networkingv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.NewWithWatch(k8sConfig, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	ctx = context.Background()
+	rr = httptest.NewRecorder()
+	router = mux.NewRouter()
+
+	var err error
+	serverURL, err = url.Parse("http://" + serverAddr)
+	Expect(err).NotTo(HaveOccurred())
+
+	server = &http.Server{Addr: serverAddr, Handler: router}
+	go func() {
+		defer GinkgoRecover()
+		Expect(
+			server.ListenAndServe(),
+		).To(MatchError("http: Server closed"))
+	}()
+})
+
+var _ = AfterEach(func() {
+	Expect(
+		server.Close(),
+	).To(Succeed())
+})
+
+func serverURI(paths ...string) string {
+	return fmt.Sprintf("%s%s", serverURL, strings.Join(paths, ""))
+}
+
+func generateGUID() string {
+	newUUID, err := uuid.NewUUID()
+	if err != nil {
+		errorMessage := fmt.Sprintf("could not generate a UUID %v", err)
+		panic(errorMessage)
+	}
+	return newUUID.String()
+}

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -53,7 +53,7 @@ func (h *OrgHandler) orgCreateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.OrgCreate
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -83,7 +83,7 @@ func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, req *http.Re
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.PackageCreate
-	rme := DecodeAndValidatePayload(req, &payload)
+	rme := decodeAndValidateJSONPayload(req, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -30,7 +30,7 @@ type CFProcessRepository interface {
 }
 
 //counterfeiter:generate -o fake -fake-name ScaleProcess . ScaleProcess
-type ScaleProcess func(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScale) (repositories.ProcessRecord, error)
+type ScaleProcess func(ctx context.Context, client client.Client, processGUID string, scale repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 
 type ProcessHandler struct {
 	logger       logr.Logger
@@ -135,7 +135,7 @@ func (h *ProcessHandler) processScaleHandler(w http.ResponseWriter, r *http.Requ
 	processGUID := vars["guid"]
 
 	var payload payloads.ProcessScale
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -159,7 +159,7 @@ func (h *RouteHandler) routeCreateHandler(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 
 	var routeCreateMessage payloads.RouteCreate
-	rme := DecodeAndValidatePayload(r, &routeCreateMessage)
+	rme := decodeAndValidateJSONPayload(r, &routeCreateMessage)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return
@@ -234,7 +234,7 @@ func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *htt
 	w.Header().Set("Content-Type", "application/json")
 
 	var destinationCreatePayload payloads.DestinationListCreate
-	rme := DecodeAndValidatePayload(r, &destinationCreatePayload)
+	rme := decodeAndValidateJSONPayload(r, &destinationCreatePayload)
 	if rme != nil {
 		writeErrorResponse(w, rme)
 		return

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -47,7 +47,7 @@ func (h *SpaceHandler) SpaceCreateHandler(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	w.Header().Set("Content-Type", "application/json")
 	var payload payloads.SpaceCreate
-	rme := DecodeAndValidatePayload(r, &payload)
+	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		h.logger.Error(rme, "Failed to decode and validate payload")
 		writeErrorResponse(w, rme)

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -1,0 +1,100 @@
+package apis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
+	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"code.cloudfoundry.org/cf-k8s-api/payloads"
+)
+
+const (
+	SpaceManifestApplyEndpoint = "/v3/spaces/{spaceGUID}/actions/apply_manifest"
+)
+
+type SpaceManifestHandler struct {
+	logger              logr.Logger
+	serverURL           url.URL
+	applyManifestAction ApplyManifestAction
+	buildClient         ClientBuilder
+	k8sConfig           *rest.Config // TODO: this would be global for all requests, not what we want
+}
+
+//counterfeiter:generate -o fake -fake-name ApplyManifestAction . ApplyManifestAction
+type ApplyManifestAction func(ctx context.Context, c client.Client, spaceGUID string, manifest payloads.SpaceManifestApply) error
+
+func NewSpaceManifestHandler(
+	logger logr.Logger,
+	serverURL url.URL,
+	applyManifestAction ApplyManifestAction,
+	buildClient ClientBuilder,
+	k8sConfig *rest.Config) *SpaceManifestHandler {
+	return &SpaceManifestHandler{
+		logger:              logger,
+		serverURL:           serverURL,
+		applyManifestAction: applyManifestAction,
+		buildClient:         buildClient,
+		k8sConfig:           k8sConfig,
+	}
+}
+
+func (h *SpaceManifestHandler) RegisterRoutes(router *mux.Router) {
+	router.Path(SpaceManifestApplyEndpoint).Methods("POST").HandlerFunc(h.applyManifestHandler)
+}
+
+func (h *SpaceManifestHandler) applyManifestHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	spaceGUID := vars["spaceGUID"]
+
+	var manifest payloads.SpaceManifestApply
+	rme := decodeAndValidateYAMLPayload(r, &manifest)
+	if rme != nil {
+		w.Header().Set("Content-Type", "application/json")
+		writeErrorResponse(w, rme)
+		return
+	}
+
+	// TODO: Instantiate config based on bearer token
+	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
+	client, err := h.buildClient(h.k8sConfig)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		h.logger.Error(err, "Unable to create Kubernetes client")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	err = h.applyManifestAction(r.Context(), client, spaceGUID, manifest)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		h.logger.Error(err, "error applying the manifest")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	w.Header().Set("Location", fmt.Sprintf("%s/v3/jobs/sync-space.apply_manifest-%s", h.serverURL.String(), spaceGUID))
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func decodeAndValidateYAMLPayload(r *http.Request, object interface{}) *requestMalformedError {
+	decoder := yaml.NewDecoder(r.Body)
+	defer r.Body.Close()
+	decoder.KnownFields(false) // TODO: make this true once we've added all fields to payloads.SpaceManifestApply
+	err := decoder.Decode(object)
+	if err != nil {
+		Logger.Error(err, fmt.Sprintf("Unable to parse the YAML body: %T: %q", err, err.Error()))
+		return &requestMalformedError{
+			httpStatus:    http.StatusBadRequest,
+			errorResponse: newMessageParseError(),
+		}
+	}
+
+	return validatePayload(object)
+}

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -1,0 +1,164 @@
+package apis_test
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	. "code.cloudfoundry.org/cf-k8s-api/apis"
+	"code.cloudfoundry.org/cf-k8s-api/apis/fake"
+)
+
+var _ = Describe("SpaceManifestHandler", func() {
+	var (
+		clientBuilder       *fake.ClientBuilder
+		applyManifestAction *fake.ApplyManifestAction
+	)
+
+	BeforeEach(func() {
+		clientBuilder = new(fake.ClientBuilder)
+		applyManifestAction = new(fake.ApplyManifestAction)
+
+		apiHandler := NewSpaceManifestHandler(
+			logf.Log.WithName("testSpaceManifestHandler"),
+			*serverURL,
+			applyManifestAction.Spy,
+			clientBuilder.Spy,
+			&rest.Config{},
+		)
+		apiHandler.RegisterRoutes(router)
+
+		var err error
+		req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+            version: 1
+            applications:
+              - name: app1
+        `))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		router.ServeHTTP(rr, req)
+	})
+
+	When("unsupported fields are provided", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+                version: 1
+                applications:
+                - name: app1
+                  buildpacks:
+                  - ruby_buildpack
+                  - java_buildpack
+                  env:
+                    VAR1: value1
+                    VAR2: value2
+                  routes:
+                  - route: route.example.com
+                  - route: another-route.example.com
+                    protocol: http2
+                  services:
+                  - my-service1
+                  - my-service2
+                  - name: my-service-with-arbitrary-params
+                    binding_name: my-binding
+                    parameters:
+                      key1: value1
+                      key2: value2
+                  stack: cflinuxfs3
+                  metadata:
+                    annotations:
+                      contact: "bob@example.com jane@example.com"
+                    labels:
+                      sensitive: true
+                  processes:
+                  - type: web
+                    command: start-web.sh
+                    disk_quota: 512M
+                    health-check-http-endpoint: /healthcheck
+                    health-check-type: http
+                    health-check-invocation-timeout: 10
+                    instances: 3
+                    memory: 500M
+                    timeout: 10
+                  - type: worker
+                    command: start-worker.sh
+                    disk_quota: 1G
+                    health-check-type: process
+                    instances: 2
+                    memory: 256M
+                    timeout: 15 
+            `))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates the record without erroring", func() {
+			Expect(rr.Code).To(Equal(http.StatusAccepted))
+			Expect(rr.Header().Get("Location")).To(Equal(defaultServerURI("/v3/jobs/sync-space.apply_manifest-", spaceGUID)))
+			Expect(applyManifestAction.CallCount()).To(Equal(1))
+		})
+	})
+
+	When("the manifest contains multiple apps", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+                version: 1
+                applications:
+                  - name: app1
+                  - name: app2
+            `))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("responds 422", func() {
+			expectUnprocessableEntityError("Applications must contain at maximum 1 item")
+		})
+
+		It("doesn't apply the manifest", func() {
+			Expect(applyManifestAction.CallCount()).To(Equal(0))
+		})
+	})
+
+	When("an invalid manifest is provided", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+                version: 1
+                applications:
+                  - {}
+            `))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("responds 422", func() {
+			expectUnprocessableEntityError("Name is a required field")
+		})
+	})
+
+	When("building the k8s client errors", func() {
+		BeforeEach(func() {
+			clientBuilder.Returns(nil, errors.New("boom"))
+		})
+
+		It("responds with Unknown Error", func() {
+			expectUnknownError()
+		})
+	})
+
+	When("applying the manifest errors", func() {
+		BeforeEach(func() {
+			applyManifestAction.Returns(errors.New("boom"))
+		})
+
+		It("respond with Unknown Error", func() {
+			expectUnknownError()
+		})
+	})
+})

--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -183,3 +183,17 @@ curl "http://localhost:9000/v3/routes" \
         ]
       }'
 ```
+
+### Manifest
+
+| Resource | Endpoint |
+|--|--|
+| Apply a manifest | POST /v3/spaces/\<space-guid>/actions/apply_manifest |
+
+#### [Applying a manifest](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
+```bash
+curl "http://localhost:9000/v3/spaces/<space-guid>/actions/apply_manifest" \
+  -X POST \
+  -H "Content-type: application/x-yaml" \
+  --data-binary @<path-to-manifest.yml>
+```

--- a/api/go.mod
+++ b/api/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
+	k8s.io/kubernetes v1.13.0
 	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/controller-tools v0.7.0
 	sigs.k8s.io/hierarchical-namespaces v0.9.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -2183,6 +2183,7 @@ k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2R
 k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d h1:lUK8GPtuJy8ClWZhuvKoaLdKGPLq9H1PxWp7VPBZBkU=
 k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kubectl v0.19.0/go.mod h1:gPCjjsmE6unJzgaUNXIFGZGafiUp5jh0If3F/x7/rRg=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/legacy-cloud-providers v0.18.8/go.mod h1:tgp4xYf6lvjrWnjQwTOPvWQE9IVqSBGPF4on0IyICQE=
 k8s.io/legacy-cloud-providers v0.19.7 h1:YJ/l/8/Hn56I9m1cudK8aNypRA/NvI/hYhg8fo/CTus=

--- a/api/main.go
+++ b/api/main.go
@@ -151,6 +151,14 @@ func main() {
 			repositories.NewOrgRepo(config.RootNamespace, privilegedCRClient, createTimeout),
 			*serverURL,
 		),
+
+		apis.NewSpaceManifestHandler(
+			ctrl.Log.WithName("SpaceManifestHandler"),
+			*serverURL,
+			actions.NewApplyManifest(new(repositories.AppRepo)).Invoke,
+			repositories.BuildCRClient,
+			k8sClientConfig,
+		),
 	}
 
 	router := mux.NewRouter()

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -8,8 +8,8 @@ type ProcessScale struct {
 	DiskMB    *int64 `json:"disk_in_mb" validate:"omitempty,gt=0"`
 }
 
-func (p ProcessScale) ToRecord() repositories.ProcessScale {
-	return repositories.ProcessScale{
+func (p ProcessScale) ToRecord() repositories.ProcessScaleMessage {
+	return repositories.ProcessScaleMessage{
 		Instances: p.Instances,
 		MemoryMB:  p.MemoryMB,
 		DiskMB:    p.DiskMB,

--- a/api/payloads/space_manifest.go
+++ b/api/payloads/space_manifest.go
@@ -1,0 +1,30 @@
+package payloads
+
+import (
+	"code.cloudfoundry.org/cf-k8s-controllers/apis/workloads/v1alpha1"
+	"github.com/google/uuid"
+
+	"code.cloudfoundry.org/cf-k8s-api/repositories"
+)
+
+type SpaceManifestApply struct {
+	Version      int                             `yaml:"version"`
+	Applications []SpaceManifestApplyApplication `yaml:"applications" validate:"max=1,dive"`
+}
+
+type SpaceManifestApplyApplication struct {
+	Name string `yaml:"name" validate:"required"`
+}
+
+func (a SpaceManifestApply) ToRecord(spaceGUID string) repositories.AppRecord {
+	appGUID := uuid.New().String()
+	return repositories.AppRecord{
+		GUID:      appGUID,
+		Name:      a.Applications[0].Name,
+		SpaceGUID: spaceGUID,
+		Lifecycle: repositories.Lifecycle{
+			Type: string(v1alpha1.BuildpackLifecycle),
+		},
+		State: repositories.DesiredState(v1alpha1.StoppedState),
+	}
+}

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -85,6 +85,21 @@ func (f *AppRepo) FetchApp(ctx context.Context, client client.Client, appGUID st
 	return returnApp(matches)
 }
 
+func (f *AppRepo) AppExistsWithNameAndSpace(ctx context.Context, c client.Client, appName, spaceGUID string) (bool, error) {
+	appList := new(workloadsv1alpha1.CFAppList)
+	err := c.List(ctx, appList, client.InNamespace(spaceGUID))
+	if err != nil { // untested
+		return false, err
+	}
+
+	for _, app := range appList.Items {
+		if app.Spec.Name == appName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (f *AppRepo) CreateApp(ctx context.Context, client client.Client, appRecord AppRecord) (AppRecord, error) {
 	cfApp := appRecordToCFApp(appRecord)
 	err := client.Create(ctx, &cfApp)

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -34,10 +34,10 @@ type ProcessRecord struct {
 type ScaleProcessMessage struct {
 	GUID      string
 	SpaceGUID string
-	ProcessScale
+	ProcessScaleMessage
 }
 
-type ProcessScale struct {
+type ProcessScaleMessage struct {
 	Instances *int
 	MemoryMB  *int64
 	DiskMB    *int64
@@ -54,7 +54,7 @@ type HealthCheckData struct {
 	TimeoutSeconds           int64
 }
 
-type ProcessRepository struct{}
+type ProcessRepository struct{} // TODO: rename this to ProcessRepo to follow our conventions
 
 func (r *ProcessRepository) FetchProcess(ctx context.Context, client client.Client, processGUID string) (ProcessRecord, error) {
 

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -296,9 +296,9 @@ var _ = Describe("ProcessRepository", func() {
 			Expect(k8sClient.Create(context.Background(), cfProcess)).To(Succeed())
 
 			scaleProcessMessage = &ScaleProcessMessage{
-				GUID:         processGUID,
-				SpaceGUID:    namespace.Name,
-				ProcessScale: ProcessScale{},
+				GUID:                processGUID,
+				SpaceGUID:           namespace.Name,
+				ProcessScaleMessage: ProcessScaleMessage{},
 			}
 		})
 
@@ -324,7 +324,7 @@ var _ = Describe("ProcessRepository", func() {
 
 			DescribeTable("calling ScaleProcess with a set of scale values returns an updated CFProcess record",
 				func(instances *int, diskMB, memoryMB *int64) {
-					scaleProcessMessage.ProcessScale = ProcessScale{
+					scaleProcessMessage.ProcessScaleMessage = ProcessScaleMessage{
 						Instances: instances,
 						DiskMB:    diskMB,
 						MemoryMB:  memoryMB,
@@ -354,7 +354,7 @@ var _ = Describe("ProcessRepository", func() {
 			)
 
 			It("eventually updates the scale of the CFProcess CR", func() {
-				scaleProcessMessage.ProcessScale = ProcessScale{
+				scaleProcessMessage.ProcessScaleMessage = ProcessScaleMessage{
 					Instances: &instanceScale,
 					MemoryMB:  &memoryScaleMB,
 					DiskMB:    &diskScaleMB,


### PR DESCRIPTION
## Is there a related GitHub Issue?
#165 

## What is this change about?
Add an initial implementation of the apply manifest endpoint. This version only deals with creating apps that are enumerated, and ignores all fields but name. Only 1 app is allowed, and requests with more than 1 will fail.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the AC in the story

## Tag your pair, your PM, and/or team
@akrishna90 @davewalter 