### PR TITLE
Implement creating an org level role binding in the API

### DIFF
--- a/api/apis/fake/cfrole_repository.go
+++ b/api/apis/fake/cfrole_repository.go
@@ -10,17 +10,17 @@ import (
 )
 
 type CFRoleRepository struct {
-	CreateSpaceRoleStub        func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)
-	createSpaceRoleMutex       sync.RWMutex
-	createSpaceRoleArgsForCall []struct {
+	CreateRoleStub        func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)
+	createRoleMutex       sync.RWMutex
+	createRoleArgsForCall []struct {
 		arg1 context.Context
 		arg2 repositories.RoleRecord
 	}
-	createSpaceRoleReturns struct {
+	createRoleReturns struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}
-	createSpaceRoleReturnsOnCall map[int]struct {
+	createRoleReturnsOnCall map[int]struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}
@@ -28,17 +28,17 @@ type CFRoleRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFRoleRepository) CreateSpaceRole(arg1 context.Context, arg2 repositories.RoleRecord) (repositories.RoleRecord, error) {
-	fake.createSpaceRoleMutex.Lock()
-	ret, specificReturn := fake.createSpaceRoleReturnsOnCall[len(fake.createSpaceRoleArgsForCall)]
-	fake.createSpaceRoleArgsForCall = append(fake.createSpaceRoleArgsForCall, struct {
+func (fake *CFRoleRepository) CreateRole(arg1 context.Context, arg2 repositories.RoleRecord) (repositories.RoleRecord, error) {
+	fake.createRoleMutex.Lock()
+	ret, specificReturn := fake.createRoleReturnsOnCall[len(fake.createRoleArgsForCall)]
+	fake.createRoleArgsForCall = append(fake.createRoleArgsForCall, struct {
 		arg1 context.Context
 		arg2 repositories.RoleRecord
 	}{arg1, arg2})
-	stub := fake.CreateSpaceRoleStub
-	fakeReturns := fake.createSpaceRoleReturns
-	fake.recordInvocation("CreateSpaceRole", []interface{}{arg1, arg2})
-	fake.createSpaceRoleMutex.Unlock()
+	stub := fake.CreateRoleStub
+	fakeReturns := fake.createRoleReturns
+	fake.recordInvocation("CreateRole", []interface{}{arg1, arg2})
+	fake.createRoleMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -48,46 +48,46 @@ func (fake *CFRoleRepository) CreateSpaceRole(arg1 context.Context, arg2 reposit
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *CFRoleRepository) CreateSpaceRoleCallCount() int {
-	fake.createSpaceRoleMutex.RLock()
-	defer fake.createSpaceRoleMutex.RUnlock()
-	return len(fake.createSpaceRoleArgsForCall)
+func (fake *CFRoleRepository) CreateRoleCallCount() int {
+	fake.createRoleMutex.RLock()
+	defer fake.createRoleMutex.RUnlock()
+	return len(fake.createRoleArgsForCall)
 }
 
-func (fake *CFRoleRepository) CreateSpaceRoleCalls(stub func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)) {
-	fake.createSpaceRoleMutex.Lock()
-	defer fake.createSpaceRoleMutex.Unlock()
-	fake.CreateSpaceRoleStub = stub
+func (fake *CFRoleRepository) CreateRoleCalls(stub func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)) {
+	fake.createRoleMutex.Lock()
+	defer fake.createRoleMutex.Unlock()
+	fake.CreateRoleStub = stub
 }
 
-func (fake *CFRoleRepository) CreateSpaceRoleArgsForCall(i int) (context.Context, repositories.RoleRecord) {
-	fake.createSpaceRoleMutex.RLock()
-	defer fake.createSpaceRoleMutex.RUnlock()
-	argsForCall := fake.createSpaceRoleArgsForCall[i]
+func (fake *CFRoleRepository) CreateRoleArgsForCall(i int) (context.Context, repositories.RoleRecord) {
+	fake.createRoleMutex.RLock()
+	defer fake.createRoleMutex.RUnlock()
+	argsForCall := fake.createRoleArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *CFRoleRepository) CreateSpaceRoleReturns(result1 repositories.RoleRecord, result2 error) {
-	fake.createSpaceRoleMutex.Lock()
-	defer fake.createSpaceRoleMutex.Unlock()
-	fake.CreateSpaceRoleStub = nil
-	fake.createSpaceRoleReturns = struct {
+func (fake *CFRoleRepository) CreateRoleReturns(result1 repositories.RoleRecord, result2 error) {
+	fake.createRoleMutex.Lock()
+	defer fake.createRoleMutex.Unlock()
+	fake.CreateRoleStub = nil
+	fake.createRoleReturns = struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFRoleRepository) CreateSpaceRoleReturnsOnCall(i int, result1 repositories.RoleRecord, result2 error) {
-	fake.createSpaceRoleMutex.Lock()
-	defer fake.createSpaceRoleMutex.Unlock()
-	fake.CreateSpaceRoleStub = nil
-	if fake.createSpaceRoleReturnsOnCall == nil {
-		fake.createSpaceRoleReturnsOnCall = make(map[int]struct {
+func (fake *CFRoleRepository) CreateRoleReturnsOnCall(i int, result1 repositories.RoleRecord, result2 error) {
+	fake.createRoleMutex.Lock()
+	defer fake.createRoleMutex.Unlock()
+	fake.CreateRoleStub = nil
+	if fake.createRoleReturnsOnCall == nil {
+		fake.createRoleReturnsOnCall = make(map[int]struct {
 			result1 repositories.RoleRecord
 			result2 error
 		})
 	}
-	fake.createSpaceRoleReturnsOnCall[i] = struct {
+	fake.createRoleReturnsOnCall[i] = struct {
 		result1 repositories.RoleRecord
 		result2 error
 	}{result1, result2}
@@ -96,8 +96,8 @@ func (fake *CFRoleRepository) CreateSpaceRoleReturnsOnCall(i int, result1 reposi
 func (fake *CFRoleRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.createSpaceRoleMutex.RLock()
-	defer fake.createSpaceRoleMutex.RUnlock()
+	fake.createRoleMutex.RLock()
+	defer fake.createRoleMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -21,10 +21,26 @@ const (
 	RolesEndpoint = "/v3/roles"
 )
 
+type RoleName string
+
+const (
+	RoleAdmin                      RoleName = "admin"
+	RoleAdminReadOnly              RoleName = "admin_read_only"
+	RoleGlobalAuditor              RoleName = "global_auditor"
+	RoleOrganizationAuditor        RoleName = "organization_auditor"
+	RoleOrganizationBillingManager RoleName = "organization_billing_manager"
+	RoleOrganizationManager        RoleName = "organization_manager"
+	RoleOrganizationUser           RoleName = "organization_user"
+	RoleSpaceAuditor               RoleName = "space_auditor"
+	RoleSpaceDeveloper             RoleName = "space_developer"
+	RoleSpaceManager               RoleName = "space_manager"
+	RoleSpaceSupporter             RoleName = "space_supporter"
+)
+
 //counterfeiter:generate -o fake -fake-name CFRoleRepository . CFRoleRepository
 
 type CFRoleRepository interface {
-	CreateSpaceRole(ctx context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error)
+	CreateRole(ctx context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error)
 }
 
 type RoleHandler struct {
@@ -56,7 +72,7 @@ func (h *RoleHandler) roleCreateHandler(w http.ResponseWriter, r *http.Request) 
 	role := payload.ToRecord()
 	role.GUID = uuid.NewString()
 
-	record, err := h.roleRepo.CreateSpaceRole(r.Context(), role)
+	record, err := h.roleRepo.CreateRole(r.Context(), role)
 	if err != nil {
 		if errors.Is(err, repositories.ErrorDuplicateRoleBinding) {
 			errorDetail := fmt.Sprintf("User '%s' already has '%s' role", role.User, role.Type)

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -37,11 +38,62 @@ var _ = Describe("RoleHandler", func() {
 		roleHandler.RegisterRoutes(router)
 	})
 
+	DescribeTable("Role org / space combination validation",
+		func(role, orgOrSpace string, succeeds bool, errMsg string) {
+			createRoleRequestBody := fmt.Sprintf(`{
+                "type": "%s",
+                "relationships": {
+                    "user": {
+                        "data": {
+                            "guid": "my-user"
+                        }
+                    },
+                    "%s": {
+                        "data": {
+                            "guid": "some-guid"
+                        }
+                    }
+                }
+            }`, role, orgOrSpace)
+
+			req, err := http.NewRequestWithContext(ctx, "POST", rolesBase, strings.NewReader(createRoleRequestBody))
+			Expect(err).NotTo(HaveOccurred())
+
+			router.ServeHTTP(rr, req)
+
+			if succeeds {
+				Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
+			} else {
+				expectUnprocessableEntityError(errMsg)
+			}
+		},
+
+		Entry("org auditor w org", string(apis.RoleOrganizationAuditor), "organization", true, ""),
+		Entry("org auditor w space", string(apis.RoleOrganizationAuditor), "space", false, "relationships.organization is a required field"),
+		Entry("org billing manager w org", string(apis.RoleOrganizationBillingManager), "organization", true, ""),
+		Entry("org billing manager w space", string(apis.RoleOrganizationBillingManager), "space", false, "relationships.organization is a required field"),
+		Entry("org manager w org", string(apis.RoleOrganizationManager), "organization", true, ""),
+		Entry("org manager w space", string(apis.RoleOrganizationManager), "space", false, "relationships.organization is a required field"),
+		Entry("org user w org", string(apis.RoleOrganizationUser), "organization", true, ""),
+		Entry("org user w space", string(apis.RoleOrganizationUser), "space", false, "relationships.organization is a required field"),
+
+		Entry("space auditor w org", string(apis.RoleSpaceAuditor), "organization", false, "relationships.space is a required field"),
+		Entry("space auditor w space", string(apis.RoleSpaceAuditor), "space", true, ""),
+		Entry("space developer w org", string(apis.RoleSpaceDeveloper), "organization", false, "relationships.space is a required field"),
+		Entry("space developer w space", string(apis.RoleSpaceDeveloper), "space", true, ""),
+		Entry("space manager w org", string(apis.RoleSpaceManager), "organization", false, "relationships.space is a required field"),
+		Entry("space manager w space", string(apis.RoleSpaceManager), "space", true, ""),
+		Entry("space supporter w org", string(apis.RoleSpaceSupporter), "organization", false, "relationships.space is a required field"),
+		Entry("space supporter w space", string(apis.RoleSpaceSupporter), "space", true, ""),
+
+		Entry("invalid role name", "does-not-exist", "organization", false, "does-not-exist is not a valid role"),
+	)
+
 	Describe("Create Role", func() {
 		var createRoleRequestBody string
 
 		BeforeEach(func() {
-			roleRepo.CreateSpaceRoleStub = func(_ context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error) {
+			roleRepo.CreateRoleStub = func(_ context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error) {
 				role.GUID = "t-h-e-r-o-l-e"
 				role.CreatedAt = now
 				role.UpdatedAt = now
@@ -52,18 +104,18 @@ var _ = Describe("RoleHandler", func() {
 			createRoleRequestBody = `{
                 "type": "space_developer",
                 "relationships": {
-                  "user": {
-                    "data": {
-                      "guid": "my-user"
+                    "user": {
+                        "data": {
+                            "guid": "my-user"
+                        }
+                    },
+                    "space": {
+                        "data": {
+                            "guid": "my-space"
+                        }
                     }
-                  },
-                  "space": {
-                    "data": {
-                      "guid": "my-space"
-                    }
-                  }
                 }
-              }`
+            }`
 		})
 
 		makePostRequest := func() {
@@ -81,47 +133,109 @@ var _ = Describe("RoleHandler", func() {
 			Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
 			Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 			Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
-          "guid": "t-h-e-r-o-l-e",
-					"created_at": "2021-09-17T15:23:10Z",
-					"updated_at": "2021-09-17T15:23:10Z",
-          "type": "space_developer",
-					"relationships": {
-            "user": {
-              "data":{
-                "guid": "my-user"
-              }
-            },
-            "space": {
-              "data":{
-                "guid": "my-space"
-              }
-            },
-            "organization": {
-              "data":null
-            }
-          },
-					"links": {
-						"self": {
-							"href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
-						},
-						"space": {
-							"href": "%[1]s/v3/spaces/my-space"
-						}
-					}
-				}`, defaultServerURL))))
+                "guid": "t-h-e-r-o-l-e",
+                "created_at": "2021-09-17T15:23:10Z",
+                "updated_at": "2021-09-17T15:23:10Z",
+                "type": "space_developer",
+                "relationships": {
+                    "user": {
+                        "data":{
+                            "guid": "my-user"
+                        }
+                    },
+                    "space": {
+                        "data":{
+                            "guid": "my-space"
+                        }
+                    },
+                    "organization": {
+                        "data":null
+                    }
+                },
+                "links": {
+                    "self": {
+                        "href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
+                    },
+                    "space": {
+                        "href": "%[1]s/v3/spaces/my-space"
+                    }
+                }
+            }`, defaultServerURL))))
 		})
 
 		It("invokes the role repo create function with expected parameters", func() {
-			Expect(roleRepo.CreateSpaceRoleCallCount()).To(Equal(1))
-			_, roleRecord := roleRepo.CreateSpaceRoleArgsForCall(0)
+			Expect(roleRepo.CreateRoleCallCount()).To(Equal(1))
+			_, roleRecord := roleRepo.CreateRoleArgsForCall(0)
 			Expect(roleRecord.Type).To(Equal("space_developer"))
 			Expect(roleRecord.Space).To(Equal("my-space"))
 			Expect(roleRecord.User).To(Equal("my-user"))
 		})
 
+		When("the role is an organisation role", func() {
+			BeforeEach(func() {
+				createRoleRequestBody = `{
+                    "type": "organization_manager",
+                    "relationships": {
+                        "user": {
+                            "data": {
+                                "guid": "my-user"
+                            }
+                        },
+                        "organization": {
+                            "data": {
+                                "guid": "my-org"
+                            }
+                        }
+                    }
+                }`
+			})
+
+			It("returns 201 with appropriate success JSON", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
+				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+				Expect(rr).To(HaveHTTPBody(MatchJSON(fmt.Sprintf(`{
+                "guid": "t-h-e-r-o-l-e",
+                "created_at": "2021-09-17T15:23:10Z",
+                "updated_at": "2021-09-17T15:23:10Z",
+                "type": "organization_manager",
+                "relationships": {
+                        "user": {
+                            "data":{
+                                "guid": "my-user"
+                            }
+                        },
+                        "space": {
+                            "data": null
+                        },
+                        "organization": {
+                            "data": {
+                                "guid": "my-org"
+                            }
+                        }
+                    },
+                    "links": {
+                        "self": {
+                            "href": "%[1]s/v3/roles/t-h-e-r-o-l-e"
+                        },
+                        "organization": {
+                            "href": "%[1]s/v3/organizations/my-org"
+                        }
+                    }
+                }`, defaultServerURL))))
+			})
+
+			It("invokes the role repo create function with expected parameters", func() {
+				Expect(roleRepo.CreateRoleCallCount()).To(Equal(1))
+				_, roleRecord := roleRepo.CreateRoleArgsForCall(0)
+				Expect(roleRecord.Type).To(Equal("organization_manager"))
+				Expect(roleRecord.Org).To(Equal("my-org"))
+				Expect(roleRecord.User).To(Equal("my-user"))
+			})
+		})
+
 		When("the user has been already assigned to that role", func() {
 			BeforeEach(func() {
-				roleRepo.CreateSpaceRoleReturns(repositories.RoleRecord{}, repositories.ErrorDuplicateRoleBinding)
+				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.ErrorDuplicateRoleBinding)
 			})
 
 			It("returns unprocessable entry error", func() {
@@ -131,7 +245,7 @@ var _ = Describe("RoleHandler", func() {
 
 		When("the user does not have a role in the parent organization", func() {
 			BeforeEach(func() {
-				roleRepo.CreateSpaceRoleReturns(repositories.RoleRecord{}, repositories.ErrorMissingRoleBindingInParentOrg)
+				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.ErrorMissingRoleBindingInParentOrg)
 			})
 
 			It("returns unprocessable entry error", func() {
@@ -139,9 +253,57 @@ var _ = Describe("RoleHandler", func() {
 			})
 		})
 
+		When("the role does not contain a space or organisation relationship", func() {
+			BeforeEach(func() {
+				createRoleRequestBody = `{
+                    "type": "organization_manager",
+                    "relationships": {
+                        "user": {
+                            "data": {
+                                "guid": "my-user"
+                            }
+                        }
+                    }
+                }`
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError("relationships.organization is a required field")
+			})
+		})
+
+		When("the role does contains both a space and organization relationship", func() {
+			BeforeEach(func() {
+				createRoleRequestBody = `{
+                    "type": "organization_manager",
+                    "relationships": {
+                        "user": {
+                            "data": {
+                                "guid": "my-user"
+                            }
+                        },
+                        "space": {
+                            "data": {
+                                "guid": "my-space"
+                            }
+                        },
+                        "organization": {
+                            "data": {
+                                "guid": "my-org"
+                            }
+                        }
+                    }
+                }`
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError("Cannot pass both 'organization' and 'space' in a create role request")
+			})
+		})
+
 		When("the org repo returns another error", func() {
 			BeforeEach(func() {
-				roleRepo.CreateSpaceRoleReturns(repositories.RoleRecord{}, errors.New("boom"))
+				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, errors.New("boom"))
 			})
 
 			It("returns unknown error", func() {
@@ -193,18 +355,18 @@ var _ = Describe("RoleHandler", func() {
 			BeforeEach(func() {
 				createRoleRequestBody = `{
                     "relationships": {
-                      "user": {
-                        "data": {
-                          "guid": "my-user"
+                        "user": {
+                            "data": {
+                                "guid": "my-user"
+                            }
+                        },
+                        "space": {
+                            "data": {
+                                "guid": "my-space"
+                            }
                         }
-                      },
-                      "space": {
-                        "data": {
-                          "guid": "my-space"
-                        }
-                      }
                     }
-                  }`
+                }`
 			})
 
 			It("returns a status 422 with appropriate error message json", func() {

--- a/api/config/base/config/role_mappings_config.yaml
+++ b/api/config/base/config/role_mappings_config.yaml
@@ -4,6 +4,7 @@ roleMappings:
   global_auditor: cf-k8s-controllers-global-auditor
   organization_auditor: cf-k8s-controllers-organization-auditor
   organization_billing_manager: cf-k8s-controllers-organization-billing-manager
+  organization_manager: cf-k8s-controllers-organization-manager
   organization_user: cf-k8s-controllers-organization-user
   space_auditor: cf-k8s-controllers-space-auditor
   space_developer: cf-k8s-controllers-space-developer

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -8,14 +8,24 @@ type RoleCreate struct {
 }
 
 type RoleRelationships struct {
-	User  Relationship `json:"user" validate:"required"`
-	Space Relationship `json:"space" validate:"required"`
+	User         Relationship  `json:"user" validate:"required"`
+	Space        *Relationship `json:"space"`
+	Organization *Relationship `json:"organization"`
 }
 
 func (p RoleCreate) ToRecord() repositories.RoleRecord {
-	return repositories.RoleRecord{
-		Type:  p.Type,
-		User:  p.Relationships.User.Data.GUID,
-		Space: p.Relationships.Space.Data.GUID,
+	record := repositories.RoleRecord{
+		Type: p.Type,
+		User: p.Relationships.User.Data.GUID,
 	}
+
+	if p.Relationships.Space != nil {
+		record.Space = p.Relationships.Space.Data.GUID
+	}
+
+	if p.Relationships.Organization != nil {
+		record.Org = p.Relationships.Organization.Data.GUID
+	}
+
+	return record
 }

--- a/api/presenter/role.go
+++ b/api/presenter/role.go
@@ -22,8 +22,9 @@ type RoleResponse struct {
 }
 
 type RoleLinks struct {
-	Self  *Link `json:"self"`
-	Space *Link `json:"space"`
+	Self         *Link `json:"self"`
+	Space        *Link `json:"space,omitempty"`
+	Organization *Link `json:"organization,omitempty"`
 }
 
 func ForCreateRole(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
@@ -31,23 +32,36 @@ func ForCreateRole(role repositories.RoleRecord, apiBaseURL url.URL) RoleRespons
 }
 
 func toRoleResponse(role repositories.RoleRecord, apiBaseURL url.URL) RoleResponse {
-	return RoleResponse{
+	resp := RoleResponse{
 		GUID:      role.GUID,
 		CreatedAt: role.CreatedAt.UTC().Format(time.RFC3339),
 		UpdatedAt: role.CreatedAt.UTC().Format(time.RFC3339),
 		Type:      role.Type,
 		Relationships: Relationships{
 			"user":         Relationship{Data: &RelationshipData{GUID: role.User}},
-			"space":        Relationship{Data: &RelationshipData{GUID: role.Space}},
+			"space":        Relationship{Data: nil},
 			"organization": Relationship{Data: nil},
 		},
 		Links: RoleLinks{
 			Self: &Link{
 				HREF: buildURL(apiBaseURL).appendPath(rolesBase, role.GUID).build(),
 			},
-			Space: &Link{
-				HREF: buildURL(apiBaseURL).appendPath(spacesBase, role.Space).build(),
-			},
 		},
 	}
+
+	if role.Org != "" {
+		resp.Relationships["organization"] = Relationship{Data: &RelationshipData{GUID: role.Org}}
+		resp.Links.Organization = &Link{
+			HREF: buildURL(apiBaseURL).appendPath(orgsBase, role.Org).build(),
+		}
+	}
+
+	if role.Space != "" {
+		resp.Relationships["space"] = Relationship{Data: &RelationshipData{GUID: role.Space}}
+		resp.Links.Space = &Link{
+			HREF: buildURL(apiBaseURL).appendPath(spacesBase, role.Space).build(),
+		}
+	}
+
+	return resp
 }

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -202,6 +202,7 @@ data:
       global_auditor: cf-k8s-controllers-global-auditor
       organization_auditor: cf-k8s-controllers-organization-auditor
       organization_billing_manager: cf-k8s-controllers-organization-billing-manager
+      organization_manager: cf-k8s-controllers-organization-manager
       organization_user: cf-k8s-controllers-organization-user
       space_auditor: cf-k8s-controllers-space-auditor
       space_developer: cf-k8s-controllers-space-developer
@@ -209,7 +210,7 @@ data:
       space_supporter: cf-k8s-controllers-space-supporter
 kind: ConfigMap
 metadata:
-  name: cf-k8s-api-config-h9h47bgdt2
+  name: cf-k8s-api-config-62bf886gfh
   namespace: cf-k8s-api-system
 ---
 apiVersion: v1
@@ -264,7 +265,7 @@ spec:
       serviceAccountName: cf-k8s-api-cf-admin-serviceaccount
       volumes:
       - configMap:
-          name: cf-k8s-api-config-h9h47bgdt2
+          name: cf-k8s-api-config-62bf886gfh
         name: cf-k8s-api-config
 ---
 apiVersion: projectcontour.io/v1

--- a/controllers/config/cf_roles/cf_org_manager.yaml
+++ b/controllers/config/cf_roles/cf_org_manager.yaml
@@ -1,0 +1,6 @@
+# The CF Organization Manager Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: organization-manager
+rules: []

--- a/controllers/config/cf_roles/kustomization.yaml
+++ b/controllers/config/cf_roles/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - cf_space_developer.yaml
+- cf_org_manager.yaml

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1426,6 +1426,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: cf-k8s-controllers-organization-manager
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: cf-k8s-controllers-proxy-role
 rules:
 - apiGroups:

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/schema v1.2.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/heroku/color v0.0.6 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -120,9 +121,4 @@ require (
 	sigs.k8s.io/hierarchical-namespaces v0.9.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
-)
-
-require (
-	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
-	github.com/gorilla/schema v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -623,7 +623,6 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -786,7 +785,6 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -1771,6 +1769,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -2040,7 +2039,6 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 h1:4CSI6oo7cOjJKajidEljs9h+uP0rRZBPPPhcCbj5mw8=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2212,8 +2210,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c h1:Lyn7+CqXIiC+LOR9aHD6jDK+hPcmAuCfuXztd1v4w1Q=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b h1:1VkfZQv42XQlA/jchYumAnv1UPo6RgF9rJFkTgZIxO4=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2336,7 +2334,6 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7 h1:6j8CgantCy3yc8JGBqkDLMKWqZ0RDU2g1HVgacojGWQ=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/cf-k8s-controllers/issues/166

## What is this change about?
User can create an org level role binding via the API.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
**GIVEN** an organisation exists
**AND** a user other than the admin exists
**AND** a `ClusterRole` exists
**WHEN** I make the following request:
```sh
curl "https://api.example.org/v3/roles" \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
      "type": "<the ClusterRole name>",
      "relationships": {
        "user": {
          "data": {
            "username": "<the username>"
          }
        },
        "organization": {
          "data": {
            "guid": "<the org GUID>"
          }
        }
      }
    }'
```
**THEN** I get the following response:
```
HTTP/1.1 201 Created
Content-Type: application/json
```

```json
{
   "guid": "40557c70-d1bd-4976-a2ab-a85f5e882418",
   "created_at": "2019-10-10T17:19:12Z",
   "updated_at": "2019-10-10T17:19:12Z",
   "type": "<the ClusterRole name>",
   "relationships": {
      "user": {
         "data": {
            "guid": "<the username>"
         }
      },
      "organization": {
         "data": {
            "guid": "<the org GUID>"
         }
      },
      "space": {
         "data": null
      }
   },
   "links": {
      "self": {
         "href": "https://api.example.org/v3/roles/40557c70-d1bd-4976-a2ab-a85f5e882418"
      },
      "organization": {
         "href": "https://api.example.org/v3/organizations/05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
      }
   }
}
```
**AND** I see a `RoleBinding` in the organisation namespace for the specified user

## Tag your pair, your PM, and/or team
@mnitchev @gcapizzi 