### PR TITLE
Only list apps the user has access to

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gorilla/schema"
-
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
+	"github.com/go-http-utils/headers"
+	"github.com/gorilla/schema"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
@@ -103,9 +103,7 @@ func (h *AppHandler) appGetHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -147,9 +145,7 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client")
 		writeUnknownErrorResponse(w)
@@ -231,9 +227,7 @@ func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client")
 		writeUnknownErrorResponse(w)
@@ -270,9 +264,7 @@ func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client")
 		writeUnknownErrorResponse(w)
@@ -335,8 +327,7 @@ func (h *AppHandler) appGetCurrentDropletHandler(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client")
 		writeUnknownErrorResponse(w)
@@ -391,9 +382,7 @@ func (h *AppHandler) appStartHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -447,9 +436,7 @@ func (h *AppHandler) appStopHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -498,9 +485,7 @@ func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Re
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -545,9 +530,7 @@ func (h *AppHandler) getRoutesForAppHandler(w http.ResponseWriter, r *http.Reque
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -600,9 +583,7 @@ func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
@@ -641,9 +622,7 @@ func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"k8s.io/client-go/rest"
@@ -61,9 +62,7 @@ func (h *BuildHandler) buildGetHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	buildGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "BuildGUID", buildGUID)
 		writeUnknownErrorResponse(w)
@@ -103,7 +102,7 @@ func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, req.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)

