### PR TITLE
Run controllers/api and e2e in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-test: test-controllers test-api test-e2e
+test: test-controllers-api test-e2e
+
+test-controllers-api: test-controllers test-api
 
 test-unit: test-controllers test-api-unit
 

--- a/scripts/check-everything.sh
+++ b/scripts/check-everything.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CF_K8S_CONTROLLERS_DIR="$SCRIPT_DIR/.."
+
+RED=1
+GREEN=2
+print_message() {
+  message=$1
+  colour=$2
+  printf "\\r\\033[00;3%sm[%s]\\033[0m\\n" "$colour" "$message"
+}
+
+main() {
+  print_message "about to run tests in parallel, it will be awesome" $GREEN
+  print_message "ctrl-d panes when they are done" $RED
+  tmux new-window -n cf-k8s-tests "/bin/bash -c \"make test-controllers-api; bash --init-file <(echo 'history -s make test-controllers-api')\""
+  tmux split-window -h -p 50 "/bin/bash -c \"make test-e2e; bash --init-file <(echo 'history -s make test-e2e')\""
+}
+
+main


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
A script (`scripts/check-everything.sh`) that opens a new tmux window with two panes. The left pane runs `make test-controllers-api`, the other one - `make test-e2e`.
Unfortunately env tests cannot be easily run in parallel, probably they share common environment so further parallelisation does not seem to be trivial.

I did not want to put tmux stuff in the Makefile as not everyone uses tmux. That is why I have introduced a dedicated file for those who do.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run `scripts/check-everything.sh` and enjoy running tests in parallel