### PR TITLE
Update developer docs and scripts

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -99,19 +99,16 @@ echo "*******************"
 echo "Installing HNC"
 echo "*******************"
 
-readonly HNC_VERSION="v0.8.0"
+readonly HNC_VERSION="v0.9.0"
 readonly HNC_PLATFORM="$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
 readonly HNC_BIN="${PWD}/bin"
 export PATH="${HNC_BIN}:${PATH}"
 
 mkdir -p "${HNC_BIN}"
-curl -L "https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/kubectl-hns_${HNC_PLATFORM}" -o "${HNC_BIN}/kubectl-hns"
+curl -L "https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/${HNC_VERSION}/kubectl-hns_${HNC_PLATFORM}" -o "${HNC_BIN}/kubectl-hns"
 chmod +x "${HNC_BIN}/kubectl-hns"
 
-kubectl label ns kube-system hnc.x-k8s.io/excluded-namespace=true --overwrite
-kubectl label ns kube-public hnc.x-k8s.io/excluded-namespace=true --overwrite
-kubectl label ns kube-node-lease hnc.x-k8s.io/excluded-namespace=true --overwrite
-kubectl apply -f "https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/hnc-manager.yaml"
+kubectl apply -f "https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/${HNC_VERSION}/hnc-manager.yaml"
 kubectl rollout status deployment/hnc-controller-manager -w -n hnc-system
 
 retry() {


### PR DESCRIPTION


Co-authored-by: Julian Hjortshoj <hjortshojj@vmware.com>

> Thanks for contributing!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## Is there a related GitHub Issue?
Fixes #213

## What is this change about?
Update developer docs and scripts
- Add instructions to manually deploy HNC
- update install-dependencies script to use v0.9.0 in its new location
- fix references to `hack` folder
- updated instructions to reflect current `make` targets

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Use docs to install cf-k8s controllers and api

## Tag your pair, your PM, and/or team
@davewalter 