--- a/api/apis/domain_handler.go
+++ b/api/apis/domain_handler.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
@@ -87,9 +88,7 @@ func (h *DomainHandler) DomainListHandler(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client")
 		writeUnknownErrorResponse(w)

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"k8s.io/client-go/rest"
@@ -55,9 +56,7 @@ func (h *DropletHandler) dropletGetHandler(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	dropletGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "dropletGUID", dropletGUID)
 		writeUnknownErrorResponse(w)

--- a/api/apis/fake/client_builder.go
+++ b/api/apis/fake/client_builder.go
@@ -10,10 +10,11 @@ import (
 )
 
 type ClientBuilder struct {
-	Stub        func(*rest.Config) (client.Client, error)
+	Stub        func(*rest.Config, string) (client.Client, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 *rest.Config
+		arg2 string
 	}
 	returns struct {
 		result1 client.Client
@@ -27,18 +28,19 @@ type ClientBuilder struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ClientBuilder) Spy(arg1 *rest.Config) (client.Client, error) {
+func (fake *ClientBuilder) Spy(arg1 *rest.Config, arg2 string) (client.Client, error) {
 	fake.mutex.Lock()
 	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 *rest.Config
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.Stub
 	returns := fake.returns
-	fake.recordInvocation("ClientBuilder", []interface{}{arg1})
+	fake.recordInvocation("ClientBuilder", []interface{}{arg1, arg2})
 	fake.mutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -52,16 +54,16 @@ func (fake *ClientBuilder) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *ClientBuilder) Calls(stub func(*rest.Config) (client.Client, error)) {
+func (fake *ClientBuilder) Calls(stub func(*rest.Config, string) (client.Client, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *ClientBuilder) ArgsForCall(i int) *rest.Config {
+func (fake *ClientBuilder) ArgsForCall(i int) (*rest.Config, string) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
-	return fake.argsForCall[i].arg1
+	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2
 }
 
 func (fake *ClientBuilder) Returns(result1 client.Client, result2 error) {

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -26,14 +26,17 @@ import (
 
 var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint", func() {
 	BeforeEach(func() {
-		appRepo := new(repositories.AppRepo)
-		processRepo := new(repositories.ProcessRepo)
+		client, err := repositories.BuildPrivilegedClient(k8sConfig, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		appRepo := repositories.NewAppRepo(client)
+		processRepo := repositories.NewProcessRepo(client)
 		apiHandler := NewSpaceManifestHandler(
 			logf.Log.WithName("integration tests"),
 			*serverURL,
 			actions.NewApplyManifest(appRepo, processRepo).Invoke,
 			repositories.NewOrgRepo("cf", k8sClient, 1*time.Minute),
-			repositories.BuildCRClient,
+			repositories.BuildPrivilegedClient,
 			k8sConfig,
 		)
 		apiHandler.RegisterRoutes(router)

--- a/api/apis/integration/create_app_test.go
+++ b/api/apis/integration/create_app_test.go
@@ -25,12 +25,15 @@ import (
 
 var _ = Describe("POST /v3/apps endpoint", func() {
 	BeforeEach(func() {
-		appRepo := new(repositories.AppRepo)
-		dropletRepo := new(repositories.DropletRepo)
-		processRepo := new(repositories.ProcessRepo)
-		routeRepo := new(repositories.RouteRepo)
-		domainRepo := new(repositories.DomainRepo)
-		podRepo := new(repositories.PodRepo)
+		client, err := repositories.BuildPrivilegedClient(k8sConfig, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		appRepo := repositories.NewAppRepo(client)
+		dropletRepo := repositories.NewDropletRepo(client)
+		processRepo := repositories.NewProcessRepo(client)
+		routeRepo := repositories.NewRouteRepo(client)
+		domainRepo := repositories.NewDomainRepo(client)
+		podRepo := repositories.NewPodRepo(client)
 		scaleProcess := actions.NewScaleProcess(processRepo).Invoke
 		scaleAppProcess := actions.NewScaleAppProcess(appRepo, processRepo, scaleProcess).Invoke
 
@@ -44,7 +47,7 @@ var _ = Describe("POST /v3/apps endpoint", func() {
 			domainRepo,
 			podRepo,
 			scaleAppProcess,
-			repositories.BuildCRClient,
+			repositories.BuildPrivilegedClient,
 			k8sConfig,
 		)
 		apiHandler.RegisterRoutes(router)

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/gorilla/mux"
@@ -83,7 +84,7 @@ func NewPackageHandler(
 func (h PackageHandler) packageGetHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, req.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)
@@ -122,7 +123,7 @@ func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, req.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)
@@ -177,7 +178,7 @@ func (h PackageHandler) packageUploadHandler(w http.ResponseWriter, req *http.Re
 	}
 	defer bitsFile.Close()
 
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, req.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Info("Error building k8s client", "error", err.Error())
 		writeUnknownErrorResponse(w)

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"k8s.io/client-go/rest"
@@ -78,7 +79,7 @@ func (h *ProcessHandler) processGetHandler(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	processGUID := vars["guid"]
 
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)
@@ -108,9 +109,7 @@ func (h *ProcessHandler) processGetSidecarsHandler(w http.ResponseWriter, r *htt
 	vars := mux.Vars(r)
 	processGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)
@@ -154,9 +153,7 @@ func (h *ProcessHandler) processScaleHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)
@@ -194,9 +191,7 @@ func (h *ProcessHandler) processGetStatsHandler(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 	processGUID := vars["guid"]
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		h.logger.Error(err, "Unable to create Kubernetes client", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)

--- a/api/apis/shared.go
+++ b/api/apis/shared.go
@@ -25,7 +25,8 @@ import (
 var Logger = ctrl.Log.WithName("Shared Handler Functions")
 
 //counterfeiter:generate -o fake -fake-name ClientBuilder . ClientBuilder
-type ClientBuilder func(*rest.Config) (client.Client, error)
+
+type ClientBuilder func(cfg *rest.Config, authHeader string) (client.Client, error)
 
 type requestMalformedError struct {
 	httpStatus    int

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v3"
@@ -67,9 +68,7 @@ func (h *SpaceManifestHandler) applyManifestHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// TODO: Instantiate config based on bearer token
-	// Spike code from EMEA folks around this: https://github.com/cloudfoundry/cf-crd-explorations/blob/136417fbff507eb13c92cd67e6fed6b061071941/cfshim/handlers/app_handler.go#L78
-	client, err := h.buildClient(h.k8sConfig)
+	client, err := h.buildClient(h.k8sConfig, r.Header.Get(headers.Authorization))
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		h.logger.Error(err, "Unable to create Kubernetes client")

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -27,9 +27,9 @@ var _ = Describe("AppRepository", func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 
-		appRepo = new(AppRepo)
 		var err error
-		testClient, err = BuildCRClient(k8sConfig)
+		testClient, err = BuildPrivilegedClient(k8sConfig, "")
+		appRepo = NewAppRepo(testClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/api/repositories/authorization/identity_provider.go
+++ b/api/repositories/authorization/identity_provider.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	bearerScheme string = "bearer"
-	certScheme   string = "clientcert"
+	BearerScheme string = "bearer"
+	CertScheme   string = "clientcert"
 )
 
 //counterfeiter:generate -o fake -fake-name IdentityInspector . IdentityInspector
@@ -46,9 +46,9 @@ func (p *IdentityProvider) GetIdentity(ctx context.Context, authorizationHeader 
 	}
 
 	switch strings.ToLower(scheme) {
-	case bearerScheme:
+	case BearerScheme:
 		return p.tokenInspector.WhoAmI(ctx, value)
-	case certScheme:
+	case CertScheme:
 		return p.certInspector.WhoAmI(ctx, value)
 	default:
 		return Identity{}, fmt.Errorf("unsupported authentication scheme %q", scheme)

--- a/api/repositories/authorization/org.go
+++ b/api/repositories/authorization/org.go
@@ -11,12 +11,12 @@ import (
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=list
 
 type Org struct {
-	k8sClient client.Client
+	privilegedClient client.Client
 }
 
-func NewOrg(k8sClient client.Client) *Org {
+func NewOrg(privilegedClient client.Client) *Org {
 	return &Org{
-		k8sClient: k8sClient,
+		privilegedClient: privilegedClient,
 	}
 }
 
@@ -24,7 +24,7 @@ func (o *Org) GetAuthorizedNamespaces(ctx context.Context, identity Identity) ([
 	var authorizedNamespaces []string
 
 	var rolebindings rbacv1.RoleBindingList
-	err := o.k8sClient.List(ctx, &rolebindings)
+	err := o.privilegedClient.List(ctx, &rolebindings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list rolebindings: %w", err)
 	}
@@ -46,7 +46,7 @@ func (o *Org) GetAuthorizedNamespaces(ctx context.Context, identity Identity) ([
 
 func (o *Org) AuthorizedIn(ctx context.Context, identity Identity, namespace string) (bool, error) {
 	var rolebindings rbacv1.RoleBindingList
-	err := o.k8sClient.List(ctx, &rolebindings, client.InNamespace(namespace))
+	err := o.privilegedClient.List(ctx, &rolebindings, client.InNamespace(namespace))
 	if err != nil {
 		return false, fmt.Errorf("failed to list rolebindings: %w", err)
 	}

--- a/api/repositories/authorization/token_reviewer.go
+++ b/api/repositories/authorization/token_reviewer.go
@@ -21,11 +21,11 @@ const (
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 
 type tokenReviewer struct {
-	client client.Client
+	privilegedClient client.Client
 }
 
-func NewTokenReviewer(client client.Client) IdentityInspector {
-	return &tokenReviewer{client: client}
+func NewTokenReviewer(privilegedClient client.Client) IdentityInspector {
+	return &tokenReviewer{privilegedClient: privilegedClient}
 }
 
 func (r *tokenReviewer) WhoAmI(ctx context.Context, token string) (Identity, error) {
@@ -37,7 +37,7 @@ func (r *tokenReviewer) WhoAmI(ctx context.Context, token string) (Identity, err
 			Token: token,
 		},
 	}
-	err := r.client.Create(ctx, tokenReview)
+	err := r.privilegedClient.Create(ctx, tokenReview)
 	if err != nil {
 		return Identity{}, fmt.Errorf("failed to create token review: %w", err)
 	}

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -47,10 +47,11 @@ var _ = Describe("BuildRepository", func() {
 			namespace2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace2Name}}
 			Expect(k8sClient.Create(context.Background(), namespace2)).To(Succeed())
 
-			buildRepo = new(BuildRepo)
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			buildRepo = NewBuildRepo(client)
 		})
 
 		AfterEach(func() {
@@ -349,6 +350,7 @@ var _ = Describe("BuildRepository", func() {
 			})
 		})
 	})
+
 	Describe("CreateBuild", func() {
 		const (
 			appGUID     = "the-app-guid"
@@ -373,11 +375,11 @@ var _ = Describe("BuildRepository", func() {
 		)
 
 		BeforeEach(func() {
-			buildRepo = new(BuildRepo)
-
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			buildRepo = NewBuildRepo(client)
 
 			beforeCtx := context.Background()
 			spaceGUID = generateGUID()

--- a/api/repositories/configure_client.go
+++ b/api/repositories/configure_client.go
@@ -1,6 +1,14 @@
 package repositories
 
 import (
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories/authorization"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -11,6 +19,64 @@ func BuildK8sClient(config *rest.Config) (k8sclient.Interface, error) {
 	return k8sclient.NewForConfig(config)
 }
 
-func BuildCRClient(config *rest.Config) (crclient.Client, error) {
+func BuildPrivilegedClient(config *rest.Config, _ string) (crclient.Client, error) {
 	return crclient.New(config, crclient.Options{Scheme: scheme.Scheme})
+}
+
+func BuildUserClient(config *rest.Config, authorizationHeader string) (crclient.Client, error) {
+	if authorizationHeader == "" {
+		return nil, authorization.NotAuthenticatedError{}
+	}
+
+	scheme, value, err := parseAuthorizationHeader(authorizationHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	config = rest.AnonymousClientConfig(config)
+
+	switch strings.ToLower(scheme) {
+	case authorization.BearerScheme:
+		config.BearerToken = value
+	case authorization.CertScheme:
+		pemBytes, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to base64 decode auth header")
+		}
+		certBlock, rst := pem.Decode(pemBytes)
+		if certBlock == nil {
+			return nil, fmt.Errorf("failed to decode cert PEM")
+		}
+
+		keyBlock, _ := pem.Decode(rst)
+		if keyBlock == nil {
+			return nil, fmt.Errorf("failed to decode key PEM")
+		}
+
+		config.CertData = pem.EncodeToMemory(certBlock)
+		config.KeyData = pem.EncodeToMemory(keyBlock)
+	default:
+		return nil, fmt.Errorf("unknown auth header scheme %q", scheme)
+	}
+
+	// This does an API call within the controller-runtime code and is
+	// sufficient to determine whether the auth is valid and accepted by the
+	// cluster
+	userClient, err := crclient.New(config, crclient.Options{})
+	if err != nil {
+		if apierrors.IsUnauthorized(err) {
+			return nil, authorization.InvalidAuthError{}
+		}
+		return nil, err
+	}
+
+	return userClient, nil
+}
+
+func parseAuthorizationHeader(headerValue string) (string, string, error) {
+	values := strings.Split(headerValue, " ")
+	if len(values) != 2 {
+		return "", "", errors.New("failed to parse authorization header")
+	}
+	return values[0], values[1], nil
 }

--- a/api/repositories/configure_client.go
+++ b/api/repositories/configure_client.go
@@ -39,8 +39,8 @@ func BuildUserClient(config *rest.Config, authorizationHeader string) (crclient.
 	case authorization.BearerScheme:
 		config.BearerToken = value
 	case authorization.CertScheme:
-		pemBytes, err := base64.StdEncoding.DecodeString(value)
-		if err != nil {
+		pemBytes, decodeErr := base64.StdEncoding.DecodeString(value)
+		if decodeErr != nil {
 			return nil, fmt.Errorf("failed to base64 decode auth header")
 		}
 		certBlock, rst := pem.Decode(pemBytes)

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -53,9 +53,10 @@ var _ = Describe("DomainRepository", func() {
 			})
 
 			It("fetches the CFDomain CR we're looking for", func() {
-				domainRepo := DomainRepo{}
-				client, err := BuildCRClient(k8sConfig)
+				client, err := BuildPrivilegedClient(k8sConfig, "")
 				Expect(err).ToNot(HaveOccurred())
+
+				domainRepo := NewDomainRepo(client)
 
 				var domain DomainRecord
 				domain, err = domainRepo.FetchDomain(testCtx, client, "domain-id-1")
@@ -74,9 +75,10 @@ var _ = Describe("DomainRepository", func() {
 
 		When("no CFDomain exists", func() {
 			It("returns an error", func() {
-				domainRepo := DomainRepo{}
-				client, err := BuildCRClient(k8sConfig)
+				client, err := BuildPrivilegedClient(k8sConfig, "")
 				Expect(err).ToNot(HaveOccurred())
+
+				domainRepo := NewDomainRepo(client)
 
 				_, err = domainRepo.FetchDomain(testCtx, client, "non-existent-domain-guid")
 				Expect(err).To(MatchError("Resource not found or permission denied."))
@@ -88,7 +90,7 @@ var _ = Describe("DomainRepository", func() {
 		var (
 			testCtx context.Context
 
-			domainRepo        DomainRepo
+			domainRepo        *DomainRepo
 			domainClient      client.Client
 			domainListMessage DomainListMessage
 		)
@@ -98,8 +100,10 @@ var _ = Describe("DomainRepository", func() {
 
 			domainListMessage = DomainListMessage{}
 			var err error
-			domainClient, err = BuildCRClient(k8sConfig)
+			domainClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			domainRepo = NewDomainRepo(domainClient)
 		})
 
 		When("multiple CFDomain exists and no filter is provided", func() {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -28,11 +28,17 @@ type DropletRecord struct {
 	Annotations     map[string]string
 }
 
-type DropletRepo struct{}
+type DropletRepo struct {
+	privilegedClient client.Client
+}
 
-func (r *DropletRepo) FetchDroplet(ctx context.Context, k8sClient client.Client, dropletGUID string) (DropletRecord, error) {
+func NewDropletRepo(privilegedClient client.Client) *DropletRepo {
+	return &DropletRepo{privilegedClient: privilegedClient}
+}
+
+func (r *DropletRepo) FetchDroplet(ctx context.Context, userClient client.Client, dropletGUID string) (DropletRecord, error) {
 	buildList := &workloadsv1alpha1.CFBuildList{}
-	err := k8sClient.List(ctx, buildList)
+	err := r.privilegedClient.List(ctx, buildList)
 	if err != nil { // untested
 		return DropletRecord{}, err
 	}

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -42,11 +42,11 @@ var _ = Describe("DropletRepository", func() {
 			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
 			Expect(k8sClient.Create(testCtx, namespace)).To(Succeed())
 
-			dropletRepo = new(DropletRepo)
-
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			dropletRepo = NewDropletRepo(client)
 
 			buildGUID = generateGUID()
 			build = &workloadsv1alpha1.CFBuild{

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -30,11 +30,11 @@ var _ = Describe("PackageRepository", func() {
 		)
 
 		BeforeEach(func() {
-			packageRepo = new(PackageRepo)
-
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			packageRepo = NewPackageRepo(client)
 
 			packageCreate = PackageCreateMessage{
 				Type:      "bits",
@@ -110,10 +110,11 @@ var _ = Describe("PackageRepository", func() {
 			namespace2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace2Name}}
 			Expect(k8sClient.Create(context.Background(), namespace2)).To(Succeed())
 
-			packageRepo = new(PackageRepo)
 			var err error
-			testClient, err = BuildCRClient(k8sConfig)
+			testClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			packageRepo = NewPackageRepo(testClient)
 		})
 
 		AfterEach(func() {
@@ -314,12 +315,13 @@ var _ = Describe("PackageRepository", func() {
 
 		BeforeEach(func() {
 			spaceGUID = generateGUID()
-			packageRepo = new(PackageRepo)
 			ctx := context.Background()
 
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			packageRepo = NewPackageRepo(client)
 
 			existingCFPackage = workloadsv1alpha1.CFPackage{
 				TypeMeta: metav1.TypeMeta{

--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -38,11 +38,12 @@ var _ = Describe("PodRepository", func() {
 
 		BeforeEach(func() {
 			spaceGUID = uuid.NewString()
-			podRepo = new(PodRepo)
 
 			var err error
-			testClient, err = BuildCRClient(k8sConfig)
+			testClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			podRepo = NewPodRepo(testClient)
 
 			ctx = context.Background()
 			Expect(
@@ -225,11 +226,12 @@ var _ = Describe("PodRepository", func() {
 
 		BeforeEach(func() {
 			spaceGUID = uuid.NewString()
-			podRepo = new(PodRepo)
 
 			var err error
-			testClient, err = BuildCRClient(k8sConfig)
+			testClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			podRepo = NewPodRepo(testClient)
 
 			ctx = context.Background()
 			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -28,10 +28,11 @@ var _ = Describe("ProcessRepo", func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 
-		processRepo = new(ProcessRepo)
 		var err error
-		testClient, err = BuildCRClient(k8sConfig)
+		testClient, err = BuildPrivilegedClient(k8sConfig, "")
 		Expect(err).ToNot(HaveOccurred())
+
+		processRepo = NewProcessRepo(testClient)
 
 		namespaceName := generateGUID()
 		namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -30,7 +30,7 @@ var _ = Describe("RouteRepository", func() {
 			cfRoute2 *networkingv1alpha1.CFRoute
 			cfDomain *networkingv1alpha1.CFDomain
 
-			routeRepo  RouteRepo
+			routeRepo  *RouteRepo
 			repoClient client.Client
 		)
 
@@ -96,8 +96,10 @@ var _ = Describe("RouteRepository", func() {
 			Expect(k8sClient.Create(ctx, cfRoute2)).To(Succeed())
 
 			var err error
-			repoClient, err = BuildCRClient(k8sConfig)
+			repoClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			routeRepo = NewRouteRepo(repoClient)
 		})
 
 		AfterEach(func() {
@@ -201,7 +203,7 @@ var _ = Describe("RouteRepository", func() {
 		var (
 			testCtx context.Context
 
-			routeRepo  RouteRepo
+			routeRepo  *RouteRepo
 			repoClient client.Client
 		)
 
@@ -209,8 +211,10 @@ var _ = Describe("RouteRepository", func() {
 			testCtx = context.Background()
 
 			var err error
-			repoClient, err = BuildCRClient(k8sConfig)
+			repoClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			routeRepo = NewRouteRepo(repoClient)
 		})
 
 		When("multiple CFRoutes exist", func() {
@@ -379,7 +383,7 @@ var _ = Describe("RouteRepository", func() {
 		var (
 			testCtx context.Context
 
-			routeRepo  RouteRepo
+			routeRepo  *RouteRepo
 			repoClient client.Client
 
 			appGUID    string
@@ -395,8 +399,10 @@ var _ = Describe("RouteRepository", func() {
 			testCtx = context.Background()
 
 			var err error
-			repoClient, err = BuildCRClient(k8sConfig)
+			repoClient, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).ToNot(HaveOccurred())
+
+			routeRepo = NewRouteRepo(repoClient)
 
 			appGUID = generateGUID()
 			route1GUID = generateGUID()
@@ -527,7 +533,7 @@ var _ = Describe("RouteRepository", func() {
 
 		var (
 			client         client.Client
-			routeRepo      RouteRepo
+			routeRepo      *RouteRepo
 			testCtx        context.Context
 			cfDomain       *networkingv1alpha1.CFDomain
 			testDomainGUID string
@@ -536,8 +542,10 @@ var _ = Describe("RouteRepository", func() {
 
 		BeforeEach(func() {
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			routeRepo = NewRouteRepo(client)
 
 			testCtx = context.Background()
 			testDomainGUID = generateGUID()
@@ -624,15 +632,17 @@ var _ = Describe("RouteRepository", func() {
 			testRouteGUID  string
 			testNamespace  string
 			client         client.Client
-			routeRepo      RouteRepo
+			routeRepo      *RouteRepo
 			testCtx        context.Context
 			newNamespace   *corev1.Namespace
 		)
 
 		BeforeEach(func() {
 			var err error
-			client, err = BuildCRClient(k8sConfig)
+			client, err = BuildPrivilegedClient(k8sConfig, "")
 			Expect(err).NotTo(HaveOccurred())
+
+			routeRepo = NewRouteRepo(client)
 
 			testCtx = context.Background()
 			testDomainGUID = generateGUID()

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -1,0 +1,82 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
+	"github.com/go-http-utils/headers"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+var _ = Describe("Listing Apps", func() {
+	var (
+		org                                presenter.OrgResponse
+		space1, space2, space3             presenter.SpaceResponse
+		app1, app2, app3, app4, app5, app6 presenter.AppResponse
+	)
+
+	BeforeEach(func() {
+		org = createOrg(uuid.NewString(), tokenAuthHeader)
+		createOrgRole("organization_user", rbacv1.UserKind, certUserName, org.GUID, tokenAuthHeader)
+
+		space1 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
+		space2 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
+		space3 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
+
+		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
+		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, tokenAuthHeader)
+
+		app1 = createApp(space1.GUID, uuid.NewString(), tokenAuthHeader)
+		app2 = createApp(space1.GUID, uuid.NewString(), tokenAuthHeader)
+		app3 = createApp(space2.GUID, uuid.NewString(), tokenAuthHeader)
+		app4 = createApp(space2.GUID, uuid.NewString(), tokenAuthHeader)
+		app5 = createApp(space3.GUID, uuid.NewString(), tokenAuthHeader)
+		app6 = createApp(space3.GUID, uuid.NewString(), tokenAuthHeader)
+
+		_, _ = app3, app4
+	})
+
+	AfterEach(func() {
+		deleteSubnamespace(org.GUID, space1.GUID)
+		deleteSubnamespace(org.GUID, space2.GUID)
+		deleteSubnamespace(org.GUID, space3.GUID)
+		deleteSubnamespace(rootNamespace, org.GUID)
+	})
+
+	It("returns apps only in authorized spaces", func() {
+		apps := listApps(certAuthHeader)
+		appNames := []string{}
+
+		for _, app := range apps.Resources {
+			appNames = append(appNames, app.Name)
+		}
+
+		Expect(appNames).To(ConsistOf(app1.Name, app2.Name, app5.Name, app6.Name))
+	})
+})
+
+func listApps(authHeader string) presenter.AppListResponse {
+	appsURL := apiServerRoot + apis.AppListEndpoint
+
+	req, err := http.NewRequest(http.MethodGet, appsURL, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	req.Header.Add(headers.Authorization, authHeader)
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+
+	apps := presenter.AppListResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&apps)
+	Expect(err).NotTo(HaveOccurred())
+
+	return apps
+}

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -399,3 +399,30 @@ func httpReq(method, url, authHeader string, jsonBody interface{}) (*http.Respon
 
 	return resp, nil
 }
+
+func createApp(spaceGUID, name, authHeader string) presenter.AppResponse {
+	appsURL := apiServerRoot + apis.AppCreateEndpoint
+
+	payload := payloads.AppCreate{
+		Name: name,
+		Relationships: payloads.AppRelationships{
+			Space: payloads.Relationship{
+				Data: &payloads.RelationshipData{
+					GUID: spaceGUID,
+				},
+			},
+		},
+	}
+
+	resp, err := httpReq(http.MethodPost, appsURL, authHeader, payload)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	Expect(resp).To(HaveHTTPStatus(http.StatusCreated))
+
+	app := presenter.AppResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&app)
+	Expect(err).NotTo(HaveOccurred())
+
+	return app
+}

--- a/api/tests/integration/build_user_client_test.go
+++ b/api/tests/integration/build_user_client_test.go
@@ -1,0 +1,167 @@
+package integration_test
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories/authorization"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("BuildUserClient", func() {
+	var (
+		userClient     client.Client
+		buildClientErr error
+		authHeader     string
+		ctx            context.Context
+		userName       string
+	)
+
+	BeforeEach(func() {
+		authHeader = ""
+		ctx = context.Background()
+		userName = uuid.NewString()
+	})
+
+	JustBeforeEach(func() {
+		userClient, buildClientErr = repositories.BuildUserClient(k8sConfig, authHeader)
+	})
+
+	Describe("using the client", func() {
+		var podListErr error
+
+		allowListingPods := func(user string) {
+			listPodClusterRole := rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userName + "-list-pods",
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						Verbs:     []string{"list"},
+						APIGroups: []string{""},
+						Resources: []string{"pods"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &listPodClusterRole)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: userName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind: rbacv1.UserKind,
+						Name: user,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     listPodClusterRole.Name,
+				},
+			})).To(Succeed())
+		}
+
+		JustBeforeEach(func() {
+			Expect(buildClientErr).NotTo(HaveOccurred())
+
+			podList := &corev1.PodList{}
+			podListErr = userClient.List(ctx, podList)
+		})
+
+		Context("certificates", func() {
+			BeforeEach(func() {
+				cert, key := obtainClientCert(userName)
+				authHeader = "clientcert " + encodeCertAndKey(cert, key)
+			})
+
+			It("succeeds and forbids access to the user", func() {
+				Expect(buildClientErr).NotTo(HaveOccurred())
+				Expect(apierrors.IsForbidden(podListErr)).To(BeTrue())
+			})
+
+			When("a role binding exists", func() {
+				BeforeEach(func() {
+					allowListingPods(userName)
+				})
+
+				It("allows listing pods", func() {
+					Expect(buildClientErr).NotTo(HaveOccurred())
+					Expect(podListErr).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		Context("tokens", func() {
+			BeforeEach(func() {
+				token := authProvider.GenerateJWTToken(userName)
+				authHeader = "bearer " + token
+			})
+
+			It("succeeds and forbids access to the user", func() {
+				Expect(buildClientErr).NotTo(HaveOccurred())
+				Expect(apierrors.IsForbidden(podListErr)).To(BeTrue())
+			})
+
+			When("a role binding exists", func() {
+				BeforeEach(func() {
+					allowListingPods(oidcPrefix + userName)
+				})
+
+				It("allows listing pods", func() {
+					Expect(buildClientErr).NotTo(HaveOccurred())
+					Expect(podListErr).NotTo(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	Context("bad auth header content", func() {
+		When("no auth header is passed", func() {
+			BeforeEach(func() {
+				authHeader = ""
+			})
+			It("fails", func() {
+				Expect(authorization.IsNotAuthenticated(buildClientErr)).To(BeTrue())
+			})
+		})
+
+		When("auth header is not two values", func() {
+			BeforeEach(func() {
+				authHeader = "bearer"
+			})
+
+			It("fails", func() {
+				Expect(buildClientErr).To(HaveOccurred())
+			})
+		})
+
+		When("auth header scheme is not recognised", func() {
+			BeforeEach(func() {
+				authHeader = "superSecure xxx"
+			})
+
+			It("fails", func() {
+				Expect(buildClientErr).To(HaveOccurred())
+			})
+		})
+
+		When("the auth is not valid", func() {
+			BeforeEach(func() {
+				authHeader = "bearer xxx"
+			})
+
+			It("fails", func() {
+				Expect(authorization.IsInvalidAuth(buildClientErr)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/api/tests/integration/cert_inspector_test.go
+++ b/api/tests/integration/cert_inspector_test.go
@@ -24,7 +24,8 @@ var _ = Describe("CertInspector", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		certInspector = authorization.NewCertInspector(k8sConfig)
-		certPEMBase64 = obtainClientCert("alice")
+		certData, keyData := obtainClientCert("alice")
+		certPEMBase64 = encodeCertAndKey(certData, keyData)
 	})
 
 	JustBeforeEach(func() {

--- a/api/tests/integration/integration_suite_test.go
+++ b/api/tests/integration/integration_suite_test.go
@@ -79,6 +79,15 @@ func startEnvTest(apiServerExtraArgs map[string]string) {
 	Eventually(func() error {
 		return k8sClient.List(context.Background(), namespaceList)
 	}).Should(Succeed())
+
+	Eventually(func() error {
+		token := authProvider.GenerateJWTToken("ping")
+		cfg := rest.AnonymousClientConfig(k8sConfig)
+		cfg.BearerToken = token
+
+		_, err := client.New(cfg, client.Options{})
+		return err
+	}).Should(Succeed())
 }
 
 func restartEnvTest(apiServerEtraArgs map[string]string) {

--- a/api/tests/integration/integration_suite_test.go
+++ b/api/tests/integration/integration_suite_test.go
@@ -95,15 +95,18 @@ func restartEnvTest(apiServerEtraArgs map[string]string) {
 	startEnvTest(apiServerEtraArgs)
 }
 
-func obtainClientCert(name string) string {
+func obtainClientCert(name string) ([]byte, []byte) {
 	authUser, err := testEnv.ControlPlane.AddUser(envtest.User{Name: name}, k8sConfig)
 	Expect(err).NotTo(HaveOccurred())
 
 	userConfig := authUser.Config()
+	return userConfig.CertData, userConfig.KeyData
+}
 
+func encodeCertAndKey(certData, keyData []byte) string {
 	authHeader := []byte{}
-	authHeader = append(authHeader, userConfig.CertData...)
-	authHeader = append(authHeader, userConfig.KeyData...)
+	authHeader = append(authHeader, certData...)
+	authHeader = append(authHeader, keyData...)
 
 	return base64.StdEncoding.EncodeToString(authHeader)
 }

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -3,4 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: space-developer
-rules: []
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - list

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1488,7 +1488,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cf-k8s-controllers-space-developer
-rules: []
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This is a first shot at the implementation of apps filtering per user. The current version is quite naive, as it tries to list apps in every namespace on the system, skipping the ones that return a `403 Forbidden`. We plan to optimise this by restricting the listing to the namespaces the user has bindings into, but we will do this in a following PR.