### PR TITLE
Add minimal log-cache API endpoints to support cf push

### DIFF
--- a/api/apis/log_cache_handler.go
+++ b/api/apis/log_cache_handler.go
@@ -1,0 +1,40 @@
+package apis
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	LogCacheInfoEndpoint = "/api/v1/info"
+	LogCacheReadEndpoint = "/api/v1/read/{guid}"
+	logCacheVersion      = "2.11.4+cf-k8s"
+)
+
+// LogCacheHandler implements the minimal set of log-cache API endpoints/features necessary
+// to support the "cf push" workflow.
+// It does not support actually fetching and returning application logs at this time
+type LogCacheHandler struct{}
+
+func NewLogCacheHandler() *LogCacheHandler {
+	return &LogCacheHandler{}
+}
+
+func (h *LogCacheHandler) logCacheInfoHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"version":"` + logCacheVersion + `","vm_uptime":"0"}`))
+}
+
+func (h *LogCacheHandler) logCacheEmptyReadHandler(w http.ResponseWriter, r *http.Request) {
+	// Since we're not currently returning an app logs there is no need to check the validity of the app guid
+	// provided in the request. A full implementation of this endpoint needs to have the appropriate
+	// validity and authorization checks in place.
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"envelopes":{"batch":[]}}`))
+}
+
+func (h *LogCacheHandler) RegisterRoutes(router *mux.Router) {
+	router.Path(LogCacheInfoEndpoint).Methods("GET").HandlerFunc(h.logCacheInfoHandler)
+	router.Path(LogCacheReadEndpoint).Methods("GET").HandlerFunc(h.logCacheEmptyReadHandler)
+}

--- a/api/apis/log_cache_handler_test.go
+++ b/api/apis/log_cache_handler_test.go
@@ -1,0 +1,63 @@
+package apis_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LogCacheHandler", func() {
+	Describe("the GET /api/v1/info endpoint", func() {
+		BeforeEach(func() {
+			req, err := http.NewRequest("GET", "/api/v1/info", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			apiHandler := apis.NewLogCacheHandler()
+			apiHandler.RegisterRoutes(router)
+
+			router.ServeHTTP(rr, req)
+		})
+
+		It("returns status 200 OK", func() {
+			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+		})
+
+		It("returns Content-Type as JSON in header", func() {
+			contentTypeHeader := rr.Header().Get("Content-Type")
+			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+		})
+
+		It("matches the expected response body format", func() {
+			expectedBody := `{"version":"2.11.4+cf-k8s","vm_uptime":"0"}`
+			Expect(rr.Body.String()).To(Equal(expectedBody), "Response body matches LogCacheHandler response:")
+		})
+	})
+
+	Describe("the GET /api/v1/read/<app-guid> endpoint", func() {
+		BeforeEach(func() {
+			req, err := http.NewRequest("GET", "/api/v1/read/unused-app-guid", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			apiHandler := apis.NewLogCacheHandler()
+			apiHandler.RegisterRoutes(router)
+
+			router.ServeHTTP(rr, req)
+		})
+
+		It("returns status 200 OK", func() {
+			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+		})
+
+		It("returns Content-Type as JSON in header", func() {
+			contentTypeHeader := rr.Header().Get("Content-Type")
+			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+		})
+
+		It("returns a hardcoded list of empty log envelopes", func() {
+			expectedBody := `{"envelopes":{"batch":[]}}`
+			Expect(rr.Body.String()).To(Equal(expectedBody), "Response body matches LogCacheHandler response:")
+		})
+	})
+})

--- a/api/apis/root_handler_test.go
+++ b/api/apis/root_handler_test.go
@@ -63,9 +63,11 @@ var _ = Describe("RootHandler", func() {
 					"credhub":           nil,
 					"routing":           nil,
 					"logging":           nil,
-					"log_cache":         nil,
-					"log_stream":        nil,
-					"app_ssh":           nil,
+					"log_cache": {
+						Link: presenter.Link{HREF: defaultServerURL},
+					},
+					"log_stream": nil,
+					"app_ssh":    nil,
 				}),
 				"CFOnK8s": Equal(true),
 			}))

--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -247,3 +247,19 @@ Content-Type: application/json
   "diff": []
 }
 ```
+
+### Log-Cache API
+We support basic, unauthenticated versions of the following [log-cache](https://github.com/cloudfoundry/log-cache) APIs that return hard-coded responses.
+
+#### [Log-Cache Info](https://github.com/cloudfoundry/log-cache#get-apiv1info)
+
+| Resource | Endpoint |
+|--|--|
+| Retrieve version information | GET /api/v1/info |
+
+#### [Log-Cache Read](https://github.com/cloudfoundry/log-cache#get-apiv1readsource-id)
+
+| Resource | Endpoint |
+|--|--|
+| Retrieve data by source-id. Currently returns a hard-coded empty list of Loggregator envelopes. | GET /api/v1/read/<source-id> |
+

--- a/api/main.go
+++ b/api/main.go
@@ -160,6 +160,7 @@ func main() {
 			ctrl.Log.WithName("JobHandler"),
 			*serverURL,
 		),
+		apis.NewLogCacheHandler(),
 
 		wireOrgHandler(*serverURL, orgRepo, privilegedCRClient, config.AuthEnabled),
 		apis.NewSpaceHandler(

--- a/api/presenter/root.go
+++ b/api/presenter/root.go
@@ -30,7 +30,7 @@ func GetRootResponse(serverURL string) RootResponse {
 			"credhub":             nil,
 			"routing":             nil,
 			"logging":             nil,
-			"log_cache":           nil,
+			"log_cache":           {Link: Link{HREF: serverURL}},
 			"log_stream":          nil,
 			"app_ssh":             nil,
 		},


### PR DESCRIPTION
## Is there a related GitHub Issue?
- https://github.com/cloudfoundry/cf-k8s-controllers/issues/222

## What is this change about?
Adds basic log-cache endpoints that return hard-coded empty responses to support `cf push`. No logs will be returned, but at least the CLI won't error.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the A/C on https://github.com/cloudfoundry/cf-k8s-controllers/issues/222.
