### PR TITLE
Manually propagate kpack service-account

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,34 +283,43 @@ certificate when connecting to the API.
 As the current implementation of HNC does not correctly propagate ServiceAccounts, when we `cf create-space`, the ServiceAccount required for image building is absent. We must create the
 ServiceAccount ourselves with a reference to the image registry credentials.
 
-Pre-req: Have a local copy of the required ServiceAccount resource
-```
-cat <<EOF >> kpack-service-account.yml
-—
-apiVersion: v1
-imagePullSecrets:
-- name: image-registry-credentials
-kind: ServiceAccount
-metadata:
-  name: kpack-service-account
-secrets:
-- name: image-registry-credentials
-EOF
-```
+1. Pre-req: Have a local copy of the required ServiceAccount resources
+
+    ```
+    cat <<EOF >> service-accounts.yml
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: eirini
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kpack-service-account
+    imagePullSecrets:
+    - name: image-registry-credentials
+    secrets:
+    - name: image-registry-credentials
+    EOF
+    ```
+
 1. Create the cf space
-```
-cf create-org <org_name>
-cf target -o <org_name>
-cf create-space <space_name>
-```
-2. Get the cf space guid which corresponds to the kubernetes namespace in which we create the ServiceAccount
-```
-cf space <space_name> —guid
-```
-3. Apply the service-account yaml to that namespace
-```
-kubectl apply -f kpack-service-account.yml -n <space_guid>
-```
+    ```
+    cf create-org <org_name>
+    cf target -o <org_name>
+    cf create-space <space_name>
+    ```
+
+1. Get the cf space guid which corresponds to the kubernetes namespace in which we create the ServiceAccount
+    ```
+    cf space <space_name> —guid
+    ```
+
+1. Apply the `service-accounts.yml` to that namespace
+    ```
+    kubectl apply -f service-accounts.yml -n <space_guid>
+    ```
 
 ### Running Tests
 make

--- a/api/config/base/config/cf_k8s_api_config.yaml
+++ b/api/config/base/config/cf_k8s_api_config.yaml
@@ -1,10 +1,10 @@
 serverURL: "https://api.example.org"
 serverPort: 9000
-rootNamespace: cf-k8s-api-system
+rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3
   stagingMemoryMB: 1024
   stagingDiskMB: 1024
 packageRegistryBase: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
-packageRegistrySecretName: image-registry-secret # Create this secret in the rootNamespace
+packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace

--- a/api/config/overlays/kind-auth-enabled/config/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind-auth-enabled/config/cf_k8s_api_config.yaml
@@ -1,11 +1,11 @@
 serverURL: http://localhost
 serverPort: 9000
-rootNamespace: cf-k8s-api-system
+rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3
   stagingMemoryMB: 1024
   stagingDiskMB: 1024
 packageRegistryBase: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
-packageRegistrySecretName: image-registry-secret # Create this secret in the rootNamespace
+packageRegistrySecretName: image-registry-credentials
 authEnabled: true

--- a/api/config/overlays/kind/config/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind/config/cf_k8s_api_config.yaml
@@ -1,10 +1,10 @@
 serverURL: http://localhost
 serverPort: 9000
-rootNamespace: cf-k8s-api-system
+rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3
   stagingMemoryMB: 1024
   stagingDiskMB: 1024
 packageRegistryBase: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
-packageRegistrySecretName: image-registry-secret # Create this secret in the rootNamespace
+packageRegistrySecretName: image-registry-credentials

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -209,14 +209,14 @@ data:
   cf_k8s_api_config.yaml: |
     serverURL: "https://api.example.org"
     serverPort: 9000
-    rootNamespace: cf-k8s-api-system
+    rootNamespace: cf
     defaultLifecycleConfig:
       type: buildpack
       stack: cflinuxfs3
       stagingMemoryMB: 1024
       stagingDiskMB: 1024
     packageRegistryBase: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
-    packageRegistrySecretName: image-registry-secret # Create this secret in the rootNamespace
+    packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
   role_mappings_config.yaml: |
     roleMappings:
       admin: cf-k8s-controllers-admin
@@ -232,7 +232,7 @@ data:
       space_supporter: cf-k8s-controllers-space-supporter
 kind: ConfigMap
 metadata:
-  name: cf-k8s-api-config-62bf886gfh
+  name: cf-k8s-api-config-b5hg59dmk4
   namespace: cf-k8s-api-system
 ---
 apiVersion: v1
@@ -287,7 +287,7 @@ spec:
       serviceAccountName: cf-k8s-api-cf-admin-serviceaccount
       volumes:
       - configMap:
