### PR TITLE
Assign logger while initializing CFProcessReconciler object

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -158,6 +158,7 @@ func main() {
 	if err = (&workloadscontrollers.CFProcessReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CFProcess"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CFProcess")
 		os.Exit(1)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#72 

## What is this change about?
While running acceptance @PureMunky pointed that a nil pointer exception was being thrown.
We traced the root cause for it to be a uninitialized logger on CFProcessReconciler. 

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Repeat acceptance steps from #72 

## Tag your pair, your PM, and/or team
@davewalter 