### PR TITLE
Remove files that contain fake, vendor or generated from coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,0 @@
-version: "2"
-exclude_patterns:
-  - "**/vendor/"
-  - "**/fake/"
-  - "**/zz_generated*"

--- a/.github/workflows/test-build-push-main.yml
+++ b/.github/workflows/test-build-push-main.yml
@@ -72,6 +72,9 @@ jobs:
     - name: Run Controllers tests
       run: make test-controllers
 
+    - name: Sanitize coverage report
+      run: sed -i -E '/(fake|generated|vendor)/d' **/cover.out
+
     - name: Upload coverage report
       uses: actions/upload-artifact@v2
       with:
@@ -99,6 +102,9 @@ jobs:
     - name: Run API unit tests
       run: make test-api-unit
 
+    - name: Sanitize coverage report
+      run: sed -i -E '/(fake|generated|vendor)/d' **/cover.out
+
     - name: Upload coverage report
       uses: actions/upload-artifact@v2
       with:
@@ -125,6 +131,9 @@ jobs:
 
     - name: Run API integration tests
       run: make test-api-integration
+
+    - name: Sanitize coverage report
+      run: sed -i -E '/(fake|generated|vendor)/d' **/cover.out
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v2


### PR DESCRIPTION

## Is there a related GitHub Issue?
#304 

## What is this change about?
Removes fakes, generated code and vendor from the coverage report, so that we have a more accurate number.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Open coverage report on codeclimate
2. Notice there are no fakes, generated or vendor in the file paths

## Tag your pair, your PM, and/or team
@danail-branekov 