### PR TITLE
Refactor e2e tests to use API where possible

### DIFF
--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	OrgListEndpoint = "/v3/organizations"
+	OrgsEndpoint = "/v3/organizations"
 )
 
 //counterfeiter:generate -o fake -fake-name CFOrgRepository . CFOrgRepository
@@ -134,6 +134,6 @@ func (h *OrgHandler) orgListHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *OrgHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(OrgListEndpoint).Methods("GET").HandlerFunc(h.orgListHandler)
-	router.Path(OrgListEndpoint).Methods("POST").HandlerFunc(h.orgCreateHandler)
+	router.Path(OrgsEndpoint).Methods("GET").HandlerFunc(h.orgListHandler)
+	router.Path(OrgsEndpoint).Methods("POST").HandlerFunc(h.orgCreateHandler)
 }

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -1,6 +1,9 @@
 package payloads
 
-import "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+import (
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
 
 type RoleCreate struct {
 	Type          string            `json:"type" validate:"required"`
@@ -8,15 +11,15 @@ type RoleCreate struct {
 }
 
 type RoleRelationships struct {
-	User         Relationship  `json:"user" validate:"required"`
-	Space        *Relationship `json:"space"`
-	Organization *Relationship `json:"organization"`
+	User                     *Relationship `json:"user" validate:"required_without=KubernetesServiceAccount"`
+	KubernetesServiceAccount *Relationship `json:"kubernetesServiceAccount" validate:"required_without=User"`
+	Space                    *Relationship `json:"space"`
+	Organization             *Relationship `json:"organization"`
 }
 
 func (p RoleCreate) ToRecord() repositories.RoleRecord {
 	record := repositories.RoleRecord{
 		Type: p.Type,
-		User: p.Relationships.User.Data.GUID,
 	}
 
 	if p.Relationships.Space != nil {
@@ -25,6 +28,14 @@ func (p RoleCreate) ToRecord() repositories.RoleRecord {
 
 	if p.Relationships.Organization != nil {
 		record.Org = p.Relationships.Organization.Data.GUID
+	}
+
+	if p.Relationships.User != nil {
+		record.Kind = rbacv1.UserKind
+		record.User = p.Relationships.User.Data.GUID
+	} else {
+		record.Kind = rbacv1.ServiceAccountKind
+		record.User = p.Relationships.KubernetesServiceAccount.Data.GUID
 	}
 
 	return record

--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -44,6 +44,7 @@ type RoleRecord struct {
 	Space     string
 	Org       string
 	User      string
+	Kind      string
 }
 
 type RoleRepo struct {
@@ -104,7 +105,7 @@ func (r *RoleRepo) CreateRole(ctx context.Context, role RoleRecord) (RoleRecord,
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Kind: rbacv1.UserKind,
+				Kind: role.Kind,
 				Name: role.User,
 			},
 		},


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Now we have proper API endpoints for creating orgs, spaces and role (bindings), we should use them rather than creating the base k8s objects.

Since creating role only supported the `User` kind, we have changed the API to allow setting roles on service accounts by
passing `KubernetesServiceAccount` relationship instead of `User`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`make test-e2e` still works!

## Tag your pair, your PM, and/or team
@eirini

