### PR TITLE
Fix GET /v3/domains names param parsing

### DIFF
--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -12,6 +12,18 @@ type DomainList struct {
 
 func (d *DomainList) ToMessage() repositories.DomainListMessage {
 	return repositories.DomainListMessage{
-		Names: strings.Split(strings.TrimSpace(d.Names), ","),
+		Names: parseArrayParam(d.Names),
 	}
+}
+
+func parseArrayParam(arrayParam string) []string {
+	if arrayParam == "" {
+		return []string{}
+	}
+
+	elements := strings.Split(arrayParam, ",")
+	for i, e := range elements {
+		elements[i] = strings.TrimSpace(e)
+	}
+	return elements
 }

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -1,0 +1,35 @@
+package payloads
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DomainList", func() {
+	Describe("ToMessage", func() {
+		When("a single name is specified", func() {
+			It("properly splits them in the message", func() {
+				payload := DomainList{Names: "example.com"}
+
+				Expect(payload.ToMessage().Names).To(Equal([]string{"example.com"}))
+			})
+		})
+
+		When("multiple names are specified", func() {
+			It("properly splits them in the message and truncates whitespace", func() {
+				payload := DomainList{Names: " example.com, example.org ,cloudfoundry.org "}
+
+				Expect(payload.ToMessage().Names).To(Equal([]string{"example.com", "example.org", "cloudfoundry.org"}))
+			})
+		})
+
+		When("no names are specified", func() {
+			It("sets Names to an empty array", func() {
+				payload := DomainList{}
+
+				Expect(payload.ToMessage().Names).To(Equal([]string{}))
+				Expect(len(payload.ToMessage().Names)).To(Equal(0))
+			})
+		})
+	})
+})

--- a/api/payloads/payloads_suite_test.go
+++ b/api/payloads/payloads_suite_test.go
@@ -1,0 +1,20 @@
+package payloads_test
+
+import (
+	"github.com/matt-royal/biloba"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPayloads(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Payloads Suite", biloba.GoLandReporter())
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -1,9 +1,8 @@
 package repositories
 
 import (
-	"context"
-
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+	"context"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = Describe("DomainRepository", func() {
-	Describe("GetDomain", func() {
+	Describe("FetchDomain", func() {
 		var testCtx context.Context
 
 		BeforeEach(func() {
@@ -85,7 +85,7 @@ var _ = Describe("DomainRepository", func() {
 		})
 	})
 
-	Describe("GetDomainList", func() {
+	Describe("FetchDomainList", func() {
 		var (
 			testCtx context.Context
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
- https://github.com/cloudfoundry/cf-k8s-controllers/issues/177

## What is this change about?
Hitting `GET /v3/domains` without a `names` filter would always return an empty list of domains instead of all visible domains. This change adds some tests and improves the param parsing to correctly interpret omitting the `names` param as empty.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Apply a `CFDomain` CR to the cluster
2. `curl /v3/domains` and see the domain in the response

