### PR TITLE
Add golangci-lint configuration and make target

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -43,6 +43,13 @@ jobs:
         make build-reference-controllers
         git diff --exit-code
 
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+
   controllers-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -43,6 +43,13 @@ jobs:
         make build-reference-controllers
         git diff --exit-code
 
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+
   controllers-tests:
     runs-on: ubuntu-latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  # increase timeout for cases when tests run in parallel with linters
+  timeout: 20m
+  # which dirs to skip: they won't be analyzed;
+  skip-dirs:
+    - vendor
+    - pkg
+  modules-download-mode: mod
+
+linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
+linters:
+  # Maximum issues count per one linter. Set to 0 to disable.
+  max-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable
+  max-same: 0
+
+  # Show only new issues
+  new: false

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ fmt: install-gofumpt install-shfmt
 vet: ## Run go vet against code.
 	go vet ./...
 
-test: test-controllers-api test-e2e
+lint:
+	golangci-lint run -v
+
+test: lint test-controllers-api test-e2e
 
 test-controllers-api: test-controllers test-api
 

--- a/api/actions/apply_manifest.go
+++ b/api/actions/apply_manifest.go
@@ -53,7 +53,9 @@ func (a *applyManifest) updateApp(ctx context.Context, c client.Client, spaceGUI
 
 	for _, processInfo := range appInfo.Processes {
 		exists := true
-		process, err := a.processRepo.FetchProcessByAppTypeAndSpace(ctx, c, appRecord.GUID, processInfo.Type, spaceGUID)
+
+		var process repositories.ProcessRecord
+		process, err = a.processRepo.FetchProcessByAppTypeAndSpace(ctx, c, appRecord.GUID, processInfo.Type, spaceGUID)
 		if err != nil {
 			if errors.As(err, new(repositories.NotFoundError)) {
 				exists = false

--- a/api/apis/apis_suite_test.go
+++ b/api/apis/apis_suite_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gorilla/mux"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 )
 
 const (
@@ -124,30 +122,4 @@ func expectUnauthorizedError() {
             }
         ]
     }`)
-}
-
-func initializeProcessRecord(processGUID, spaceGUID, appGUID string) *repositories.ProcessRecord {
-	return &repositories.ProcessRecord{
-		GUID:             processGUID,
-		SpaceGUID:        spaceGUID,
-		AppGUID:          appGUID,
-		Type:             "web",
-		Command:          "rackup",
-		DesiredInstances: 1,
-		MemoryMB:         256,
-		DiskQuotaMB:      1024,
-		Ports:            []int32{8080},
-		HealthCheck: repositories.HealthCheck{
-			Type: "port",
-			Data: repositories.HealthCheckData{
-				HTTPEndpoint:             "",
-				InvocationTimeoutSeconds: 0,
-				TimeoutSeconds:           0,
-			},
-		},
-		Labels:      map[string]string{},
-		Annotations: map[string]string{},
-		CreatedAt:   "",
-		UpdatedAt:   "",
-	}
 }

--- a/api/apis/apis_suite_test.go
+++ b/api/apis/apis_suite_test.go
@@ -21,7 +21,6 @@ const (
 
 var (
 	rr        *httptest.ResponseRecorder
-	req       *http.Request
 	router    *mux.Router
 	serverURL *url.URL
 	ctx       context.Context

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -682,7 +682,8 @@ func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		terminated, err := h.podRepo.WatchForPodsTermination(ctx, client, app.GUID, app.SpaceGUID)
+		var terminated bool
+		terminated, err = h.podRepo.WatchForPodsTermination(ctx, client, app.GUID, app.SpaceGUID)
 		if err != nil {
 			h.logger.Error(err, "Failed to fetch pods for app in Kubernetes", "AppGUID", appGUID)
 			writeUnknownErrorResponse(w)

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -133,7 +133,7 @@ func (h *AppHandler) appGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +143,7 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 	var payload payloads.AppCreate
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -194,7 +194,7 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
@@ -254,7 +254,7 @@ func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.Request) {
@@ -266,7 +266,7 @@ func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.
 	var payload payloads.AppSetCurrentDroplet
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -326,7 +326,7 @@ func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appGetCurrentDropletHandler(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func (h *AppHandler) appGetCurrentDropletHandler(w http.ResponseWriter, r *http.
 		writeUnknownErrorResponse(w)
 		return
 	}
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appStartHandler(w http.ResponseWriter, r *http.Request) {
@@ -437,7 +437,7 @@ func (h *AppHandler) appStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appStopHandler(w http.ResponseWriter, r *http.Request) {
@@ -488,7 +488,7 @@ func (h *AppHandler) appStopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Request) {
@@ -535,7 +535,7 @@ func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) getRoutesForAppHandler(w http.ResponseWriter, r *http.Request) {
@@ -582,7 +582,7 @@ func (h *AppHandler) getRoutesForAppHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -596,7 +596,7 @@ func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Reque
 	var payload payloads.ProcessScale
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -631,7 +631,7 @@ func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
@@ -715,7 +715,7 @@ func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) lookupAppRouteAndDomainList(ctx context.Context, client client.Client, appGUID, spaceGUID string) ([]repositories.RouteRecord, error) {

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -37,6 +37,7 @@ var _ = Describe("AppHandler", func() {
 		domainRepo          *fake.CFDomainRepository
 		podRepo             *fake.PodRepository
 		clientBuilder       *fake.ClientBuilder
+		req                 *http.Request
 	)
 
 	BeforeEach(func() {

--- a/api/apis/authentication_middleware_test.go
+++ b/api/apis/authentication_middleware_test.go
@@ -3,7 +3,6 @@ package apis_test
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories/authorization"
@@ -19,13 +18,11 @@ var _ = Describe("Authentication Middleware", func() {
 	var (
 		authMiddleware   *apis.AuthenticationMiddleware
 		nextHandler      http.Handler
-		rr               *httptest.ResponseRecorder
 		identityProvider *fake.IdentityProvider
 		requestPath      string
 	)
 
 	BeforeEach(func() {
-		rr = httptest.NewRecorder()
 		nextHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) })
 
 		identityProvider = new(fake.IdentityProvider)

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -90,7 +90,7 @@ func (h *BuildHandler) buildGetHandler(w http.ResponseWriter, r *http.Request) {
 		writeUnknownErrorResponse(w)
 		return
 	}
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Request) {
@@ -99,7 +99,7 @@ func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Reque
 	var payload payloads.BuildCreate
 	rme := decodeAndValidateJSONPayload(req, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -38,6 +38,7 @@ var _ = Describe("BuildHandler", func() {
 		var (
 			buildRepo     *fake.CFBuildRepository
 			clientBuilder *fake.ClientBuilder
+			req           *http.Request
 		)
 
 		// set up happy path defaults

--- a/api/apis/domain_handler.go
+++ b/api/apis/domain_handler.go
@@ -110,7 +110,7 @@ func (h *DomainHandler) DomainListHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *DomainHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/domain_handler_test.go
+++ b/api/apis/domain_handler_test.go
@@ -53,8 +53,7 @@ var _ = Describe("DomainHandler", func() {
 
 		When("on the happy path", func() {
 			BeforeEach(func() {
-				var err error
-				req, err = http.NewRequest("GET", "/v3/domains", nil)
+				req, err := http.NewRequest("GET", "/v3/domains", nil)
 				Expect(err).NotTo(HaveOccurred())
 				router.ServeHTTP(rr, req)
 			})
@@ -119,8 +118,7 @@ var _ = Describe("DomainHandler", func() {
 		When("no domain exists", func() {
 			BeforeEach(func() {
 				domainRepo.FetchDomainListReturns([]repositories.DomainRecord{}, nil)
-				var err error
-				req, err = http.NewRequest("GET", "/v3/domains", nil)
+				req, err := http.NewRequest("GET", "/v3/domains", nil)
 				Expect(err).NotTo(HaveOccurred())
 				router.ServeHTTP(rr, req)
 			})
@@ -159,8 +157,7 @@ var _ = Describe("DomainHandler", func() {
 		When("there is an error listing domains", func() {
 			BeforeEach(func() {
 				domainRepo.FetchDomainListReturns([]repositories.DomainRecord{}, errors.New("unexpected error!"))
-				var err error
-				req, err = http.NewRequest("GET", "/v3/domains", nil)
+				req, err := http.NewRequest("GET", "/v3/domains", nil)
 				Expect(err).NotTo(HaveOccurred())
 				router.ServeHTTP(rr, req)
 			})
@@ -172,8 +169,7 @@ var _ = Describe("DomainHandler", func() {
 
 		When("invalid query parameters are provided", func() {
 			BeforeEach(func() {
-				var err error
-				req, err = http.NewRequest("GET", "/v3/domains?foo=bar", nil)
+				req, err := http.NewRequest("GET", "/v3/domains?foo=bar", nil)
 				Expect(err).NotTo(HaveOccurred())
 				router.ServeHTTP(rr, req)
 			})

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -84,7 +84,7 @@ func (h *DropletHandler) dropletGetHandler(w http.ResponseWriter, r *http.Reques
 		writeUnknownErrorResponse(w)
 		return
 	}
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *DropletHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/droplet_handler_test.go
+++ b/api/apis/droplet_handler_test.go
@@ -30,6 +30,7 @@ var _ = Describe("DropletHandler", func() {
 		var (
 			dropletRepo   *fake.CFDropletRepository
 			clientBuilder *fake.ClientBuilder
+			req           *http.Request
 		)
 
 		BeforeEach(func() {

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -67,7 +67,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), namespace)
+			Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {

--- a/api/apis/integration/create_app_test.go
+++ b/api/apis/integration/create_app_test.go
@@ -74,7 +74,7 @@ var _ = Describe("POST /v3/apps endpoint", func() {
 				"relationships": {
 					"space": {
 						"data": {
-							"guid": %q 
+							"guid": %q
 						}
 					}
 				},

--- a/api/apis/integration/create_app_test.go
+++ b/api/apis/integration/create_app_test.go
@@ -92,7 +92,7 @@ var _ = Describe("POST /v3/apps endpoint", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), namespace)
+			Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 		})
 
 		It("creates a CFApp and Secret, returns 201 and an App object as JSON", func() {

--- a/api/apis/job_handler.go
+++ b/api/apis/job_handler.go
@@ -50,7 +50,7 @@ func (h *JobHandler) jobGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func getSpaceGUID(jobGUID string) string {

--- a/api/apis/log_cache_handler.go
+++ b/api/apis/log_cache_handler.go
@@ -23,7 +23,7 @@ func NewLogCacheHandler() *LogCacheHandler {
 
 func (h *LogCacheHandler) logCacheInfoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"version":"` + logCacheVersion + `","vm_uptime":"0"}`))
+	_, _ = w.Write([]byte(`{"version":"` + logCacheVersion + `","vm_uptime":"0"}`))
 }
 
 func (h *LogCacheHandler) logCacheEmptyReadHandler(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func (h *LogCacheHandler) logCacheEmptyReadHandler(w http.ResponseWriter, r *htt
 	// provided in the request. A full implementation of this endpoint needs to have the appropriate
 	// validity and authorization checks in place.
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"envelopes":{"batch":[]}}`))
+	_, _ = w.Write([]byte(`{"envelopes":{"batch":[]}}`))
 }
 
 func (h *LogCacheHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -1,7 +1,6 @@
 package apis
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,7 +47,7 @@ func (h *OrgHandler) orgCreateHandler(w http.ResponseWriter, r *http.Request) {
 	var payload payloads.OrgCreate
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 
 		return
 	}
@@ -91,9 +90,8 @@ func (h *OrgHandler) orgCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	orgResponse := presenter.ForCreateOrg(record, h.apiBaseURL)
-	json.NewEncoder(w).Encode(orgResponse)
+	writeResponse(w, http.StatusCreated, orgResponse)
 }
 
 func (h *OrgHandler) orgListHandler(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +135,7 @@ func (h *OrgHandler) orgListHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	orgList := presenter.ForOrgList(orgs, h.apiBaseURL)
-	json.NewEncoder(w).Encode(orgList)
+	writeResponse(w, http.StatusOK, orgList)
 }
 
 func (h *OrgHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -29,16 +29,13 @@ const (
 
 var _ = Describe("OrgHandler", func() {
 	var (
-		ctx             context.Context
 		orgHandler      *apis.OrgHandler
 		orgRepoProvider *fake.OrgRepositoryProvider
 		orgRepo         *repositoriesfake.CFOrgRepository
-		req             *http.Request
 		now             time.Time
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
 		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
 
 		orgRepoProvider = new(fake.OrgRepositoryProvider)
@@ -51,11 +48,11 @@ var _ = Describe("OrgHandler", func() {
 
 	Describe("Create Org", func() {
 		makePostRequest := func(requestBody string) {
-			req, err := http.NewRequestWithContext(ctx, "POST", orgsBase, strings.NewReader(requestBody))
+			request, err := http.NewRequestWithContext(ctx, "POST", orgsBase, strings.NewReader(requestBody))
 			Expect(err).NotTo(HaveOccurred())
-			req.Header.Add(headers.Authorization, "Bearer my-token")
+			request.Header.Add(headers.Authorization, "Bearer my-token")
 
-			router.ServeHTTP(rr, req)
+			router.ServeHTTP(rr, request)
 		}
 
 		BeforeEach(func() {
@@ -310,6 +307,7 @@ var _ = Describe("OrgHandler", func() {
 	})
 
 	Describe("Listing Orgs", func() {
+		var req *http.Request
 		BeforeEach(func() {
 			orgRepo.FetchOrgsReturns([]repositories.OrgRecord{
 				{

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -118,7 +118,7 @@ func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, req *http.Re
 	var payload payloads.PackageCreate
 	rme := decodeAndValidateJSONPayload(req, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -98,7 +98,7 @@ func (h *ProcessHandler) processGetHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) processGetSidecarsHandler(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +123,7 @@ func (h *ProcessHandler) processGetSidecarsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	w.Write([]byte(fmt.Sprintf(`{
+	_, _ = w.Write([]byte(fmt.Sprintf(`{
 					"pagination": {
 						"total_results": 0,
 						"total_pages": 1,
@@ -150,7 +150,7 @@ func (h *ProcessHandler) processScaleHandler(w http.ResponseWriter, r *http.Requ
 	var payload payloads.ProcessScale
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -184,7 +184,7 @@ func (h *ProcessHandler) processScaleHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) processGetStatsHandler(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +215,7 @@ func (h *ProcessHandler) processGetStatsHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) LogError(w http.ResponseWriter, processGUID string, err error) {

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -27,6 +27,7 @@ var _ = Describe("ProcessHandler", func() {
 		fetchProcessStats *fake.FetchProcessStats
 		scaleProcessFunc  *fake.ScaleProcess
 		clientBuilder     *fake.ClientBuilder
+		req               *http.Request
 	)
 
 	BeforeEach(func() {

--- a/api/apis/resource_matches_handler.go
+++ b/api/apis/resource_matches_handler.go
@@ -21,7 +21,7 @@ func NewResourceMatchesHandler(serverURL string) *ResourceMatchesHandler {
 func (h *ResourceMatchesHandler) resourceMatchesPostHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	w.Write([]byte(`{"resources":[]}`))
+	_, _ = w.Write([]byte(`{"resources":[]}`))
 }
 
 func (h *ResourceMatchesHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -64,7 +63,7 @@ func (h *RoleHandler) roleCreateHandler(w http.ResponseWriter, r *http.Request) 
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		h.logger.Error(rme, "Failed to parse body")
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 
 		return
 	}
@@ -91,9 +90,8 @@ func (h *RoleHandler) roleCreateHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	roleResponse := presenter.ForCreateRole(record, h.apiBaseURL)
-	json.NewEncoder(w).Encode(roleResponse)
+	writeResponse(w, http.StatusCreated, roleResponse)
 }
 
 func (h *RoleHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -22,14 +22,12 @@ const (
 
 var _ = Describe("RoleHandler", func() {
 	var (
-		ctx         context.Context
 		roleHandler *apis.RoleHandler
 		roleRepo    *fake.CFRoleRepository
 		now         time.Time
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
 		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
 
 		roleRepo = new(fake.CFRoleRepository)

--- a/api/apis/root_handler.go
+++ b/api/apis/root_handler.go
@@ -30,7 +30,7 @@ func (h *RootHandler) rootGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(body))
+	_, _ = w.Write([]byte(body))
 }
 
 func (h *RootHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/root_v3_handler.go
+++ b/api/apis/root_v3_handler.go
@@ -20,7 +20,7 @@ func NewRootV3Handler(serverURL string) *RootV3Handler {
 
 func (h *RootV3Handler) rootV3GetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"links":{"self":{"href":"` + h.serverURL + `/v3"}}}`))
+	_, _ = w.Write([]byte(`{"links":{"self":{"href":"` + h.serverURL + `/v3"}}}`))
 }
 
 func (h *RootV3Handler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -155,7 +155,7 @@ func (h *RouteHandler) routeCreateHandler(w http.ResponseWriter, r *http.Request
 	var routeCreateMessage payloads.RouteCreate
 	rme := decodeAndValidateJSONPayload(r, &routeCreateMessage)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -220,7 +220,7 @@ func (h *RouteHandler) routeCreateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *http.Request) {
@@ -230,7 +230,7 @@ func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *htt
 	var destinationCreatePayload payloads.DestinationListCreate
 	rme := decodeAndValidateJSONPayload(r, &destinationCreatePayload)
 	if rme != nil {
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -274,7 +274,7 @@ func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	w.Write(responseBody)
+	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -1,7 +1,6 @@
 package apis
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -49,7 +48,7 @@ func (h *SpaceHandler) SpaceCreateHandler(w http.ResponseWriter, r *http.Request
 	rme := decodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		h.logger.Error(rme, "Failed to decode and validate payload")
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -92,13 +91,8 @@ func (h *SpaceHandler) SpaceCreateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	spaceResponse := presenter.ForCreateSpace(record, h.apiBaseURL)
-
-	err = json.NewEncoder(w).Encode(spaceResponse)
-	if err != nil {
-		h.logger.Error(err, "Failed to write response")
-	}
+	writeResponse(w, http.StatusCreated, spaceResponse)
 }
 
 func (h *SpaceHandler) SpaceListHandler(w http.ResponseWriter, r *http.Request) {
@@ -139,7 +133,7 @@ func (h *SpaceHandler) SpaceListHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	spaceList := presenter.ForSpaceList(spaces, h.apiBaseURL)
-	json.NewEncoder(w).Encode(spaceList)
+	writeResponse(w, http.StatusOK, spaceList)
 }
 
 func (h *SpaceHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -63,7 +63,7 @@ func (h *SpaceManifestHandler) applyManifestHandler(w http.ResponseWriter, r *ht
 	rme := decodeAndValidateYAMLPayload(r, &manifest)
 	if rme != nil {
 		w.Header().Set("Content-Type", "application/json")
-		writeErrorResponse(w, rme)
+		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
@@ -92,7 +92,7 @@ func (h *SpaceManifestHandler) applyManifestHandler(w http.ResponseWriter, r *ht
 func (h *SpaceManifestHandler) diffManifestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	w.Write([]byte(`{"diff":[]}`))
+	_, _ = w.Write([]byte(`{"diff":[]}`))
 }
 
 func decodeAndValidateYAMLPayload(r *http.Request, object interface{}) *requestMalformedError {

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -23,6 +23,7 @@ var _ = Describe("SpaceManifestHandler", func() {
 		clientBuilder       *fake.ClientBuilder
 		applyManifestAction *fake.ApplyManifestAction
 		spaceRepo           *repositoriesfake.CFSpaceRepository
+		req                 *http.Request
 	)
 
 	BeforeEach(func() {

--- a/api/presenter/process_stats.go
+++ b/api/presenter/process_stats.go
@@ -4,12 +4,6 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 )
 
-const (
-	processBase            = "/v3/processes"
-	workloadsContainerName = "opi"
-	cfInstanceIndexKey     = "CF_INSTANCE_INDEX"
-)
-
 type ProcessStatsResponse struct {
 	Resources []ProcessStatsResource `json:"resources"`
 }

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -228,7 +227,7 @@ func (f *AppRepo) returnAppList(appList []workloadsv1alpha1.CFApp) []AppRecord {
 }
 
 func (f *AppRepo) FetchNamespace(ctx context.Context, client client.Client, nsGUID string) (SpaceRecord, error) {
-	namespace := &v1.Namespace{}
+	namespace := &corev1.Namespace{}
 	err := client.Get(ctx, types.NamespacedName{Name: nsGUID}, namespace)
 	if err != nil {
 		switch errtype := err.(type) {
@@ -370,7 +369,7 @@ func filterAppsByMetadataName(apps []workloadsv1alpha1.CFApp, name string) []wor
 	return filtered
 }
 
-func v1NamespaceToSpaceRecord(namespace *v1.Namespace) SpaceRecord {
+func v1NamespaceToSpaceRecord(namespace *corev1.Namespace) SpaceRecord {
 	// TODO How do we derive Organization GUID here?
 	return SpaceRecord{
 		Name:             namespace.Name,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -961,10 +961,7 @@ var _ = Describe("AppRepository", func() {
 				createdCFAppSecret := &corev1.Secret{}
 				Eventually(func() bool {
 					err := testClient.Get(context.Background(), cfAppSecretLookupKey, createdCFAppSecret)
-					if err != nil {
-						return false
-					}
-					return true
+					return err == nil
 				}, timeCheckThreshold*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not find the secret created by the repo")
 
 				// Secret has an owner reference that points to the App CR

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -784,9 +784,10 @@ var _ = Describe("AppRepository", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(testCtx, &corev1.Namespace{
+			err := k8sClient.Delete(testCtx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: spaceGUID},
 			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("creates a new app CR", func() {
@@ -1138,10 +1139,6 @@ var _ = Describe("AppRepository", func() {
 			appCR   *workloadsv1alpha1.CFApp
 		)
 
-		AfterEach(func() {
-			k8sClient.Delete(context.Background(), appCR)
-		})
-
 		When("starting an app", func() {
 			var (
 				returnedAppRecord *AppRecord
@@ -1162,6 +1159,10 @@ var _ = Describe("AppRepository", func() {
 				})
 				returnedAppRecord = &appRecord
 				returnedErr = err
+			})
+
+			AfterEach(func() {
+				Expect(k8sClient.Delete(context.Background(), appCR)).To(Succeed())
 			})
 
 			It("doesn't return an error", func() {
@@ -1208,6 +1209,10 @@ var _ = Describe("AppRepository", func() {
 				})
 				returnedAppRecord = &appRecord
 				returnedErr = err
+			})
+
+			AfterEach(func() {
+				Expect(k8sClient.Delete(context.Background(), appCR)).To(Succeed())
 			})
 
 			It("doesn't return an error", func() {

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -418,7 +418,7 @@ var _ = Describe("BuildRepository", func() {
 
 			AfterEach(func() {
 				afterCtx := context.Background()
-				cleanupBuild(afterCtx, client, buildCreateRecord.GUID, spaceGUID)
+				Expect(cleanupBuild(afterCtx, client, buildCreateRecord.GUID, spaceGUID)).To(Succeed())
 			})
 
 			It("does not return an error", func() {

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -144,8 +144,8 @@ var _ = Describe("DomainRepository", func() {
 
 			AfterEach(func() {
 				ctx := context.Background()
-				k8sClient.Delete(ctx, cfDomain1)
-				k8sClient.Delete(ctx, cfDomain2)
+				Expect(k8sClient.Delete(ctx, cfDomain1)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cfDomain2)).To(Succeed())
 			})
 
 			It("eventually returns a list of domainRecords for each CFDomain CR", func() {
@@ -251,8 +251,8 @@ var _ = Describe("DomainRepository", func() {
 
 			AfterEach(func() {
 				ctx := context.Background()
-				k8sClient.Delete(ctx, cfDomain1)
-				k8sClient.Delete(ctx, cfDomain2)
+				Expect(k8sClient.Delete(ctx, cfDomain1)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cfDomain2)).To(Succeed())
 			})
 
 			When("a single value is provided for a key", func() {

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -57,7 +57,7 @@ var _ = Describe("DomainRepository", func() {
 				client, err := BuildCRClient(k8sConfig)
 				Expect(err).ToNot(HaveOccurred())
 
-				domain := DomainRecord{}
+				var domain DomainRecord
 				domain, err = domainRepo.FetchDomain(testCtx, client, "domain-id-1")
 				Expect(err).ToNot(HaveOccurred())
 

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -96,7 +96,6 @@ var _ = Describe("DomainRepository", func() {
 		BeforeEach(func() {
 			testCtx = context.Background()
 
-			domainRepo = DomainRepo{}
 			domainListMessage = DomainListMessage{}
 			var err error
 			domainClient, err = BuildCRClient(k8sConfig)

--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -79,8 +79,8 @@ var _ = Describe("PodRepository", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), pod1)
-			k8sClient.Delete(context.Background(), pod2)
+			Expect(k8sClient.Delete(context.Background(), pod1)).To(Succeed())
+			Expect(k8sClient.Delete(context.Background(), pod2)).To(Succeed())
 		})
 
 		When("All required pods exists", func() {
@@ -249,15 +249,16 @@ var _ = Describe("PodRepository", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), namespace)
+			Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
 		})
 
 		When("pods exist", func() {
 			It("returns true when pods are deleted", func() {
 				go func() {
+					defer GinkgoRecover()
 					time.Sleep(time.Millisecond * 200)
-					k8sClient.Delete(context.Background(), pod1)
-					k8sClient.Delete(context.Background(), pod2)
+					Expect(k8sClient.Delete(context.Background(), pod1)).To(Succeed())
+					Expect(k8sClient.Delete(context.Background(), pod2)).To(Succeed())
 				}()
 
 				terminated, err := podRepo.WatchForPodsTermination(ctx, testClient, appGUID, spaceGUID)

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -61,7 +61,7 @@ var _ = Describe("ProcessRepo", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), namespace2)
+			Expect(k8sClient.Delete(context.Background(), namespace2)).To(Succeed())
 		})
 
 		When("on the happy path", func() {

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -33,10 +33,9 @@ func TestRepositories(t *testing.T) {
 }
 
 var (
-	testEnv           *envtest.Environment
-	k8sClient         client.WithWatch
-	k8sConfig         *rest.Config
-	testServerAddress string
+	testEnv   *envtest.Environment
+	k8sClient client.WithWatch
+	k8sConfig *rest.Config
 )
 
 var _ = BeforeSuite(func() {

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -55,11 +55,6 @@ var _ = Describe("RoleRepository", func() {
 	}
 
 	Describe("Create Org Role", func() {
-		var (
-			createdRole repositories.RoleRecord
-			createErr   error
-		)
-
 		BeforeEach(func() {
 			roleRecord = repositories.RoleRecord{
 				GUID: uuid.NewString(),

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -554,7 +553,7 @@ var _ = Describe("RouteRepository", func() {
 
 			BeforeEach(func() {
 				cfDomain = &networkingv1alpha1.CFDomain{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: testDomainGUID,
 					},
 					Spec: networkingv1alpha1.CFDomainSpec{
@@ -653,7 +652,7 @@ var _ = Describe("RouteRepository", func() {
 				Expect(k8sClient.Create(beforeCtx, newNamespace)).To(Succeed())
 
 				cfDomain := &networkingv1alpha1.CFDomain{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: testDomainGUID,
 					},
 					Spec: networkingv1alpha1.CFDomainSpec{},
@@ -765,7 +764,7 @@ var _ = Describe("RouteRepository", func() {
 				Expect(k8sClient.Create(beforeCtx, newNamespace)).To(Succeed())
 
 				cfDomain := &networkingv1alpha1.CFDomain{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: testDomainGUID,
 					},
 					Spec: networkingv1alpha1.CFDomainSpec{},

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -102,9 +102,9 @@ var _ = Describe("RouteRepository", func() {
 
 		AfterEach(func() {
 			ctx := context.Background()
-			k8sClient.Delete(ctx, cfRoute1)
-			k8sClient.Delete(ctx, cfRoute2)
-			k8sClient.Delete(ctx, cfDomain)
+			Expect(k8sClient.Delete(ctx, cfRoute1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cfRoute2)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cfDomain)).To(Succeed())
 		})
 
 		When("multiple CFRoute resources exist", func() {
@@ -182,8 +182,8 @@ var _ = Describe("RouteRepository", func() {
 
 			AfterEach(func() {
 				afterCtx := context.Background()
-				k8sClient.Delete(afterCtx, cfRoute1A)
-				k8sClient.Delete(afterCtx, otherNamespace)
+				Expect(k8sClient.Delete(afterCtx, cfRoute1A)).To(Succeed())
+				Expect(k8sClient.Delete(afterCtx, otherNamespace)).To(Succeed())
 			})
 
 			It("returns an error", func() {
@@ -288,9 +288,9 @@ var _ = Describe("RouteRepository", func() {
 
 			AfterEach(func() {
 				ctx := context.Background()
-				k8sClient.Delete(ctx, cfRoute1)
-				k8sClient.Delete(ctx, cfRoute2)
-				k8sClient.Delete(ctx, cfDomain)
+				Expect(k8sClient.Delete(ctx, cfRoute1)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cfRoute2)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, cfDomain)).To(Succeed())
 			})
 
 			It("eventually returns a list of routeRecords for each CFRoute CR", func() {
@@ -451,8 +451,8 @@ var _ = Describe("RouteRepository", func() {
 
 		AfterEach(func() {
 			ctx := context.Background()
-			k8sClient.Delete(ctx, cfRoute1)
-			k8sClient.Delete(ctx, cfRoute2)
+			Expect(k8sClient.Delete(ctx, cfRoute1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cfRoute2)).To(Succeed())
 		})
 
 		When("multiple CFRoutes exist", func() {

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -96,7 +96,6 @@ var _ = Describe("RouteRepository", func() {
 			}
 			Expect(k8sClient.Create(ctx, cfRoute2)).To(Succeed())
 
-			routeRepo = RouteRepo{}
 			var err error
 			repoClient, err = BuildCRClient(k8sConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -210,7 +209,6 @@ var _ = Describe("RouteRepository", func() {
 		BeforeEach(func() {
 			testCtx = context.Background()
 
-			routeRepo = RouteRepo{}
 			var err error
 			repoClient, err = BuildCRClient(k8sConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -397,7 +395,6 @@ var _ = Describe("RouteRepository", func() {
 		BeforeEach(func() {
 			testCtx = context.Background()
 
-			routeRepo = RouteRepo{}
 			var err error
 			repoClient, err = BuildCRClient(k8sConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -543,8 +540,6 @@ var _ = Describe("RouteRepository", func() {
 			client, err = BuildCRClient(k8sConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			routeRepo = RouteRepo{}
-
 			testCtx = context.Background()
 			testDomainGUID = generateGUID()
 			testRouteGUID = generateGUID()
@@ -639,8 +634,6 @@ var _ = Describe("RouteRepository", func() {
 			var err error
 			client, err = BuildCRClient(k8sConfig)
 			Expect(err).NotTo(HaveOccurred())
-
-			routeRepo = RouteRepo{}
 
 			testCtx = context.Background()
 			testDomainGUID = generateGUID()

--- a/api/repositories/shared_test.go
+++ b/api/repositories/shared_test.go
@@ -1,15 +1,12 @@
 package repositories_test
 
 import (
-	"context"
-
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -98,32 +95,6 @@ func initializeAppCreateMessage(appName string, spaceGUID string) AppCreateMessa
 			},
 		},
 	}
-}
-
-func initializeAppRecord(appName string, appGUID string, spaceGUID string) AppRecord {
-	return AppRecord{
-		Name:      appName,
-		GUID:      appGUID,
-		SpaceGUID: spaceGUID,
-		State:     "STOPPED",
-		Lifecycle: Lifecycle{
-			Type: "buildpack",
-			Data: LifecycleData{
-				Buildpacks: []string{},
-				Stack:      "cflinuxfs3",
-			},
-		},
-	}
-}
-
-func cleanupApp(k8sClient client.Client, ctx context.Context, appGUID, appNamespace string) error {
-	app := workloadsv1alpha1.CFApp{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      appGUID,
-			Namespace: appNamespace,
-		},
-	}
-	return k8sClient.Delete(ctx, &app)
 }
 
 func generateAppEnvSecretName(appGUID string) string {

--- a/api/repositories/upload_source_image.go
+++ b/api/repositories/upload_source_image.go
@@ -27,7 +27,7 @@ func UploadSourceImage(imageRef string, packageSrcFile multipart.File, credentia
 		return "", fmt.Errorf("error from io.Copy: %w", err)
 	}
 
-	if err := tmpFile.Close(); err != nil {
+	if err = tmpFile.Close(); err != nil {
 		return "", fmt.Errorf("error from ioutil.TempFile: %w", err)
 	}
 

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -39,15 +39,7 @@ import (
 	hnsv1alpha2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
-type hierarchicalNamespace struct {
-	label     string
-	createdAt string
-	guid      string
-	children  []hierarchicalNamespace
-}
-
 var (
-	testServerAddress   string
 	k8sClient           client.Client
 	clientset           *kubernetes.Clientset
 	rootNamespace       string
@@ -276,33 +268,6 @@ func createOrgRole(roleName, kind, userName, orgGUID, authHeader string) present
 
 func createSpaceRole(roleName, kind, userName, spaceGUID, authHeader string) presenter.RoleResponse {
 	return createRole(roleName, kind, "space", userName, spaceGUID, authHeader)
-}
-
-func createApp(spaceGUID, name, authHeader string) presenter.AppResponse {
-	appsURL := apiServerRoot + apis.AppCreateEndpoint
-
-	payload := payloads.AppCreate{
-		Name: name,
-		Relationships: payloads.AppRelationships{
-			Space: payloads.Relationship{
-				Data: &payloads.RelationshipData{
-					GUID: spaceGUID,
-				},
-			},
-		},
-	}
-
-	resp, err := httpReq(http.MethodPost, appsURL, authHeader, payload)
-	Expect(err).NotTo(HaveOccurred())
-	defer resp.Body.Close()
-
-	Expect(resp).To(HaveHTTPStatus(http.StatusCreated))
-
-	app := presenter.AppResponse{}
-	err = json.NewDecoder(resp.Body).Decode(&app)
-	Expect(err).NotTo(HaveOccurred())
-
-	return app
 }
 
 func obtainServiceAccountToken(name string) string {

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	hnsv1alpha2.AddToScheme(scheme.Scheme)
+	Expect(hnsv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	config, err := controllerruntime.GetConfig()
 	Expect(err).NotTo(HaveOccurred())

--- a/api/tests/e2e/helpers/fail_handler.go
+++ b/api/tests/e2e/helpers/fail_handler.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -26,10 +26,10 @@ type podContainerDescriptor struct {
 
 func E2EFailHandler(message string, callerSkip ...int) {
 	config, err := controllerruntime.GetConfig()
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	clientset, err := kubernetes.NewForConfig(config)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	printPodsLogs(clientset, []podContainerDescriptor{
 		{
@@ -46,25 +46,25 @@ func E2EFailHandler(message string, callerSkip ...int) {
 		},
 	})
 
-	Fail(message, callerSkip...)
+	ginkgo.Fail(message, callerSkip...)
 }
 
 func printPodsLogs(clientset kubernetes.Interface, podContainerDescriptors []podContainerDescriptor) {
 	for _, desc := range podContainerDescriptors {
 		pods, err := getPods(clientset, desc.Namespace, desc.LabelKey, desc.LabelValue)
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "Failed to get pods with label %s=%s: %v\n", desc.LabelKey, desc.LabelValue, err)
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get pods with label %s=%s: %v\n", desc.LabelKey, desc.LabelValue, err)
 		}
 
 		for _, pod := range pods {
 			log, err := getSinglePodLog(clientset, pod, desc.Container)
 			if err != nil {
-				fmt.Fprintf(GinkgoWriter, "Failed to get logs for pod %s: %v\n", pod.Name, err)
+				fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get logs for pod %s: %v\n", pod.Name, err)
 
 				continue
 			}
 
-			fmt.Fprintf(GinkgoWriter,
+			fmt.Fprintf(ginkgo.GinkgoWriter,
 				"\n\n===== Logs for pod %q (last %d lines) =====\n%s\n==============================================\n\n",
 				pod.Name,
 				logTailLines,

--- a/api/tests/integration/token_reviewer_test.go
+++ b/api/tests/integration/token_reviewer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("TokenReviewer", func() {
 
 	When("the token is issued for a serviceaccount", func() {
 		BeforeEach(func() {
-			restartEnvTest(authProvider.APIServerExtraArgs("system:serviceaccount:")...)
+			restartEnvTest(authProvider.APIServerExtraArgs("system:serviceaccount:"))
 			token = authProvider.GenerateJWTToken(
 				"my-serviceaccount",
 				"system:serviceaccounts",
@@ -58,7 +58,7 @@ var _ = Describe("TokenReviewer", func() {
 
 	When("the serviceaccount token is malformed", func() {
 		BeforeEach(func() {
-			restartEnvTest(authProvider.APIServerExtraArgs("incorrect-prefix:")...)
+			restartEnvTest(authProvider.APIServerExtraArgs("incorrect-prefix:"))
 			token = authProvider.GenerateJWTToken(
 				"my-serviceaccount",
 				"system:serviceaccounts",

--- a/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
+++ b/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
@@ -63,7 +63,7 @@ var _ = Describe("CFRouteMutatingWebhook Integration Tests", func() {
 
 			Expect(createdCFRoute.ObjectMeta.Labels).To(HaveKeyWithValue(cfDomainLabelKey, cfDomainGUID))
 			Expect(createdCFRoute.ObjectMeta.Labels).To(HaveKeyWithValue(cfRouteLabelKey, cfRouteGUID))
-			k8sClient.Delete(testCtx, cfRoute)
+			Expect(k8sClient.Delete(testCtx, cfRoute)).To(Succeed())
 		})
 	})
 })

--- a/controllers/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
@@ -56,7 +56,7 @@ var _ = Describe("CFAppMutatingWebhook Integration Tests", func() {
 			}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFApp resource does not have any metadata.labels")
 
 			Expect(createdCFApp.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfAppGUID))
-			k8sClient.Delete(testCtx, cfApp)
+			Expect(k8sClient.Delete(testCtx, cfApp)).To(Succeed())
 		})
 	})
 })

--- a/controllers/apis/workloads/v1alpha1/integration/cfbuild_webhook_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/cfbuild_webhook_integration_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CFBuildMutatingWebhook Integration Tests", func() {
 		AfterEach(func() {
 			afterCtx := context.Background()
 			// Cleaning up the created CFBuild resource
-			k8sClient.Delete(afterCtx, cfBuild)
+			Expect(k8sClient.Delete(afterCtx, cfBuild)).To(Succeed())
 		})
 
 		It("should have metadata labels for related resources", func() {

--- a/controllers/apis/workloads/v1alpha1/integration/cfpackage_webhook_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/cfpackage_webhook_integration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("CFPackageMutatingWebhook Integration Tests", func() {
 		})
 
 		AfterEach(func() {
-			k8sClient.Delete(context.Background(), cfApp)
+			Expect(k8sClient.Delete(context.Background(), cfApp)).To(Succeed())
 		})
 
 		When("a CFPackage record referencing the CFAPP is created", func() {
@@ -83,7 +83,7 @@ var _ = Describe("CFPackageMutatingWebhook Integration Tests", func() {
 						Namespace: namespace,
 					},
 				}
-				k8sClient.Delete(context.Background(), cfPackage)
+				Expect(k8sClient.Delete(context.Background(), cfPackage)).To(Succeed())
 			})
 
 			It("should have CFAppGUID metadata label on it and its value should matches spec.appRef", func() {

--- a/controllers/apis/workloads/v1alpha1/integration/cfprocess_webhook_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/cfprocess_webhook_integration_test.go
@@ -63,7 +63,7 @@ var _ = Describe("CFProcessMutatingWebhook Integration Tests", func() {
 					Namespace: namespace,
 				},
 			}
-			k8sClient.Create(context.Background(), matchCFProcess)
+			Expect(k8sClient.Delete(context.Background(), matchCFProcess)).To(Succeed())
 		})
 
 		It("should add the appropriate labels", func() {

--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -447,7 +447,7 @@ func (r *CFRouteReconciler) fetchServicesByMatchingLabels(ctx context.Context, l
 }
 
 func isFinalizing(cfRoute *networkingv1alpha1.CFRoute) bool {
-	return cfRoute.ObjectMeta.DeletionTimestamp != nil && cfRoute.ObjectMeta.DeletionTimestamp.IsZero() == false
+	return cfRoute.ObjectMeta.DeletionTimestamp != nil && !cfRoute.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
 func generateServiceName(destination *networkingv1alpha1.Destination) string {

--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -439,7 +439,7 @@ func (r *CFRouteReconciler) fetchServicesByMatchingLabels(ctx context.Context, l
 	serviceList := corev1.ServiceList{}
 	err = r.Client.List(ctx, &serviceList, &client.ListOptions{LabelSelector: selector, Namespace: namespace})
 	if err != nil {
-		r.Log.Error(err, fmt.Sprintf("Failed to list services"))
+		r.Log.Error(err, "Failed to list services")
 		return nil, err
 	}
 

--- a/controllers/controllers/networking/cfroute_controller.go
+++ b/controllers/controllers/networking/cfroute_controller.go
@@ -81,9 +81,9 @@ func (r *CFRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		description := "Error adding finalizer"
 		r.Log.Error(err, description)
 		errMsg := fmt.Sprintf("%v", err)
-		if err := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, description, "AddFinalizer", errMsg); err != nil {
-			r.Log.Error(err, "Error when updating CFRoute status")
-			return ctrl.Result{}, err
+		if statusErr := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, description, "AddFinalizer", errMsg); statusErr != nil {
+			r.Log.Error(statusErr, "Error when updating CFRoute status")
+			return ctrl.Result{}, statusErr
 		}
 		return ctrl.Result{}, err
 	}
@@ -141,9 +141,9 @@ func (r *CFRouteReconciler) setRouteStatus(ctx context.Context, cfRoute *network
 func (r *CFRouteReconciler) setRouteErrorStatusAndReturn(ctx context.Context, cfRoute *networkingv1alpha1.CFRoute, err error, description, reason string) (ctrl.Result, error) {
 	r.Log.Error(err, description)
 	errMsg := fmt.Sprintf("%v", err)
-	if err := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, description, reason, errMsg); err != nil {
-		r.Log.Error(err, "Error when updating CFRoute status")
-		return ctrl.Result{}, err
+	if statusErr := r.setRouteStatus(ctx, cfRoute, networkingv1alpha1.InvalidStatus, description, reason, errMsg); statusErr != nil {
+		r.Log.Error(statusErr, "Error when updating CFRoute status")
+		return ctrl.Result{}, statusErr
 	}
 	return ctrl.Result{}, err
 }

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -138,18 +138,18 @@ var _ = Describe("CFRouteReconciler.Reconcile", func() {
 		updateCFRouteStatusError = nil
 
 		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object) error {
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *networkingv1alpha1.CFDomain:
-				cfDomain.DeepCopyInto(obj.(*networkingv1alpha1.CFDomain))
+				cfDomain.DeepCopyInto(obj)
 				return getDomainError
 			case *networkingv1alpha1.CFRoute:
-				cfRoute.DeepCopyInto(obj.(*networkingv1alpha1.CFRoute))
+				cfRoute.DeepCopyInto(obj)
 				return getRouteError
 			case *contourv1.HTTPProxy:
 				if obj.GetName() == testFQDN {
-					fqdnHTTPProxy.DeepCopyInto(obj.(*contourv1.HTTPProxy))
+					fqdnHTTPProxy.DeepCopyInto(obj)
 				} else {
-					routeHTTPProxy.DeepCopyInto(obj.(*contourv1.HTTPProxy))
+					routeHTTPProxy.DeepCopyInto(obj)
 				}
 				return getHTTPProxyError
 			case *v1.Service:
@@ -160,12 +160,12 @@ var _ = Describe("CFRouteReconciler.Reconcile", func() {
 		}
 
 		fakeClient.ListStub = func(ctx context.Context, list client.ObjectList, option ...client.ListOption) error {
-			switch list.(type) {
+			switch list := list.(type) {
 			case *contourv1.HTTPProxyList:
-				httpProxyList.DeepCopyInto(list.(*contourv1.HTTPProxyList))
+				httpProxyList.DeepCopyInto(list)
 				return listHTTPProxiesError
 			case *v1.ServiceList:
-				serviceList.DeepCopyInto(list.(*v1.ServiceList))
+				serviceList.DeepCopyInto(list)
 				return listServicesError
 			default:
 				panic("TestClient List provided an unexpected object type")

--- a/controllers/controllers/networking/cfroute_controller_test.go
+++ b/controllers/controllers/networking/cfroute_controller_test.go
@@ -33,7 +33,6 @@ const (
 	testRouteHost            = "test-route-host"
 	testRouteDestinationGUID = "test-route-destination-guid"
 	testFQDN                 = testRouteHost + "." + testDomainName
-	testHTTPProxyName        = "test-httpproxy-name"
 	testServiceGUID          = "s-" + testRouteDestinationGUID
 	routeGUIDLabelKey        = "networking.cloudfoundry.org/route-guid"
 )

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -70,12 +70,12 @@ var _ = Describe("CFAppReconciler", func() {
 
 		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object) error {
 			// cast obj to find its kind
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *workloadsv1alpha1.CFBuild:
-				cfBuild.DeepCopyInto(obj.(*workloadsv1alpha1.CFBuild))
+				cfBuild.DeepCopyInto(obj)
 				return cfBuildError
 			case *workloadsv1alpha1.CFApp:
-				cfApp.DeepCopyInto(obj.(*workloadsv1alpha1.CFApp))
+				cfApp.DeepCopyInto(obj)
 				return cfAppError
 			default:
 				panic("TestClient Get provided a weird obj")

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -162,7 +162,7 @@ func (r *CFBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			failureStatusConditionMessage := r.concatenateStrings(":", kpackReadyStatusCondition.Reason, kpackReadyStatusCondition.Message)
 			setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.StagingConditionType, metav1.ConditionFalse, "kpack", "kpack")
 			setStatusConditionOnLocalCopy(&cfBuild.Status.Conditions, workloadsv1alpha1.SucceededConditionType, metav1.ConditionFalse, "kpack", failureStatusConditionMessage)
-			if err := r.Client.Status().Update(ctx, &cfBuild); err != nil {
+			if err = r.Client.Status().Update(ctx, &cfBuild); err != nil {
 				r.Log.Error(err, "Error when updating CFBuild status")
 				return ctrl.Result{}, err
 			}

--- a/controllers/controllers/workloads/cfbuild_controller_test.go
+++ b/controllers/controllers/workloads/cfbuild_controller_test.go
@@ -29,7 +29,6 @@ var _ = Describe("CFBuildReconciler", func() {
 	const (
 		defaultNamespace        = "default"
 		stagingConditionType    = "Staging"
-		readyConditionType      = "Ready"
 		succeededConditionType  = "Succeeded"
 		kpackReadyConditionType = "Ready"
 	)

--- a/controllers/controllers/workloads/cfprocess_controller_test.go
+++ b/controllers/controllers/workloads/cfprocess_controller_test.go
@@ -70,20 +70,20 @@ var _ = Describe("CFRouteReconciler Unit Tests", func() {
 
 		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object) error {
 			// cast obj to find its kind
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *workloadsv1alpha1.CFProcess:
-				cfProcess.DeepCopyInto(obj.(*workloadsv1alpha1.CFProcess))
+				cfProcess.DeepCopyInto(obj)
 				return cfProcessError
 			case *workloadsv1alpha1.CFBuild:
-				cfBuild.DeepCopyInto(obj.(*workloadsv1alpha1.CFBuild))
+				cfBuild.DeepCopyInto(obj)
 				return cfBuildError
 			case *workloadsv1alpha1.CFApp:
-				cfApp.DeepCopyInto(obj.(*workloadsv1alpha1.CFApp))
+				cfApp.DeepCopyInto(obj)
 				return cfAppError
 			case *corev1.Secret:
 				return appEnvSecretError
 			case *eiriniv1.LRP:
-				lrp.DeepCopyInto(obj.(*eiriniv1.LRP))
+				lrp.DeepCopyInto(obj)
 				return lrpError
 			default:
 				panic("TestClient Get provided a weird obj")

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -29,7 +29,7 @@ var _ = Describe("CFAppReconciler", func() {
 	})
 
 	AfterEach(func() {
-		k8sClient.Delete(context.Background(), ns)
+		Expect(k8sClient.Delete(context.Background(), ns)).To(Succeed())
 	})
 
 	When("a new CFApp resource is created", func() {

--- a/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
@@ -86,7 +86,7 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 	})
 
 	AfterEach(func() {
-		k8sClient.Delete(context.Background(), ns)
+		Expect(k8sClient.Delete(context.Background(), ns)).To(Succeed())
 	})
 
 	When("the CFApp desired state is STARTED", func() {

--- a/scripts/check-everything.sh
+++ b/scripts/check-everything.sh
@@ -17,7 +17,8 @@ print_message() {
 main() {
   print_message "about to run tests in parallel, it will be awesome" $GREEN
   print_message "ctrl-d panes when they are done" $RED
-  tmux new-window -n cf-k8s-tests "/bin/bash -c \"make test-controllers-api; bash --init-file <(echo 'history -s make test-controllers-api')\""
+  tmux new-window -n cf-k8s-tests "/bin/bash -c \"make lint; bash --init-file <(echo 'history -s make lint')\""
+  tmux split-window -h -p 66 "/bin/bash -c \"make test-controllers-api; bash --init-file <(echo 'history -s make test-controllers-api')\""
   tmux split-window -h -p 50 "/bin/bash -c \"make test-e2e; bash --init-file <(echo 'history -s make test-e2e')\""
 }
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#144 

## What is this change about?
It adds:
* configuration for [golangci-lint](https://golangci-lint.run/)
* a make target (`make lint`)
*  an additional split in the check-everything script
* a job in the GitHub Actions workflows
* various fixes around the code to make it green

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run `make lint` and see that there are no issues.

## Tag your pair, your PM, and/or team
@danail-branekov 