### PR TITLE
Fix the app-guid label applied to the app env var secret

### DIFF
--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -34,7 +34,7 @@ const (
 	Kind            string = "CFApp"
 	APIVersion      string = "workloads.cloudfoundry.org/v1alpha1"
 	TimestampFormat string = time.RFC3339
-	CFAppGUIDLabel  string = "apps.cloudfoundry.org/appGuid"
+	CFAppGUIDLabel  string = "workloads.cloudfoundry.org/app-guid"
 )
 
 type AppRecord struct {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR updates the `app-guid` label applied to the app env var secret to match similar labels applied to other resources.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Push an app with an env var and check the label on the secret that is created.