### PR TITLE
Add minimal space manifest diff endpoint

### DIFF
--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -28,6 +29,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 			logf.Log.WithName("integration tests"),
 			*serverURL,
 			actions.NewApplyManifest(appRepo).Invoke,
+			repositories.NewOrgRepo("cf", k8sClient, 1*time.Minute),
 			repositories.BuildCRClient,
 			k8sConfig,
 		)

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -1,9 +1,11 @@
 package apis_test
 
 import (
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,38 +20,63 @@ var _ = Describe("SpaceManifestHandler", func() {
 	var (
 		clientBuilder       *fake.ClientBuilder
 		applyManifestAction *fake.ApplyManifestAction
+		spaceRepo           *fake.CFSpaceRepository
 	)
 
 	BeforeEach(func() {
 		clientBuilder = new(fake.ClientBuilder)
 		applyManifestAction = new(fake.ApplyManifestAction)
+		spaceRepo = new(fake.CFSpaceRepository)
+
+		now := time.Unix(1631892190, 0)
+		spaceRepo.FetchSpacesReturns([]repositories.SpaceRecord{
+			{
+				Name:             "my-test-space",
+				GUID:             spaceGUID,
+				OrganizationGUID: "org-guid-1",
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+			{
+				Name:             "bob",
+				GUID:             "b-o-b",
+				OrganizationGUID: "org-guid-2",
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+		}, nil)
 
 		apiHandler := NewSpaceManifestHandler(
 			logf.Log.WithName("testSpaceManifestHandler"),
 			*serverURL,
 			applyManifestAction.Spy,
+			spaceRepo,
 			clientBuilder.Spy,
 			&rest.Config{},
 		)
 		apiHandler.RegisterRoutes(router)
-
-		var err error
-		req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
-            version: 1
-            applications:
-              - name: app1
-        `))
-		Expect(err).NotTo(HaveOccurred())
 	})
 
-	JustBeforeEach(func() {
-		router.ServeHTTP(rr, req)
-	})
-
-	When("unsupported fields are provided", func() {
+	Describe("POST /v3/spaces/{spaceGUID}/actions/apply_manifest", func() {
 		BeforeEach(func() {
 			var err error
 			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+                version: 1
+                applications:
+                  - name: app1
+            `))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Add("Content-type", "application/x-yaml")
+		})
+
+		JustBeforeEach(func() {
+			router.ServeHTTP(rr, req)
+		})
+
+		When("unsupported fields are provided", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
                 version: 1
                 applications:
                 - name: app1
@@ -95,70 +122,118 @@ var _ = Describe("SpaceManifestHandler", func() {
                     memory: 256M
                     timeout: 15 
             `))
-			Expect(err).NotTo(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Add("Content-type", "application/x-yaml")
+			})
+
+			It("creates the record without erroring", func() {
+				Expect(rr.Code).To(Equal(http.StatusAccepted))
+				Expect(rr.Header().Get("Location")).To(Equal(defaultServerURI("/v3/jobs/sync-space.apply_manifest-", spaceGUID)))
+				Expect(applyManifestAction.CallCount()).To(Equal(1))
+			})
 		})
 
-		It("creates the record without erroring", func() {
-			Expect(rr.Code).To(Equal(http.StatusAccepted))
-			Expect(rr.Header().Get("Location")).To(Equal(defaultServerURI("/v3/jobs/sync-space.apply_manifest-", spaceGUID)))
-			Expect(applyManifestAction.CallCount()).To(Equal(1))
-		})
-	})
-
-	When("the manifest contains multiple apps", func() {
-		BeforeEach(func() {
-			var err error
-			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+		When("the manifest contains multiple apps", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
                 version: 1
                 applications:
                   - name: app1
                   - name: app2
             `))
-			Expect(err).NotTo(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Add("Content-type", "application/x-yaml")
+			})
+
+			It("responds 422", func() {
+				expectUnprocessableEntityError("Applications must contain at maximum 1 item")
+			})
+
+			It("doesn't apply the manifest", func() {
+				Expect(applyManifestAction.CallCount()).To(Equal(0))
+			})
 		})
 
-		It("responds 422", func() {
-			expectUnprocessableEntityError("Applications must contain at maximum 1 item")
-		})
-
-		It("doesn't apply the manifest", func() {
-			Expect(applyManifestAction.CallCount()).To(Equal(0))
-		})
-	})
-
-	When("an invalid manifest is provided", func() {
-		BeforeEach(func() {
-			var err error
-			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
+		When("an invalid manifest is provided", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/actions/apply_manifest", strings.NewReader(`---
                 version: 1
                 applications:
                   - {}
             `))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("responds 422", func() {
+				expectUnprocessableEntityError("Name is a required field")
+			})
+		})
+
+		When("building the k8s client errors", func() {
+			BeforeEach(func() {
+				clientBuilder.Returns(nil, errors.New("boom"))
+			})
+
+			It("responds with Unknown Error", func() {
+				expectUnknownError()
+			})
+		})
+
+		When("applying the manifest errors", func() {
+			BeforeEach(func() {
+				applyManifestAction.Returns(errors.New("boom"))
+			})
+
+			It("respond with Unknown Error", func() {
+				expectUnknownError()
+			})
+		})
+	})
+
+	Describe("POST /v3/spaces/{spaceGUID}/manifest_diff", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("POST", "/v3/spaces/"+spaceGUID+"/manifest_diff", strings.NewReader(`---
+				version: 1
+				applications:
+				  - name: app1
+			`))
 			Expect(err).NotTo(HaveOccurred())
+			req.Header.Add("Content-type", "application/x-yaml")
 		})
 
-		It("responds 422", func() {
-			expectUnprocessableEntityError("Name is a required field")
-		})
-	})
-
-	When("building the k8s client errors", func() {
-		BeforeEach(func() {
-			clientBuilder.Returns(nil, errors.New("boom"))
+		JustBeforeEach(func() {
+			router.ServeHTTP(rr, req)
 		})
 
-		It("responds with Unknown Error", func() {
-			expectUnknownError()
+		When("the space exists", func() {
+			It("returns 202 with an empty diff", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusAccepted))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(MatchJSON(`{
+                	"diff": []
+            	}`)))
+			})
 		})
-	})
 
-	When("applying the manifest errors", func() {
-		BeforeEach(func() {
-			applyManifestAction.Returns(errors.New("boom"))
-		})
+		When("the space is not found", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("POST", "/v3/spaces/"+"fake-space-guid"+"/manifest_diff", strings.NewReader(`---
+				version: 1
+				applications:
+				  - name: app1
+			`))
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Add("Content-type", "application/x-yaml")
+			})
 
-		It("respond with Unknown Error", func() {
-			expectUnknownError()
+			It("returns a 404", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+				expectNotFoundError("Space not found")
+			})
 		})
 	})
 })

--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -197,3 +197,28 @@ curl "http://localhost:9000/v3/spaces/<space-guid>/actions/apply_manifest" \
   -H "Content-type: application/x-yaml" \
   --data-binary @<path-to-manifest.yml>
 ```
+
+| Resource | Endpoint |
+|--|--|
+| Create a manifest diff for a space | POST /v3/spaces/\<space-guid>/manifest_diff |
+
+#### [Create a manifest diff for a space](https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#create-a-manifest-diff-for-a-space-experimental)
+**WARNING:** Currently this endpoint always returns an empty diff.
+
+##### Example Request
+```bash
+curl "http://localhost:9000/v3/spaces/<space-guid>/manifest_diff" \
+  -X POST \
+  -H "Content-type: application/x-yaml" \
+  --data-binary @<path-to-manifest.yml>
+```
+
+##### Example Response
+```json
+HTTP/1.1 202 OK
+Content-Type: application/json
+
+{
+  "diff": []
+}
+```

--- a/api/main.go
+++ b/api/main.go
@@ -156,6 +156,7 @@ func main() {
 			ctrl.Log.WithName("SpaceManifestHandler"),
 			*serverURL,
 			actions.NewApplyManifest(new(repositories.AppRepo)).Invoke,
+			repositories.NewOrgRepo(config.RootNamespace, privilegedCRClient, createTimeout),
 			repositories.BuildCRClient,
 			k8sClientConfig,
 		),

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0 // indirect
@@ -88,14 +88,14 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.5.0 // indirect
-	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect
+	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
-	golang.org/x/tools v0.1.5 // indirect
+	golang.org/x/tools v0.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -121,3 +121,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+require github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -625,6 +625,8 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fullstorydev/grpcurl v1.8.0/go.mod h1:Mn2jWbdMrQGJQ8UD62uNyMumT2acsZUCkZIqFxsQf1o=
 github.com/fullstorydev/grpcurl v1.8.1/go.mod h1:3BWhvHZwNO7iLXaQlojdg5NA6SxUDePli4ecpK1N7gw=
@@ -784,6 +786,7 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -2037,6 +2040,8 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 h1:4CSI6oo7cOjJKajidEljs9h+uP0rRZBPPPhcCbj5mw8=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -2208,6 +2213,8 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c h1:Lyn7+CqXIiC+LOR9aHD6jDK+hPcmAuCfuXztd1v4w1Q=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b h1:1VkfZQv42XQlA/jchYumAnv1UPo6RgF9rJFkTgZIxO4=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2329,6 +2336,8 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.7 h1:6j8CgantCy3yc8JGBqkDLMKWqZ0RDU2g1HVgacojGWQ=
+golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Is there a related GitHub Issue?
* https://github.com/cloudfoundry/cf-k8s-controllers/issues/210

## What is this change about?
Newer CF CLIs hit this endpoint to be able to display a diff of the current state of their app with the manifest that they're applying. We first need to implement the ability to generate manifests before we can implement true diffing, so for now this endpoint will always return an empty diff. For more information check out the issue: https://github.com/cloudfoundry/cf-k8s-controllers/issues/210

## Does this PR introduce a breaking change?
Nope

## Acceptance Steps
Follow the A/C on the issue.

## Tag your pair, your PM, and/or team
@matt-royal @gnovv 
