### PR TITLE
Remove command from controllers deployment

### DIFF
--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -25,9 +25,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: cloudfoundry/cf-k8s-controllers:latest
         name: manager

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1561,8 +1561,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        command:
-        - /manager
         env:
         - name: CONFIG
           value: /cf_k8s_controllers_config.yaml


### PR DESCRIPTION
## Is there a related GitHub Issue?
#116 

## What is this change about?
This PR removes the command from the controller deployment template as it is provided by the entrypoint of the image.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the instructions in the README to deploy the controller manager and see that it starts normally.