### PR TITLE
Fix RBAC for retrieving Pods

### DIFF
--- a/api/config/base/rbac/role.yaml
+++ b/api/config/base/rbac/role.yaml
@@ -17,6 +17,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -95,20 +109,6 @@ rules:
   verbs:
   - create
   - list
-- apiGroups:
-  - v1
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - v1
-  resources:
-  - pods/status
-  verbs:
-  - get
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -26,6 +26,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -104,20 +118,6 @@ rules:
   verbs:
   - create
   - list
-- apiGroups:
-  - v1
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - v1
-  resources:
-  - pods/status
-  verbs:
-  - get
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//+kubebuilder:rbac:groups=v1,resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups=v1,resources=pods/status,verbs=get
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods/status,verbs=get
 
 const (
 	workloadsContainerName = "opi"


### PR DESCRIPTION
## Is there a related GitHub Issue?
Nope

## What is this change about?
Pods are actually in the '""' apiGroup. Without this you get an error like this:
```
2021-11-17T23:34:25.840Z	ERROR	ProcessHandler	Failed to fetch process from Kubernetes	{"ProcessGUID": "5a8bae25-47d0-11ec-8560-ce6c6a3b098d", "error": "pods is forbidden: User \"system:serviceaccount:cf-k8s-api-system:cf-k8s-api-cf-admin-serviceaccount\" cannot list resource \"pods\" in API group \"\" in the namespace \"49c31b07-bf89-45c0-8eef-401efd0fa7e5\""}
```

## Does this PR introduce a breaking change?
No

## Acceptance Steps
The `GET /v3/process/:guid/stats` endpoint should work better with this.

## Tag your pair, your PM, and/or team
@akrishna90 @Birdrock 
