### PR TITLE
Make checks a bit faster

### DIFF
--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -172,9 +172,6 @@ jobs:
     - build-controllers
     - check-reference-api
     - check-reference-controllers
-    - api-unit-tests
-    - api-integration-tests
-    - controllers-tests
 
     runs-on: ubuntu-latest
 
@@ -233,7 +230,12 @@ jobs:
       working-directory: ./cf-k8s-controllers
 
   push-latest-docker-images:
-    needs: e2e-tests
+    needs:
+    - api-unit-tests
+    - api-integration-tests
+    - controllers-tests
+    - e2e-tests
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -172,9 +172,6 @@ jobs:
     - build-controllers
     - check-reference-api
     - check-reference-controllers
-    - api-unit-tests
-    - api-integration-tests
-    - controllers-tests
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Remove dependency of e2e tests to other tests thus making execution more
parallel. Pushing of the docker images now depends on all tests, since
they run in a more parallel fashion.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Checks are green.

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
