### PR TITLE
Add GET /v3/apps/<guid/droplets/current endpoint

### DIFF
--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -38,6 +38,7 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#apps
 | Get App | GET /v3/apps/\<guid> |
 | Create App | POST /v3/apps |
 | Set App's Current Droplet | PATCH /v3/apps/\<guid>/relationships/current_droplet |
+| Get App's Current Droplet | GET /v3/apps/\<guid>/droplets/current |
 | Start App | POST /v3/apps/\<guid>/actions/start |
 | Stop App | POST /v3/apps/\<guid>/actions/stop |
 | List App Processes | GET /v3/apps/\<guid>/processes |
@@ -57,6 +58,11 @@ curl "http://localhost:9000/v3/apps" \
 curl "http://localhost:9000/v3/apps/<app-guid>/relationships/current_droplet" \
   -X PATCH \
   -d '{"data":{"guid":"<droplet-guid>"}}'
+```
+
+#### [Getting App's Current Droplet](https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#get-current-droplet)
+```bash
+curl "http://localhost:9000/v3/apps/<app-guid>/droplets/current"
 ```
 
 #### [Scaling App's Process](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#scale-a-process)


### PR DESCRIPTION
## Is there a related GitHub Issue?
- Issue: https://github.com/cloudfoundry/cf-k8s-controllers/issues/174

## What is this change about?
Add endpoint for retrieving the droplet currently assigned to an app.

## Does this PR introduce a breaking change?
Nope

## Acceptance Steps
In general, follow the steps on https://github.com/cloudfoundry/cf-k8s-controllers/issues/174.

I had to do the following to get a suitable `CFBuild` with droplet info in the status:

1. `kubectl apply -f controllers/config/samples/cfapp.yaml`
2. `kubectl apply -f controllers/config/samples/cfbuild.yaml`
3. `kubectl proxy &`
4. Then hit the proxied Kubernetes API with the following to add droplet info to the build:

```console
curl -k -s -X PATCH -H "Accept: application/json, */*" \
-H "Content-Type: application/merge-patch+json" \
http://127.0.0.1:8001/apis/workloads.cloudfoundry.org/v1alpha1/namespaces/default/cfbuilds/1591ee05-e208-4cf3-a662-1c2da42f20a7/status \
--data '{ "status": {
          "conditions": [
            {
              "type": "Succeeded",
              "status": "True",
              "reason": "Buildpack",
              "message": "",
              "lastTransitionTime": "2021-11-08T22:06:02Z"
            },
            {
              "type": "Staging",
              "status": "False",
              "reason": "Succeeded",
              "message": "",
              "lastTransitionTime": "2021-11-08T22:06:02Z"
            }
          ],
          "droplet": {
            "stack": "cflinuxfs3",
            "ports": [
              80,
              443
            ],
            "processTypes": [
              {
                "type": "web",
                "command": "bundle exec rackup config.ru -p $PORT -o 0.0.0.0"
              },
              {
                "type": "worker",
                "command": "bundle exec rackup config.ru"
              }
            ],
            "registry": {
              "image": "gcr.io/buildpack/14dcda7d-1fa1-4a91-b437-fbdba20e8c5a@sha256:17ef1315d87bb57657ee14f387394f56d6f4429151262d731a31e92e5497ad35",
              "imagePullSecrets": [
                {
                  "name": "app-registry-credentials"
                }
              ]
            }
          }
        }}'
```

## Tag your pair, your PM, and/or team
@matt-royal whom I poloed with.