### PR TITLE
Add code quality badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status](https://github.com/cloudfoundry/cf-k8s-controllers/actions/workflows/test-build-push-main.yml/badge.svg) [![Maintainability](https://api.codeclimate.com/v1/badges/f8dff20cd9bab4fb4117/maintainability)](https://codeclimate.com/github/cloudfoundry/cf-k8s-controllers/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/f8dff20cd9bab4fb4117/test_coverage)](https://codeclimate.com/github/cloudfoundry/cf-k8s-controllers/test_coverage)
+
 # Initial Setup
 ## Clone this repo
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#286 

## What is this change about?
Adding some badges about code quality to the readme

## Does this PR introduce a breaking change?
No

## Acceptance Steps
There should be three shiny badges on the top of the README.md

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
