### PR TITLE
Fix flaky app filtering test

### DIFF
--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -478,8 +478,8 @@ var _ = Describe("AppRepository", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(appList).To(HaveLen(2))
 
-						Expect(appList[0].GUID).To(Equal(app2GUID))
-						Expect(appList[1].GUID).To(Equal(app3GUID))
+						Expect(appList[0].GUID).To(BeElementOf(app2GUID, app3GUID))
+						Expect(appList[1].GUID).To(BeElementOf(app2GUID, app3GUID))
 					})
 				})
 			})
@@ -613,8 +613,8 @@ var _ = Describe("AppRepository", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(appList).To(HaveLen(2))
 
-						Expect(appList[0].GUID).To(Equal(app2GUID))
-						Expect(appList[1].GUID).To(Equal(app3GUID))
+						Expect(appList[0].GUID).To(BeElementOf(app2GUID, app3GUID))
+						Expect(appList[1].GUID).To(BeElementOf(app2GUID, app3GUID))
 					})
 				})
 			})


### PR DESCRIPTION
## What is this change about?
Fixes a flaky test I introduced in https://github.com/cloudfoundry/cf-k8s-controllers/pull/270 😔 

- The order that the apps get returned by the K8s API is
non-deterministic
- Issue https://github.com/cloudfoundry/cf-k8s-controllers/issues/266


## Tag your pair, your PM, and/or team
@gnovv 
