### PR TITLE
Teach identity provider how to read client certs

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -203,7 +203,8 @@ func wireOrgHandler(serverUrl url.URL, orgRepo *repositories.OrgRepo, client cli
 	if authEnabled {
 		authNsProvider := authorization.NewOrg(client)
 		tokenReviewer := authorization.NewTokenReviewer(client)
-		identityProvider := authorization.NewIdentityProvider(tokenReviewer)
+		certInspector := authorization.NewCertInspector()
+		identityProvider := authorization.NewIdentityProvider(tokenReviewer, certInspector)
 		orgRepoProvider = provider.NewOrg(orgRepo, authNsProvider, identityProvider)
 	}
 

--- a/api/repositories/authorization/cert_inspector.go
+++ b/api/repositories/authorization/cert_inspector.go
@@ -1,0 +1,39 @@
+package authorization
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type CertInspector struct{}
+
+func NewCertInspector() CertInspector {
+	return CertInspector{}
+}
+
+func (c CertInspector) WhoAmI(_ context.Context, certPEMB64 string) (Identity, error) {
+	pemBytes, err := base64.StdEncoding.DecodeString(certPEMB64)
+	if err != nil {
+		return Identity{}, fmt.Errorf("failed to base64 decode cert")
+	}
+
+	pemBlock, _ := pem.Decode(pemBytes)
+	if pemBlock == nil {
+		return Identity{}, fmt.Errorf("failed to decode PEM")
+	}
+
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		return Identity{}, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return Identity{
+		Name: cert.Subject.CommonName,
+		Kind: rbacv1.UserKind,
+	}, nil
+}

--- a/api/repositories/authorization/cert_inspector_test.go
+++ b/api/repositories/authorization/cert_inspector_test.go
@@ -1,0 +1,90 @@
+package authorization_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/pem"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories/authorization"
+)
+
+var _ = Describe("CertInspector", func() {
+	var (
+		certInspector authorization.CertInspector
+		certPEMBase64 string
+		identity      authorization.Identity
+		err           error
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		certInspector = authorization.NewCertInspector()
+		certPEMBase64 = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNmRENDQVdTZ0F3SUJBZ0lRWFRUb3RMZmxJengzQkFEblF2RVMzVEFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEl4TVRFeE1URXdNREkwTWxvWERUSXlNVEV4TVRFdwpNREkwTWxvd0d6RVpNQmNHQTFVRUF4TVFZMlZ5ZEMxMWMyVnlMVEJoTWprNVlqQ0JuekFOQmdrcWhraUc5dzBCCkFRRUZBQU9CalFBd2dZa0NnWUVBMlRVcDFuOGRyOXNRZjJaTFNwRkdCZDl1dy8rUDFlK2poaXozSGhSVjdmWTkKVDZTSlhGUnVxdjV1Yk9nK1pUSVhleDZUTUFOOTdHaktTKzdsWjVlYjl6Rmw1R0xhRStObzY3enJQU3kzbjZvMgpEWTRiTzBRTHQxZUpxdW12LzByOFd2aVhDcHJRM1dNZ2pNSHEvRTZSR00wVzVrU3VqZHlnN0czd2dzMnZxQ1VDCkF3RUFBYU5HTUVRd0V3WURWUjBsQkF3d0NnWUlLd1lCQlFVSEF3SXdEQVlEVlIwVEFRSC9CQUl3QURBZkJnTlYKSFNNRUdEQVdnQlRPbnIwcys3VENKbkltcE8wNWhTMnBwY0poc0RBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpwZnNmaHR0dXBYTUYyK0JVNDZwZGlNVzhqSmxEVE5MK2ZIbStTNFJlN2lqRmNZN0pGQ3VYQWNEczNQOUZJL05qCnhxaXRWaE1nL1g2NCtGN3JhYnVkN2Ftdm5yL2E0WE1JWlBCc1J5RzIrNzRJZ1JUK2ZLZ1RnalMyNHNZaUVyOVQKeHhHOEIxRGh0VHMrcVNhL1I2cml5dnU0aXdVS0o0SlR4ZGRYSENTZWJBWFRGTjg1UmkvMFBBNjd3blFKS3ZOZgpzWlhvZVhBMDVXdXhmN1VCQXMzcmtrbDVFSGVlaGlybXhSdGFLd25RRTlRc2pOa3RBc050NjRYc1ZUSXdYRHlhCnRRMTJNcHltem92RDhwTDJoYnZzeDRHdSsxQ0VWWUpCZ2txazU3ZUMwaGQxTjR0YWU2YVgrOFZZTDhnNUprRWQKOFA3SWxBWnZ2QjFWV3Z5a2JqbWN6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+		ctx = context.Background()
+	})
+
+	JustBeforeEach(func() {
+		identity, err = certInspector.WhoAmI(ctx, certPEMBase64)
+	})
+
+	It("extracts the common name from a x509 cert", func() {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identity.Name).To(Equal("cert-user-0a299b"))
+		Expect(identity.Kind).To(Equal(rbacv1.UserKind))
+	})
+
+	When("the cert is invalid base64", func() {
+		BeforeEach(func() {
+			certPEMBase64 = "$*&^^%%"
+		})
+
+		It("returns an error", func() {
+			Expect(err).To(MatchError("failed to base64 decode cert"))
+		})
+	})
+
+	When("the cert is not PEM encoded", func() {
+		BeforeEach(func() {
+			certPEMBase64 = "Zm9vCg=="
+		})
+
+		It("returns an error", func() {
+			Expect(err).To(MatchError("failed to decode PEM"))
+		})
+	})
+
+	When("the cert contains multiple PEM blocks", func() {
+		BeforeEach(func() {
+			certPEMBase64 += getBadPEMBlock()
+		})
+
+		It("uses the first", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity.Name).To(Equal("cert-user-0a299b"))
+		})
+	})
+
+	When("the cert cannot be parsed", func() {
+		BeforeEach(func() {
+			certPEMBase64 = getBadPEMBlock()
+		})
+
+		It("returns an error", func() {
+			Expect(err).To(MatchError(ContainSubstring("failed to parse certificate")))
+		})
+	})
+})
+
+func getBadPEMBlock() string {
+	certBytes := []byte("hello")
+	pemBlock := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}
+	certPEM := pem.EncodeToMemory(&pemBlock)
+	return base64.StdEncoding.EncodeToString(certPEM)
+}

