### PR TITLE
Use docker cache volume for go mod download

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,8 @@ FROM golang:1.17 as builder
 WORKDIR /workspace
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY controllers/apis controllers/apis/
 COPY controllers/webhooks controllers/webhooks/
@@ -16,6 +17,7 @@ COPY api/repositories api/repositories/
 COPY api/config/config.go api/config/
 COPY api/main.go api/
 RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cfapi api/main.go
 
 FROM gcr.io/distroless/static:nonroot

--- a/controllers/Dockerfile
+++ b/controllers/Dockerfile
@@ -4,7 +4,8 @@ FROM golang:1.17.2 as builder
 WORKDIR /workspace
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY controllers/apis controllers/apis/
 COPY controllers/controllers controllers/controllers/
@@ -12,6 +13,7 @@ COPY controllers/webhooks controllers/webhooks/
 COPY controllers/config/config.go controllers/config/
 COPY controllers/main.go controllers/
 RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager controllers/main.go
 
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Introduce a cache for `go mod download` so that building docker files repeatedly speeds up.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`make docker-build` works and runs quickly on subsequent occasions

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
