### PR TITLE
Change ginkgo flags to v2 counterparts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-controllers: ginkgo manifests-controllers generate-controllers fmt vet ## R
 test-api: test-api-unit test-api-integration
 
 test-api-unit: ginkgo fmt vet
-	cd api && ../scripts/run-tests.sh -skipPackage=test
+	cd api && ../scripts/run-tests.sh --skip-package=test
 
 test-api-integration: ginkgo
 	cd api && ../scripts/run-tests.sh tests/integration

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,7 @@ if ! egrep -q e2e <(echo "$@"); then
   source $ENVTEST_ASSETS_DIR/setup-envtest.sh
   fetch_envtest_tools $ENVTEST_ASSETS_DIR
   setup_envtest_env $ENVTEST_ASSETS_DIR
-  extra_args+=("-coverprofile=cover.out" "-skipPackage=e2e")
+  extra_args+=("-coverprofile=cover.out" "--skip-package=e2e")
 else
   if [ -z "$SKIP_DEPLOY" ]; then
     $SCRIPT_DIR/deploy-on-kind.sh e2e
@@ -24,6 +24,8 @@ else
   export KUBECONFIG="${HOME}/.kube/e2e.yml"
   export API_SERVER_ROOT=http://localhost
   export ROOT_NAMESPACE=cf-k8s-api-system
+
+  extra_args+=("--slow-spec-threshold=30s")
 fi
 
-ginkgo -r -p -randomizeSuites -randomizeAllSpecs "${extra_args[@]}" $@
+ginkgo -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
- Replace deprecated ginkgo command line arguments with the new ones
- Set the e2e slow test threshold
- remove the .test file that was accidentally committed