-          name: cf-k8s-api-config-62bf886gfh
+          name: cf-k8s-api-config-b5hg59dmk4
         name: cf-k8s-api-config
 ---
 apiVersion: projectcontour.io/v1

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -42,14 +42,14 @@ deploy_cf_k8s_controllers() {
   pushd $ROOT_DIR > /dev/null
   {
     "$SCRIPT_DIR/install-dependencies.sh"
-    export IMG_CONTROLLERS=${CONTROLLERS_IMG:-"cf-k8s-controllers:$(uuidgen)"}
     export KUBEBUILDER_ASSETS=$ROOT_DIR/testbin/bin
     echo $PWD
     make generate-controllers
     if [[ -z "${SKIP_DOCKER_BUILD:-}" ]]; then
+      export IMG_CONTROLLERS=${CONTROLLERS_IMG:-"cf-k8s-controllers:$(uuidgen)"}
       make docker-build-controllers
+      kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     fi
-    kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     make install-crds
     make deploy-controllers
   }
@@ -59,11 +59,11 @@ deploy_cf_k8s_controllers() {
 deploy_cf_k8s_api() {
   pushd $ROOT_DIR > /dev/null
   {
-    export IMG_API=${API_IMG:-"cf-k8s-api:$(uuidgen)"}
     if [[ -z "${SKIP_DOCKER_BUILD:-}" ]]; then
+      export IMG_API=${API_IMG:-"cf-k8s-api:$(uuidgen)"}
       make docker-build-api
+      kind load docker-image --name "$cluster" "$IMG_API"
     fi
-    kind load docker-image --name "$cluster" "$IMG_API"
     make deploy-api-kind-auth
   }
   popd > /dev/null

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -132,9 +132,8 @@ retry kubectl get namespace ping-hnc-child
 retry kubectl hns set --allowCascadingDeletion ping-hnc
 retry kubectl delete namespace ping-hnc --wait=false
 
-# The eirini controller requires a service account and rolebinding, which are
-# used by the statefulset controller to be able to create pods
-retry kubectl hns config set-resource serviceaccounts --mode Propagate
+# Propagate the kpack image registry write secret
+retry kubectl hns config set-resource secrets --mode Propagate
 
 echo "*******************"
 echo "Installing Eirini"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -23,7 +23,7 @@ else
 
   export KUBECONFIG="${HOME}/.kube/e2e.yml"
   export API_SERVER_ROOT=http://localhost
-  export ROOT_NAMESPACE=cf-k8s-api-system
+  export ROOT_NAMESPACE=cf
 
   extra_args+=("--slow-spec-threshold=30s")
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,21 +4,21 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-ENVTEST_ASSETS_DIR=$SCRIPT_DIR/../testbin
-mkdir -p $ENVTEST_ASSETS_DIR
+ENVTEST_ASSETS_DIR="${SCRIPT_DIR}/../testbin"
+mkdir -p "${ENVTEST_ASSETS_DIR}"
 
 go install github.com/onsi/ginkgo/ginkgo
 
 extra_args=()
 if ! egrep -q e2e <(echo "$@"); then
-  test -f $ENVTEST_ASSETS_DIR/setup-envtest.sh || curl -sSLo $ENVTEST_ASSETS_DIR/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-  source $ENVTEST_ASSETS_DIR/setup-envtest.sh
-  fetch_envtest_tools $ENVTEST_ASSETS_DIR
-  setup_envtest_env $ENVTEST_ASSETS_DIR
+  test -f "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" || curl -sSLo "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+  source "${ENVTEST_ASSETS_DIR}/setup-envtest.sh"
+  fetch_envtest_tools "${ENVTEST_ASSETS_DIR}"
+  setup_envtest_env "${ENVTEST_ASSETS_DIR}"
   extra_args+=("-coverprofile=cover.out" "--skip-package=e2e")
 else
-  if [ -z "$SKIP_DEPLOY" ]; then
-    $SCRIPT_DIR/deploy-on-kind.sh e2e
+  if [ -z "${SKIP_DEPLOY}" ]; then
+    "${SCRIPT_DIR}/deploy-on-kind.sh" e2e
   fi
 
   export KUBECONFIG="${HOME}/.kube/e2e.yml"
@@ -28,4 +28,4 @@ else
   extra_args+=("--slow-spec-threshold=30s")
 fi
 
-ginkgo -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+ginkgo -r -p --procs "${TEST_NUM_NODES:=2}" --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
#243

## What is this change about?
Update HNC config script to propagate secrets and not service accounts

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Install cf dependencies with the install-dependencies.sh script
Install cf on a cluster with auth disabled  using the make deploy target
Configure ingress as necessary
Login to the cf api
Follow instructions in the README.md for `Space Creation` to create a space with image build configured
Apply sample resources as necessary to trigger a build

## Tag your pair, your PM, and/or team
pair w/ @davewalter 
