### PR TITLE
Only limit ginkgo nodes for controllers tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ IMG_API ?= cloudfoundry/cf-k8s-api:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
+# Run controllers tests with two nodes by default to (potentially) minimise
+# flakes.
+CONTROLLERS_GINKGO_NODES ?= 2
+ifdef GINKGO_NODES
+CONTROLLERS_GINKGO_NODES = $(GINKGO_NODES)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -68,7 +75,7 @@ test-controllers-api: test-controllers test-api
 test-unit: test-controllers test-api-unit
 
 test-controllers: install-ginkgo manifests-controllers generate-controllers fmt vet ## Run tests.
-	cd controllers && ../scripts/run-tests.sh
+	cd controllers && GINKGO_NODES=$(CONTROLLERS_GINKGO_NODES) ../scripts/run-tests.sh
 
 test-api: test-api-unit test-api-integration
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -28,4 +28,8 @@ else
   extra_args+=("--slow-spec-threshold=30s")
 fi
 
-ginkgo -r -p --procs "${TEST_NUM_NODES:=2}" --randomize-all --randomize-suites "${extra_args[@]}" $@
+if [[ -n "$GINKGO_NODES" ]]; then
+  extra_args+=("--procs=${GINKGO_NODES}")
+fi
+
+ginkgo -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/302

## What is this change about?
Get rid of limiting Ginkgo nodes (except for controllers tests) during test runs to make running tests faster

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run all tests, see them pass 