--- a/api/repositories/authorization/identity_provider_test.go
+++ b/api/repositories/authorization/identity_provider_test.go
@@ -15,57 +15,108 @@ var _ = Describe("IdentityProvider", func() {
 	var (
 		authHeader     string
 		tokenInspector *fake.IdentityInspector
+		certInspector  *fake.IdentityInspector
 		idProvider     *authorization.IdentityProvider
 		aliceId, id    authorization.Identity
 		err            error
 	)
 
-	BeforeEach(func() {
-		aliceId = authorization.Identity{Kind: rbacv1.UserKind, Name: "alice"}
-		authHeader = "Bearer token"
-		tokenInspector = new(fake.IdentityInspector)
-		idProvider = authorization.NewIdentityProvider(tokenInspector)
-		tokenInspector.WhoAmIReturns(aliceId, nil)
-	})
-
 	JustBeforeEach(func() {
 		id, err = idProvider.GetIdentity(context.Background(), authHeader)
 	})
 
-	It("succeeds", func() {
-		Expect(err).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		tokenInspector = new(fake.IdentityInspector)
+		certInspector = new(fake.IdentityInspector)
+		idProvider = authorization.NewIdentityProvider(tokenInspector, certInspector)
+		aliceId = authorization.Identity{Kind: rbacv1.UserKind, Name: "alice"}
 	})
 
-	It("gets the identity from the token inspector", func() {
-		Expect(tokenInspector.WhoAmICallCount()).To(Equal(1))
-		_, actualToken := tokenInspector.WhoAmIArgsForCall(0)
-		Expect(actualToken).To(Equal("token"))
-	})
-
-	It("gets the identity associated with the given header", func() {
-		Expect(id).To(Equal(aliceId))
-	})
-
-	When("the scheme is lowercase", func() {
+	When("the Authorization header contains a Bearer token", func() {
 		BeforeEach(func() {
-			authHeader = "bearer token"
+			authHeader = "Bearer token"
+			tokenInspector.WhoAmIReturns(aliceId, nil)
+		})
+
+		It("succeeds", func() {
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("gets the identity from the token inspector", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(tokenInspector.WhoAmICallCount()).To(Equal(1))
 			_, actualToken := tokenInspector.WhoAmIArgsForCall(0)
 			Expect(actualToken).To(Equal("token"))
 		})
-	})
 
-	When("token inspector fails", func() {
-		BeforeEach(func() {
-			tokenInspector.WhoAmIReturns(authorization.Identity{}, errors.New("boom"))
+		It("gets the identity associated with the given header", func() {
+			Expect(id).To(Equal(aliceId))
 		})
 
-		It("returns an error", func() {
-			Expect(err).To(MatchError(ContainSubstring("boom")))
+		When("the scheme is lowercase", func() {
+			BeforeEach(func() {
+				authHeader = "bearer token"
+			})
+
+			It("gets the identity from the token inspector", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tokenInspector.WhoAmICallCount()).To(Equal(1))
+				_, actualToken := tokenInspector.WhoAmIArgsForCall(0)
+				Expect(actualToken).To(Equal("token"))
+			})
+		})
+
+		When("token inspector fails", func() {
+			BeforeEach(func() {
+				tokenInspector.WhoAmIReturns(authorization.Identity{}, errors.New("boom"))
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("boom")))
+			})
+		})
+	})
+
+	When("the Authorization header contains a ClientCert", func() {
+		BeforeEach(func() {
+			authHeader = "ClientCert certificate"
+			certInspector.WhoAmIReturns(aliceId, nil)
+		})
+
+		It("succeeds", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("gets the identity from the cert inspector", func() {
+			Expect(certInspector.WhoAmICallCount()).To(Equal(1))
+			_, actualCert := certInspector.WhoAmIArgsForCall(0)
+			Expect(actualCert).To(Equal("certificate"))
+		})
+
+		It("gets the identity associated with the given header", func() {
+			Expect(id).To(Equal(aliceId))
+		})
+
+		When("the scheme is lowercase", func() {
+			BeforeEach(func() {
+				authHeader = "clientcert certificate"
+			})
+
+			It("gets the identity from the cert inspector", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(certInspector.WhoAmICallCount()).To(Equal(1))
+				_, actualCert := certInspector.WhoAmIArgsForCall(0)
+				Expect(actualCert).To(Equal("certificate"))
+			})
+		})
+
+		When("cert inspector fails", func() {
+			BeforeEach(func() {
+				certInspector.WhoAmIReturns(authorization.Identity{}, errors.New("boom"))
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("boom")))
+			})
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0
-	github.com/hashicorp/go-uuid v1.0.2
 	github.com/heroku/color v0.0.6 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1073,7 +1073,6 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/168

## What is this change about?
When auth uses the ClientCert type, the identity provider can get the username by decoding the passed client certificate and extracting the common name from the subject.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Deploy the API on kind (`make test-e2e` will do that as a side effect)
2. Build the CF CLI client from https://github.com/eirini-forks/cli (`make build` and use the binary from the `out` dir)
3. `cf api http://localhost`
4. `cf login` and select the entry for kind-e2e -- this now works, rather than failing when listing orgs
5. `cf orgs` -- this also no longer fails, although currently you'll need to create a rolebinding for your user in the cf-k8s-api-system namespace in order to see any orgs (e.g. `kubectl create rolebinding admin --clusterrole cf-k8s-controllers-space-developer --user kubernetes-admin -n cf-k8s-api-system`)

## Tag your pair, your PM, and/or team
@gcapizzi 
