### PR TITLE
Generate and publish code coverage reports

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -72,6 +72,12 @@ jobs:
     - name: Run Controllers tests
       run: make test-controllers
 
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v2
+      with:
+        name: controllers-coverage
+        path: "**/cover.out"
+
   api-unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +99,12 @@ jobs:
     - name: Run API unit tests
       run: make test-api-unit
 
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v2
+      with:
+        name: api-unit-coverage
+        path: "**/cover.out"
+
   api-integration-tests:
     runs-on: ubuntu-latest
     steps:
@@ -113,6 +125,48 @@ jobs:
 
     - name: Run API integration tests
       run: make test-api-integration
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v2
+      with:
+        name: api-integration-coverage
+        path: "**/cover.out"
+
+  publish-code-coverage:
+    needs:
+    - controllers-tests
+    - api-unit-tests
+    - api-integration-tests
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download controllers coverage
+      uses: actions/download-artifact@v2
+      with:
+        name: controllers-coverage
+        path: controllers-coverage
+
+    - name: Download api unit coverage
+      uses: actions/download-artifact@v2
+      with:
+        name: api-unit-coverage
+        path: api-unit-coverage
+
+    - name: Download api integration coverage
+      uses: actions/download-artifact@v2
+      with:
+        name: api-integration-coverage
+        path: api-integration-coverage
+
+    - name: Generate and publish code coverage report
+      uses: paambaati/codeclimate-action@v3.0.0
+      env:
+        CC_TEST_REPORTER_ID: eac10b59cb33cb6a2ae137260587e43e3e148c72f0d2a3b7cca35761cfe257ee
+      with:
+        coverageLocations: "**/cover.out:gocov"
+        prefix: "code.cloudfoundry.org/cf-k8s-controllers"
 
   build-api:
     runs-on: ubuntu-latest

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,7 @@ if ! egrep -q e2e <(echo "$@"); then
   source "${ENVTEST_ASSETS_DIR}/setup-envtest.sh"
   fetch_envtest_tools "${ENVTEST_ASSETS_DIR}"
   setup_envtest_env "${ENVTEST_ASSETS_DIR}"
-  extra_args+=("-coverprofile=cover.out" "--skip-package=e2e")
+  extra_args+=("--skip-package=e2e" "--coverprofile=cover.out" "--coverpkg=code.cloudfoundry.org/cf-k8s-controllers/...")
 else
   if [ -z "${SKIP_DEPLOY}" ]; then
     "${SCRIPT_DIR}/deploy-on-kind.sh" e2e


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/286

## What is this change about?
Publish code coverage report to [codeclimate](https://codeclimate.com/github/cloudfoundry/cf-k8s-controllers)

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Unfortunately this is one of those changes that you can't really test fully until it makes its way to the `main` branch.
I tried to test as much as possible by doing the same changes to the pr workflow and making sure the actions are
passing.

Here is what should happen after the workflow executes successfully on `main`:
- https://codeclimate.com/github/cloudfoundry/cf-k8s-controllers should display coverage percentage
- https://codeclimate.com/github/cloudfoundry/cf-k8s-controllers/code should display coverage percentage
- In the above page when you click on a file it should visualize line coverage.


## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 

