### PR TITLE
Bump v3 API Version

### DIFF
--- a/api/apis/root_handler_test.go
+++ b/api/apis/root_handler_test.go
@@ -54,7 +54,7 @@ var _ = Describe("RootHandler", func() {
 					"cloud_controller_v2": nil,
 					"cloud_controller_v3": {
 						Link: presenter.Link{HREF: defaultServerURL + "/v3"},
-						Meta: presenter.APILinkMeta{Version: "3.90.0"},
+						Meta: presenter.APILinkMeta{Version: "3.111.0+cf-k8s"},
 					},
 					"network_policy_v0": nil,
 					"network_policy_v1": nil,

--- a/api/presenter/root.go
+++ b/api/presenter/root.go
@@ -14,13 +14,15 @@ type RootResponse struct {
 	CFOnK8s bool                `json:"cf_on_k8s"`
 }
 
+const v3APIVersion = "3.111.0+cf-k8s"
+
 func GetRootResponse(serverURL string) RootResponse {
 	return RootResponse{
 		Links: map[string]*APILink{
 			"self":                {Link: Link{HREF: serverURL}},
 			"bits_service":        nil,
 			"cloud_controller_v2": nil,
-			"cloud_controller_v3": {Link: Link{HREF: serverURL + "/v3"}, Meta: APILinkMeta{Version: "3.90.0"}},
+			"cloud_controller_v3": {Link: Link{HREF: serverURL + "/v3"}, Meta: APILinkMeta{Version: v3APIVersion}},
 			"network_policy_v0":   nil,
 			"network_policy_v1":   nil,
 			"login":               nil,


### PR DESCRIPTION
## Is there a related GitHub Issue?
Addresses https://github.com/cloudfoundry/cf-k8s-controllers/issues/209

## What is this change about?
Bumps the presented v3 API version so that the `cf` CLI stops complaining and appends a `+cf-k8s` suffix to the version to disambiguate it from Cloud Controller

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Hit the root `/` endpoint and see the version updated
2. Target the API with the `cf` CLI and see that it doesn't error
