### PR TITLE
Ensure build-reference gets run so that check always succeeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,16 +124,13 @@ deploy: install-crds deploy-controllers deploy-api
 
 deploy-kind: install-crds deploy-controllers deploy-api-kind-auth
 
-deploy-controllers: manifests-controllers kustomize
-	cd controllers/config/manager && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-controllers=${IMG_CONTROLLERS}
+deploy-controllers: kustomize build-reference-controllers
 	$(KUSTOMIZE) build controllers/config/default | kubectl apply -f -
 
-deploy-api: kustomize
-	cd api/config/base && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-api=${IMG_API}
+deploy-api: kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/base | kubectl apply -f -
 
-deploy-api-kind-auth: kustomize
-	cd api/config/base && $(KUSTOMIZE) edit set image cloudfoundry/cf-k8s-api=${IMG_API}
+deploy-api-kind-auth: kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/overlays/kind-auth-enabled | kubectl apply -f -
 
 undeploy-controllers: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -9,6 +9,15 @@ CTRL_DIR="$ROOT_DIR/controllers"
 EIRINI_CONTROLLER_DIR="$ROOT_DIR/../eirini-controller"
 export PATH="$PATH:$API_DIR/bin"
 
+# undo *_IMG changes in config and reference
+clean_up_img_refs() {
+  cd "$ROOT_DIR"
+  unset IMG_CONTROLLERS
+  unset IMG_API
+  make build-reference
+}
+trap clean_up_img_refs EXIT
+
 ensure_kind_cluster() {
   if ! kind get clusters | grep -q "$cluster"; then
     current_cluster="$(kubectl config current-context)" || true


### PR DESCRIPTION
## Is there a related GitHub Issue?
#151

## What is this change about?
Make sure the yaml reference is updated automatically when e2e tests are run. This way we will avoid yaml drift failures.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
make test-e2e should update the yaml reference 

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
