### PR TITLE
Align Kpack and Eirini workloads namespace

### DIFF
--- a/controllers/config/samples/cfapp.yaml
+++ b/controllers/config/samples/cfapp.yaml
@@ -4,6 +4,7 @@ apiVersion: workloads.cloudfoundry.org/v1alpha1
 kind: CFApp
 metadata: #workloads.cloudfoundry.org/* labels are managed by a mutating webhook
   name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  namespace: cf
 spec:
   name: my-app # validated to be unique per namespace by validating webhook
   currentDropletRef: # starts empty and is filled by CF Shim PATCH endpoint /v3/apps/:guid/current_droplet

--- a/controllers/config/samples/cfbuild.yaml
+++ b/controllers/config/samples/cfbuild.yaml
@@ -8,6 +8,7 @@ metadata: #workloads.cloudfoundry.org/* labels are managed by a mutating webhook
   #  workloads.cloudfoundry.org/app-guid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
   #  workloads.cloudfoundry.org/package-guid: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
   name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
+  namespace: cf
 spec:
   appRef:
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a

--- a/controllers/config/samples/cfdomain.yaml
+++ b/controllers/config/samples/cfdomain.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.cloudfoundry.org/v1alpha1
 kind: CFDomain
 metadata:
   name: 5b5032ab-7fc8-4da5-b853-821fd1879201
+  namespace: cf
   # workloads.cloudfoundry.org/ labels are all managed by a mutating webhook
   labels:
     workloads.cloudfoundry.org/domainGUID: 5b5032ab-7fc8-4da5-b853-821fd1879201

--- a/controllers/config/samples/cfpackage.yaml
+++ b/controllers/config/samples/cfpackage.yaml
@@ -4,6 +4,7 @@ apiVersion: workloads.cloudfoundry.org/v1alpha1
 kind: CFPackage
 metadata: #workloads.cloudfoundry.org/* labels are managed by a mutating webhook
   name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
+  namespace: cf
 spec:
   type: bits
   appRef:

--- a/controllers/config/samples/cfprocess.yaml
+++ b/controllers/config/samples/cfprocess.yaml
@@ -4,6 +4,7 @@ apiVersion: workloads.cloudfoundry.org/v1alpha1
 kind: CFProcess
 metadata:  # workloads.cloudfoundry.org/ labels are all managed by a mutating webhook based on appRef and its droplet
   name: 99dcda7d-1fa1-4a91-b437-fbdba20et56y
+  namespace: cf
 spec:
   appRef:
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a

--- a/controllers/config/samples/cfroute.yaml
+++ b/controllers/config/samples/cfroute.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.cloudfoundry.org/v1alpha1
 kind: CFRoute
 metadata:
   name: 84afc0f2-3dc2-4709-9fc8-8340be584a43
+  namespace: cf
 spec:
   host: my-host
   path: /

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CFBuildReconciler", func() {
 		kpackImageGUID = cfBuildGUID
 
 		kpackRegistrySecretName = "kpack-registry-secret"
-		kpackServiceAccountName = defaultNamespace + "-kpack-service-account"
+		kpackServiceAccountName = "kpack-service-account"
 
 		cfBuild = BuildCFBuildObject(cfBuildGUID, defaultNamespace, cfPackageGUID, cfAppGUID)
 		cfBuildError = nil

--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -201,7 +201,7 @@ var _ = Describe("CFBuildReconciler", func() {
 			dockerRegistrySecret := BuildDockerRegistrySecret(wellFormedRegistryCredentialsSecret, namespaceGUID)
 			Expect(k8sClient.Create(beforeCtx, dockerRegistrySecret)).To(Succeed())
 
-			registryServiceAccountName := namespaceGUID + "-kpack-service-account"
+			registryServiceAccountName := "kpack-service-account"
 			registryServiceAccount := BuildServiceAccount(registryServiceAccountName, namespaceGUID, wellFormedRegistryCredentialsSecret)
 			Expect(k8sClient.Create(beforeCtx, registryServiceAccount)).To(Succeed())
 

--- a/controllers/docs/architecture-decisions/0006-managing-builders.md
+++ b/controllers/docs/architecture-decisions/0006-managing-builders.md
@@ -40,7 +40,7 @@ After a stack is updated, subsequent builds will use the new stack, so we focus 
 ### Default Cluster Builder
 Operator is responsible for creating a default cluster builder, and it has be named as `cf-kpack-cluster-builder`.
 Operator is also responsible for creating service-account & secrets for access to a single registry on each namespace.
-We expect the operators to follow `${namespace}-kpack-service-account` naming convention for service accounts.
+We expect the operators to follow `kpack-service-account` naming convention for service accounts.
 
 ### Handling Stack and Buildpack Updates
 At kpack Builder update time (for both Stack and Buildpack), the kpack controller will see the changes, find affected kpack Images, rebuild them, and add a new status on the Image with the reason for rebuild. A CF controller will see the changes on the kpack Image status, find affected CFApps by builder guid label, and update the droplet image ref of the associated CFBuild with the newly built image ref.

--- a/dependencies/kpack/cluster_builder.yaml
+++ b/dependencies/kpack/cluster_builder.yaml
@@ -4,8 +4,8 @@ metadata:
   name: cf-kpack-cluster-builder
 spec:
   serviceAccountRef:
-    name: default-kpack-service-account
-    namespace: default
+    name: kpack-service-account
+    namespace: cf
   # Replace with real docker registry
   tag: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/akira/builder
   stack:

--- a/dependencies/kpack/service_account.yaml
+++ b/dependencies/kpack/service_account.yaml
@@ -1,7 +1,9 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: default-kpack-service-account
+  name: kpack-service-account
+  namespace: cf
 secrets:
 - name: image-registry-credentials
 imagePullSecrets:

--- a/dependencies/namespace.yaml
+++ b/dependencies/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cf


### PR DESCRIPTION
## What is this change about?
#229 

## Does this PR introduce a breaking change?
Existing installations will need to update the `kpack-service-account` ServiceAccount and `image-registry-credentials` Secret.

## Acceptance Steps
Run all tests.
