### PR TITLE
Fix e2e in github actions

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -220,8 +220,8 @@ jobs:
     - name: Run e2e tests
       env:
         SKIP_DOCKER_BUILD: true
-        API_IMG: cloudfoundry/cf-k8s-api:${{ github.sha }}
-        CONTROLLERS_IMG: cloudfoundry/cf-k8s-controllers:${{ github.sha }}
+        IMG_API: cloudfoundry/cf-k8s-api:${{ github.sha }}
+        IMG_CONTROLLERS: cloudfoundry/cf-k8s-controllers:${{ github.sha }}
       run: make test-e2e
       working-directory: ./cf-k8s-controllers
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -220,7 +220,7 @@ jobs:
     - name: Run e2e tests
       env:
         SKIP_DOCKER_BUILD: true
-        API_IMG: cloudfoundry/cf-k8s-api:${{ github.sha }}
-        CONTROLLERS_IMG: cloudfoundry/cf-k8s-controllers:${{ github.sha }}
+        IMG_API: cloudfoundry/cf-k8s-api:${{ github.sha }}
+        IMG_CONTROLLERS: cloudfoundry/cf-k8s-controllers:${{ github.sha }}
       run: make test-e2e
       working-directory: ./cf-k8s-controllers

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -115,7 +115,7 @@ func ensureServerIsUp() {
 		resp.Body.Close()
 
 		return resp.StatusCode, nil
-	}, "30s").Should(Equal(http.StatusOK), "API Server at %s was not running after 30 seconds", apiServerRoot)
+	}, "5m").Should(Equal(http.StatusOK), "API Server at %s was not running after 5 minutes", apiServerRoot)
 }
 
 func generateGUID(prefix string) string {

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -39,34 +39,36 @@ EOF
 }
 
 deploy_cf_k8s_controllers() {
-  pushd $ROOT_DIR > /dev/null
+  pushd $ROOT_DIR >/dev/null
   {
     "$SCRIPT_DIR/install-dependencies.sh"
     export KUBEBUILDER_ASSETS=$ROOT_DIR/testbin/bin
     echo $PWD
     make generate-controllers
+    IMG_CONTROLLERS=${IMG_CONTROLLERS:-"cf-k8s-controllers:$(uuidgen)"}
+    export IMG_CONTROLLERS
     if [[ -z "${SKIP_DOCKER_BUILD:-}" ]]; then
-      export IMG_CONTROLLERS=${CONTROLLERS_IMG:-"cf-k8s-controllers:$(uuidgen)"}
       make docker-build-controllers
-      kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     fi
+    kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     make install-crds
     make deploy-controllers
   }
-  popd > /dev/null
+  popd >/dev/null
 }
 
 deploy_cf_k8s_api() {
-  pushd $ROOT_DIR > /dev/null
+  pushd $ROOT_DIR >/dev/null
   {
+    IMG_API=${IMG_API:-"cf-k8s-api:$(uuidgen)"}
+    export IMG_API
     if [[ -z "${SKIP_DOCKER_BUILD:-}" ]]; then
-      export IMG_API=${API_IMG:-"cf-k8s-api:$(uuidgen)"}
       make docker-build-api
-      kind load docker-image --name "$cluster" "$IMG_API"
     fi
+    kind load docker-image --name "$cluster" "$IMG_API"
     make deploy-api-kind-auth
   }
-  popd > /dev/null
+  popd >/dev/null
 }
 
 cluster=${1:?specify cluster name}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?

1. Contour may take up to 5 minutes to start, so extend the before suite timeout to 5 minutes
2. The controllers and api images need to be loaded into kind when running locally _and_ when running in github actions
3. Unify the *_IMG variable names

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Locally, `make test-e2e` should work.
Remotely, github actions should work for PRs and on main.

## Tag your pair, your PM, and/or team
@georgethebeatle, @cloudfoundry/eirini 