### PR TITLE
kpack Image OwnerReferences are set upon creation

### DIFF
--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -39,6 +39,7 @@ import (
 	k8sclient "k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -232,7 +233,13 @@ func (r *CFBuildReconciler) createKpackImageAndUpdateStatus(ctx context.Context,
 		},
 	}
 
-	err := r.createKpackImageIfNotExists(ctx, desiredKpackImage)
+	err := controllerutil.SetOwnerReference(cfBuild, &desiredKpackImage, r.Scheme)
+	if err != nil {
+		r.Log.Error(err, "failed to set OwnerRef on Kpack Image")
+		return err
+	}
+
+	err = r.createKpackImageIfNotExists(ctx, desiredKpackImage)
 	if err != nil {
 		return err
 	}

--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -99,6 +99,12 @@ var _ = Describe("CFBuildReconciler", func() {
 					}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
 					kpackImageTag := "image/registry/tag" + "/" + cfBuildGUID
 					Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
+					Expect(createdKpackImage.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
+						UID:        desiredCFBuild.UID,
+						Kind:       "CFBuild",
+						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+						Name:       desiredCFBuild.Name,
+					}))
 					Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
 				})
 

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -94,6 +94,10 @@ func BuildCFBuildObject(cfBuildGUID string, namespace string, cfPackageGUID stri
 			Name:      cfBuildGUID,
 			Namespace: namespace,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CFBuild",
+			APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+		},
 		Spec: workloadsv1alpha1.CFBuildSpec{
 			PackageRef: corev1.LocalObjectReference{
 				Name: cfPackageGUID,


### PR DESCRIPTION
## Is there a related GitHub Issue?
#69 

## What is this change about?
Sets owner references on Kpack Image when created by CFBuild controller.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Automation:
* Run tests.
Manual:
* Install/Deploy to cluster.
* Apply CFApp, CFPackage, CFBuild to cluster.
* Describe resulting Kpack image. `kubectl describe image <image-name>`
* Look for `Owner References`

## Tag your pair, your PM, and/or team
@davewalter @acosta11 