### PR TITLE
Set the FQDN and URI status fields on a CFRoute

### DIFF
--- a/controllers/apis/networking/v1alpha1/cfdomain_types.go
+++ b/controllers/apis/networking/v1alpha1/cfdomain_types.go
@@ -41,6 +41,8 @@ type CFDomainStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster
+//+kubebuilder:printcolumn:name="Domain Name",type=string,JSONPath=`.spec.name`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFDomain is the Schema for the cfdomains API
 type CFDomain struct {

--- a/controllers/apis/networking/v1alpha1/cfroute_types.go
+++ b/controllers/apis/networking/v1alpha1/cfroute_types.go
@@ -73,6 +73,8 @@ type CFRouteStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="URI",type=string,JSONPath=`.status.uri`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 
 // CFRoute is the Schema for the cfroutes API
 type CFRoute struct {

--- a/controllers/apis/networking/v1alpha1/cfroute_types.go
+++ b/controllers/apis/networking/v1alpha1/cfroute_types.go
@@ -61,8 +61,14 @@ type CFRouteSpec struct {
 
 // CFRouteStatus defines the observed state of CFRoute
 type CFRouteStatus struct {
-	// Conditions capture the current status of the Build
-	Conditions []metav1.Condition `json:"conditions"`
+	// FQDN captures the fully-qualified domain name for the route
+	FQDN string `json:"fqdn,omitempty"`
+
+	// URI captures the URI (FQDN + path) for the route
+	URI string `json:"uri,omitempty"`
+
+	// Conditions capture the current status of the route
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/config/crd/bases/networking.cloudfoundry.org_cfdomains.yaml
+++ b/controllers/config/crd/bases/networking.cloudfoundry.org_cfdomains.yaml
@@ -16,7 +16,14 @@ spec:
     singular: cfdomain
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Domain Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFDomain is the Schema for the cfdomains API

--- a/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
+++ b/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
@@ -16,7 +16,14 @@ spec:
     singular: cfroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.uri
+      name: URI
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFRoute is the Schema for the cfroutes API

--- a/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
+++ b/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
@@ -85,7 +85,7 @@ spec:
             description: CFRouteStatus defines the observed state of CFRoute
             properties:
               conditions:
-                description: Conditions capture the current status of the Build
+                description: Conditions capture the current status of the route
                 items:
                   description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                   properties:
@@ -128,8 +128,12 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - conditions
+              fqdn:
+                description: FQDN captures the fully-qualified domain name for the route
+                type: string
+              uri:
+                description: URI captures the URI (FQDN + path) for the route
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
+++ b/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
@@ -171,7 +171,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 				},
 				Spec: networkingv1alpha1.CFRouteSpec{
 					Host:     testRouteHost,
-					Path:     "/",
+					Path:     "/test/path",
 					Protocol: "http",
 					DomainRef: corev1.LocalObjectReference{
 						Name: testDomainGUID,
@@ -230,7 +230,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			Expect(proxy.Spec.Routes[0]).To(Equal(contourv1.Route{
 				Conditions: []contourv1.MatchCondition{
 					{
-						Prefix: "/",
+						Prefix: "/test/path",
 					},
 				},
 				Services: []contourv1.Service{
@@ -277,6 +277,22 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 					},
 				}))
 			})
+		})
+
+		It("eventually adds the FQDN and URI status fields to the CFRoute", func() {
+			ctx := context.Background()
+
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testRouteGUID, Namespace: testNamespace}, cfRoute)
+				Expect(err).NotTo(HaveOccurred())
+				return cfRoute.Status.FQDN
+			}).Should(Equal(testFQDN))
+
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: testRouteGUID, Namespace: testNamespace}, cfRoute)
+				Expect(err).NotTo(HaveOccurred())
+				return cfRoute.Status.URI
+			}).Should(Equal(testFQDN + "/test/path"))
 		})
 	})
 

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -468,7 +468,14 @@ spec:
     singular: cfdomain
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Domain Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFDomain is the Schema for the cfdomains API
@@ -932,7 +939,14 @@ spec:
     singular: cfroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.uri
+      name: URI
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CFRoute is the Schema for the cfroutes API

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1017,7 +1017,7 @@ spec:
             description: CFRouteStatus defines the observed state of CFRoute
             properties:
               conditions:
-                description: Conditions capture the current status of the Build
+                description: Conditions capture the current status of the route
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -1086,8 +1086,13 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - conditions
+              fqdn:
+                description: FQDN captures the fully-qualified domain name for the
+                  route
+                type: string
+              uri:
+                description: URI captures the URI (FQDN + path) for the route
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
## Is there a related GitHub Issue?
#101 

## What is this change about?
This PR updates the CFRoute reconcile loop to set the FQDN and URI status fields

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #101