### PR TITLE
#102 Kubectl user can see whether a CFRoute is valid or invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/testbin
 .idea/
 ~/.*
+*.test

--- a/controllers/apis/networking/v1alpha1/cfroute_types.go
+++ b/controllers/apis/networking/v1alpha1/cfroute_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ValidStatus   CurrentStatus = "valid"
+	InvalidStatus CurrentStatus = "invalid"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -61,6 +66,8 @@ type CFRouteSpec struct {
 
 // CFRouteStatus defines the observed state of CFRoute
 type CFRouteStatus struct {
+	CurrentStatus CurrentStatus `json:"currentStatus"`
+	Description   string        `json:"description"`
 	// FQDN captures the fully-qualified domain name for the route
 	FQDN string `json:"fqdn,omitempty"`
 
@@ -70,6 +77,10 @@ type CFRouteStatus struct {
 	// Conditions capture the current status of the route
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// CurrentStatus declares whether the CFRoute is currently valid or invalid
+// +kubebuilder:validation:Enum=valid;invalid
+type CurrentStatus string
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
+++ b/controllers/config/crd/bases/networking.cloudfoundry.org_cfroutes.yaml
@@ -135,12 +135,23 @@ spec:
                   - type
                   type: object
                 type: array
+              currentStatus:
+                description: CurrentStatus declares whether the CFRoute is currently valid or invalid
+                enum:
+                - valid
+                - invalid
+                type: string
+              description:
+                type: string
               fqdn:
                 description: FQDN captures the fully-qualified domain name for the route
                 type: string
               uri:
                 description: URI captures the URI (FQDN + path) for the route
                 type: string
+            required:
+            - currentStatus
+            - description
             type: object
         type: object
     served: true

--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -58,8 +58,8 @@ type CFRouteReconciler struct {
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 func (r *CFRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var cfRoute networkingv1alpha1.CFRoute
-	err := r.Client.Get(ctx, req.NamespacedName, &cfRoute)
+	cfRoute := new(networkingv1alpha1.CFRoute)
+	err := r.Client.Get(ctx, req.NamespacedName, cfRoute)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			r.Log.Error(err, "failed to get CFRoute")
@@ -70,46 +70,86 @@ func (r *CFRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var cfDomain networkingv1alpha1.CFDomain
 	err = r.Client.Get(ctx, types.NamespacedName{Name: cfRoute.Spec.DomainRef.Name}, &cfDomain)
 	if err != nil {
-		r.Log.Error(err, "failed to get CFDomain")
-
+		if apierrors.IsNotFound(err) {
+			r.Log.Error(err, "CFDomain not found")
+			errMsg := fmt.Sprintf("%v", err)
+			if err := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, "Invalid domain reference", "InvalidDomainRef", errMsg); err != nil {
+				r.Log.Error(err, "Error when updating CFRoute status")
+				return ctrl.Result{}, err
+			}
+		} else {
+			description := "Error fetching domain reference"
+			r.Log.Error(err, description)
+			errMsg := fmt.Sprintf("%v", err)
+			if err := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, description, "FetchDomainRef", errMsg); err != nil {
+				r.Log.Error(err, "Error when updating CFRoute status")
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{}, err
 	}
 
-	err = r.addFinalizer(ctx, &cfRoute)
+	err = r.addFinalizer(ctx, cfRoute)
+	if err != nil {
+		// TODO: Add failed status here
+		return ctrl.Result{}, err
+	}
+
+	if isFinalizing(cfRoute) {
+		return r.finalizeCFRoute(ctx, cfRoute, &cfDomain)
+	}
+
+	err = r.setStatusFields(ctx, cfRoute, &cfDomain)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if isFinalizing(&cfRoute) {
-		return r.finalizeCFRoute(ctx, &cfRoute, &cfDomain)
-	}
-
-	err = r.setStatusFields(ctx, &cfRoute, &cfDomain)
+	err = r.createOrPatchServices(ctx, cfRoute)
 	if err != nil {
+		// TODO: Add failed status here
 		return ctrl.Result{}, err
 	}
 
-	err = r.createOrPatchServices(ctx, &cfRoute)
+	err = r.createOrPatchRouteProxy(ctx, cfRoute)
 	if err != nil {
+		// TODO: Add failed status here
 		return ctrl.Result{}, err
 	}
 
-	err = r.createOrPatchRouteProxy(ctx, &cfRoute)
+	err = r.createOrPatchFQDNProxy(ctx, cfRoute, &cfDomain)
 	if err != nil {
+		// TODO: Add failed status here
 		return ctrl.Result{}, err
 	}
 
-	err = r.createOrPatchFQDNProxy(ctx, &cfRoute, &cfDomain)
+	err = r.deleteOrphanedServices(ctx, cfRoute)
 	if err != nil {
+		// TODO: Add failed status here
 		return ctrl.Result{}, err
 	}
 
-	err = r.deleteOrphanedServices(ctx, &cfRoute)
-	if err != nil {
+	if err := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.ValidStatus, "Valid CFRoute", "Valid", "Valid CFRoute"); err != nil {
+		r.Log.Error(err, "Error when updating CFRoute status")
 		return ctrl.Result{}, err
 	}
-
 	return ctrl.Result{}, nil
+}
+
+func (r *CFRouteReconciler) setRouteStatus(ctx context.Context, cfRoute *networkingv1alpha1.CFRoute, statusValue networkingv1alpha1.CurrentStatus, description, reason, message string) error {
+
+	cfRoute.Status.CurrentStatus = statusValue
+	cfRoute.Status.Description = description
+
+	statusConditionValue := metav1.ConditionUnknown
+	if statusValue == networkingv1alpha1.InvalidStatus {
+		statusConditionValue = metav1.ConditionFalse
+	} else if statusValue == networkingv1alpha1.ValidStatus {
+		statusConditionValue = metav1.ConditionTrue
+	}
+
+	setStatusConditionOnLocalCopy(&cfRoute.Status.Conditions, "Valid", statusConditionValue, reason, message)
+
+	return r.Client.Status().Update(ctx, cfRoute)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/controllers/networking/shared.go
+++ b/controllers/controllers/networking/shared.go
@@ -1,7 +1,27 @@
 package networking
 
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 //counterfeiter:generate -o fake -fake-name Client sigs.k8s.io/controller-runtime/pkg/client.Client
 
 //counterfeiter:generate -o fake -fake-name StatusWriter sigs.k8s.io/controller-runtime/pkg/client.StatusWriter
+// This is a helper function for updating local copy of status conditions
+
+func setStatusConditionOnLocalCopy(conditions *[]metav1.Condition, conditionType string, conditionStatus metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:   conditionType,
+		Status: conditionStatus,
+		LastTransitionTime: metav1.Time{
+			Time: time.Now(),
+		},
+		Reason:  reason,
+		Message: message,
+	})
+}

--- a/controllers/controllers/networking/suite_test.go
+++ b/controllers/controllers/networking/suite_test.go
@@ -3,11 +3,49 @@ package networking_test
 import (
 	"testing"
 
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestWorkloadsControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Networking Controllers Unit Test Suite")
+}
+
+func expectCFRouteValidStatus(cfRouteStatus networkingv1alpha1.CFRouteStatus, valid bool, desc ...string) {
+	expectedCurrentStatus := networkingv1alpha1.ValidStatus
+	expectedValidStatusCondition := metav1.ConditionTrue
+	if !valid {
+		expectedCurrentStatus = networkingv1alpha1.InvalidStatus
+		expectedValidStatusCondition = metav1.ConditionFalse
+	}
+	Expect(cfRouteStatus.CurrentStatus).To(Equal(expectedCurrentStatus))
+
+	if len(desc) == 0 {
+		Expect(cfRouteStatus.Description).NotTo(BeEmpty())
+	} else {
+		Expect(cfRouteStatus.Description).To(Equal(desc[0]))
+	}
+	reasonMatcher := Not(BeEmpty())
+	messageMatcher := Not(BeEmpty())
+	if len(desc) > 1 {
+		reasonMatcher = Equal(desc[1])
+	}
+	if len(desc) > 2 {
+		messageMatcher = Equal(desc[2])
+	}
+
+	validStatus := meta.FindStatusCondition(cfRouteStatus.Conditions, "Valid")
+	Expect(validStatus).NotTo(BeNil())
+	Expect(*validStatus).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal("Valid"),
+		"Status":  Equal(expectedValidStatusCondition),
+		"Reason":  reasonMatcher,
+		"Message": messageMatcher,
+	}))
 }

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1100,6 +1100,15 @@ spec:
                   - type
                   type: object
                 type: array
+              currentStatus:
+                description: CurrentStatus declares whether the CFRoute is currently
+                  valid or invalid
+                enum:
+                - valid
+                - invalid
+                type: string
+              description:
+                type: string
               fqdn:
                 description: FQDN captures the fully-qualified domain name for the
                   route
@@ -1107,6 +1116,9 @@ spec:
               uri:
                 description: URI captures the URI (FQDN + path) for the route
                 type: string
+            required:
+            - currentStatus
+            - description
             type: object
         type: object
     served: true


### PR DESCRIPTION
## Is there a related GitHub Issue?
resolves #102

## What is this change about?
Adds status fields to CFRoute for whether it is valid or not

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow README to install CRDs and run Controllers
apply `config/samples/cfroute.yaml`
confirm that its status field are set to Valid: false
apply `config/samples/cfdomain.yaml`
confirm that the cfroute status fields are Valid:true

## Tag your pair, your PM, and/or team
@akrishna90 
