### PR TITLE
App developer can view apps in a space using `cf apps`

### DIFF
--- a/api/actions/fake/cfprocess_repository.go
+++ b/api/actions/fake/cfprocess_repository.go
@@ -56,19 +56,18 @@ type CFProcessRepository struct {
 		result1 repositories.ProcessRecord
 		result2 error
 	}
-	FetchProcessesForAppStub        func(context.Context, client.Client, string, string) ([]repositories.ProcessRecord, error)
-	fetchProcessesForAppMutex       sync.RWMutex
-	fetchProcessesForAppArgsForCall []struct {
+	FetchProcessListStub        func(context.Context, client.Client, repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error)
+	fetchProcessListMutex       sync.RWMutex
+	fetchProcessListArgsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 string
-		arg4 string
+		arg3 repositories.FetchProcessListMessage
 	}
-	fetchProcessesForAppReturns struct {
+	fetchProcessListReturns struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}
-	fetchProcessesForAppReturnsOnCall map[int]struct {
+	fetchProcessListReturnsOnCall map[int]struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}
@@ -301,21 +300,20 @@ func (fake *CFProcessRepository) FetchProcessByAppTypeAndSpaceReturnsOnCall(i in
 	}{result1, result2}
 }
 
-func (fake *CFProcessRepository) FetchProcessesForApp(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string) ([]repositories.ProcessRecord, error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	ret, specificReturn := fake.fetchProcessesForAppReturnsOnCall[len(fake.fetchProcessesForAppArgsForCall)]
-	fake.fetchProcessesForAppArgsForCall = append(fake.fetchProcessesForAppArgsForCall, struct {
+func (fake *CFProcessRepository) FetchProcessList(arg1 context.Context, arg2 client.Client, arg3 repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error) {
+	fake.fetchProcessListMutex.Lock()
+	ret, specificReturn := fake.fetchProcessListReturnsOnCall[len(fake.fetchProcessListArgsForCall)]
+	fake.fetchProcessListArgsForCall = append(fake.fetchProcessListArgsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 string
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
-	stub := fake.FetchProcessesForAppStub
-	fakeReturns := fake.fetchProcessesForAppReturns
-	fake.recordInvocation("FetchProcessesForApp", []interface{}{arg1, arg2, arg3, arg4})
-	fake.fetchProcessesForAppMutex.Unlock()
+		arg3 repositories.FetchProcessListMessage
+	}{arg1, arg2, arg3})
+	stub := fake.FetchProcessListStub
+	fakeReturns := fake.fetchProcessListReturns
+	fake.recordInvocation("FetchProcessList", []interface{}{arg1, arg2, arg3})
+	fake.fetchProcessListMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -323,46 +321,46 @@ func (fake *CFProcessRepository) FetchProcessesForApp(arg1 context.Context, arg2
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppCallCount() int {
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
-	return len(fake.fetchProcessesForAppArgsForCall)
+func (fake *CFProcessRepository) FetchProcessListCallCount() int {
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
+	return len(fake.fetchProcessListArgsForCall)
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppCalls(stub func(context.Context, client.Client, string, string) ([]repositories.ProcessRecord, error)) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = stub
+func (fake *CFProcessRepository) FetchProcessListCalls(stub func(context.Context, client.Client, repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error)) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = stub
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppArgsForCall(i int) (context.Context, client.Client, string, string) {
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
-	argsForCall := fake.fetchProcessesForAppArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+func (fake *CFProcessRepository) FetchProcessListArgsForCall(i int) (context.Context, client.Client, repositories.FetchProcessListMessage) {
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
+	argsForCall := fake.fetchProcessListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppReturns(result1 []repositories.ProcessRecord, result2 error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = nil
-	fake.fetchProcessesForAppReturns = struct {
+func (fake *CFProcessRepository) FetchProcessListReturns(result1 []repositories.ProcessRecord, result2 error) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = nil
+	fake.fetchProcessListReturns = struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppReturnsOnCall(i int, result1 []repositories.ProcessRecord, result2 error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = nil
-	if fake.fetchProcessesForAppReturnsOnCall == nil {
-		fake.fetchProcessesForAppReturnsOnCall = make(map[int]struct {
+func (fake *CFProcessRepository) FetchProcessListReturnsOnCall(i int, result1 []repositories.ProcessRecord, result2 error) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = nil
+	if fake.fetchProcessListReturnsOnCall == nil {
+		fake.fetchProcessListReturnsOnCall = make(map[int]struct {
 			result1 []repositories.ProcessRecord
 			result2 error
 		})
 	}
-	fake.fetchProcessesForAppReturnsOnCall[i] = struct {
+	fake.fetchProcessListReturnsOnCall[i] = struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}{result1, result2}
@@ -506,8 +504,8 @@ func (fake *CFProcessRepository) Invocations() map[string][][]interface{} {
 	defer fake.fetchProcessMutex.RUnlock()
 	fake.fetchProcessByAppTypeAndSpaceMutex.RLock()
 	defer fake.fetchProcessByAppTypeAndSpaceMutex.RUnlock()
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
 	fake.patchProcessMutex.RLock()
 	defer fake.patchProcessMutex.RUnlock()
 	fake.scaleProcessMutex.RLock()

--- a/api/actions/scale_app_process.go
+++ b/api/actions/scale_app_process.go
@@ -31,7 +31,12 @@ func (a *ScaleAppProcess) Invoke(ctx context.Context, client client.Client, appG
 		return repositories.ProcessRecord{}, err
 	}
 
-	appProcesses, err := a.processRepo.FetchProcessesForApp(ctx, client, app.GUID, app.SpaceGUID)
+	fetchProcessMessage := repositories.FetchProcessListMessage{
+		AppGUID:   []string{app.GUID},
+		SpaceGUID: app.SpaceGUID,
+	}
+
+	appProcesses, err := a.processRepo.FetchProcessList(ctx, client, fetchProcessMessage)
 	if err != nil {
 		return repositories.ProcessRecord{}, err
 	}

--- a/api/actions/scale_app_process_test.go
+++ b/api/actions/scale_app_process_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 			SpaceGUID: testProcessSpaceGUID,
 		}, nil)
 
-		processRepo.FetchProcessesForAppReturns([]repositories.ProcessRecord{processRecord}, nil)
+		processRepo.FetchProcessListReturns([]repositories.ProcessRecord{processRecord}, nil)
 
 		newInstances := 10
 		var newMemoryMB int64 = 256
@@ -113,10 +113,10 @@ var _ = Describe("ScaleAppProcessAction", func() {
 			Expect(appGUID).To(Equal(testAppGUID))
 		})
 		It("fetches the processes associated with the App GUID", func() {
-			Expect(processRepo.FetchProcessesForAppCallCount()).ToNot(BeZero())
-			_, _, appGUID, calledNamespace := processRepo.FetchProcessesForAppArgsForCall(0)
-			Expect(appGUID).To(Equal(testAppGUID))
-			Expect(calledNamespace).To(Equal(testProcessSpaceGUID))
+			Expect(processRepo.FetchProcessListCallCount()).ToNot(BeZero())
+			_, _, message := processRepo.FetchProcessListArgsForCall(0)
+			Expect(message.AppGUID[0]).To(Equal(testAppGUID))
+			Expect(message.SpaceGUID).To(Equal(testProcessSpaceGUID))
 		})
 		It("fabricates a ProcessScaleValues using the inputs and the process GUID and looked-up space", func() {
 			Expect(scaleProcessAction.CallCount()).ToNot(BeZero())
@@ -166,7 +166,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 			var toReturnErr error
 			BeforeEach(func() {
 				toReturnErr = errors.New("some-other-error")
-				processRepo.FetchProcessesForAppReturns([]repositories.ProcessRecord{}, toReturnErr)
+				processRepo.FetchProcessListReturns([]repositories.ProcessRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {
 				Expect(responseRecord).To(Equal(repositories.ProcessRecord{}))

--- a/api/actions/shared.go
+++ b/api/actions/shared.go
@@ -15,7 +15,7 @@ import (
 //counterfeiter:generate -o fake -fake-name CFProcessRepository . CFProcessRepository
 type CFProcessRepository interface {
 	FetchProcess(context.Context, client.Client, string) (repositories.ProcessRecord, error)
-	FetchProcessesForApp(context.Context, client.Client, string, string) ([]repositories.ProcessRecord, error)
+	FetchProcessList(context.Context, client.Client, repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error)
 	ScaleProcess(context.Context, client.Client, repositories.ProcessScaleMessage) (repositories.ProcessRecord, error)
 	CreateProcess(context.Context, client.Client, repositories.ProcessCreateMessage) error
 	FetchProcessByAppTypeAndSpace(context.Context, client.Client, string, string, string) (repositories.ProcessRecord, error)

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -506,14 +506,19 @@ func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	processList, err := h.processRepo.FetchProcessesForApp(ctx, client, appGUID, app.SpaceGUID)
+	fetchProcessesForAppMessage := repositories.FetchProcessListMessage{
+		AppGUID:   []string{appGUID},
+		SpaceGUID: app.SpaceGUID,
+	}
+
+	processList, err := h.processRepo.FetchProcessList(ctx, client, fetchProcessesForAppMessage)
 	if err != nil {
 		h.logger.Error(err, "Failed to fetch app Process(es) from Kubernetes")
 		writeUnknownErrorResponse(w)
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcessList(processList, h.serverURL, appGUID))
+	responseBody, err := json.Marshal(presenter.ForAppProcessList(processList, h.serverURL, appGUID))
 	if err != nil { // untested
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)

--- a/api/apis/fake/cfprocess_repository.go
+++ b/api/apis/fake/cfprocess_repository.go
@@ -26,19 +26,18 @@ type CFProcessRepository struct {
 		result1 repositories.ProcessRecord
 		result2 error
 	}
-	FetchProcessesForAppStub        func(context.Context, client.Client, string, string) ([]repositories.ProcessRecord, error)
-	fetchProcessesForAppMutex       sync.RWMutex
-	fetchProcessesForAppArgsForCall []struct {
+	FetchProcessListStub        func(context.Context, client.Client, repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error)
+	fetchProcessListMutex       sync.RWMutex
+	fetchProcessListArgsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 string
-		arg4 string
+		arg3 repositories.FetchProcessListMessage
 	}
-	fetchProcessesForAppReturns struct {
+	fetchProcessListReturns struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}
-	fetchProcessesForAppReturnsOnCall map[int]struct {
+	fetchProcessListReturnsOnCall map[int]struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}
@@ -112,21 +111,20 @@ func (fake *CFProcessRepository) FetchProcessReturnsOnCall(i int, result1 reposi
 	}{result1, result2}
 }
 
-func (fake *CFProcessRepository) FetchProcessesForApp(arg1 context.Context, arg2 client.Client, arg3 string, arg4 string) ([]repositories.ProcessRecord, error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	ret, specificReturn := fake.fetchProcessesForAppReturnsOnCall[len(fake.fetchProcessesForAppArgsForCall)]
-	fake.fetchProcessesForAppArgsForCall = append(fake.fetchProcessesForAppArgsForCall, struct {
+func (fake *CFProcessRepository) FetchProcessList(arg1 context.Context, arg2 client.Client, arg3 repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error) {
+	fake.fetchProcessListMutex.Lock()
+	ret, specificReturn := fake.fetchProcessListReturnsOnCall[len(fake.fetchProcessListArgsForCall)]
+	fake.fetchProcessListArgsForCall = append(fake.fetchProcessListArgsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
-		arg3 string
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
-	stub := fake.FetchProcessesForAppStub
-	fakeReturns := fake.fetchProcessesForAppReturns
-	fake.recordInvocation("FetchProcessesForApp", []interface{}{arg1, arg2, arg3, arg4})
-	fake.fetchProcessesForAppMutex.Unlock()
+		arg3 repositories.FetchProcessListMessage
+	}{arg1, arg2, arg3})
+	stub := fake.FetchProcessListStub
+	fakeReturns := fake.fetchProcessListReturns
+	fake.recordInvocation("FetchProcessList", []interface{}{arg1, arg2, arg3})
+	fake.fetchProcessListMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -134,46 +132,46 @@ func (fake *CFProcessRepository) FetchProcessesForApp(arg1 context.Context, arg2
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppCallCount() int {
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
-	return len(fake.fetchProcessesForAppArgsForCall)
+func (fake *CFProcessRepository) FetchProcessListCallCount() int {
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
+	return len(fake.fetchProcessListArgsForCall)
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppCalls(stub func(context.Context, client.Client, string, string) ([]repositories.ProcessRecord, error)) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = stub
+func (fake *CFProcessRepository) FetchProcessListCalls(stub func(context.Context, client.Client, repositories.FetchProcessListMessage) ([]repositories.ProcessRecord, error)) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = stub
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppArgsForCall(i int) (context.Context, client.Client, string, string) {
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
-	argsForCall := fake.fetchProcessesForAppArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+func (fake *CFProcessRepository) FetchProcessListArgsForCall(i int) (context.Context, client.Client, repositories.FetchProcessListMessage) {
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
+	argsForCall := fake.fetchProcessListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppReturns(result1 []repositories.ProcessRecord, result2 error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = nil
-	fake.fetchProcessesForAppReturns = struct {
+func (fake *CFProcessRepository) FetchProcessListReturns(result1 []repositories.ProcessRecord, result2 error) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = nil
+	fake.fetchProcessListReturns = struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CFProcessRepository) FetchProcessesForAppReturnsOnCall(i int, result1 []repositories.ProcessRecord, result2 error) {
-	fake.fetchProcessesForAppMutex.Lock()
-	defer fake.fetchProcessesForAppMutex.Unlock()
-	fake.FetchProcessesForAppStub = nil
-	if fake.fetchProcessesForAppReturnsOnCall == nil {
-		fake.fetchProcessesForAppReturnsOnCall = make(map[int]struct {
+func (fake *CFProcessRepository) FetchProcessListReturnsOnCall(i int, result1 []repositories.ProcessRecord, result2 error) {
+	fake.fetchProcessListMutex.Lock()
+	defer fake.fetchProcessListMutex.Unlock()
+	fake.FetchProcessListStub = nil
+	if fake.fetchProcessListReturnsOnCall == nil {
+		fake.fetchProcessListReturnsOnCall = make(map[int]struct {
 			result1 []repositories.ProcessRecord
 			result2 error
 		})
 	}
-	fake.fetchProcessesForAppReturnsOnCall[i] = struct {
+	fake.fetchProcessListReturnsOnCall[i] = struct {
 		result1 []repositories.ProcessRecord
 		result2 error
 	}{result1, result2}
@@ -184,8 +182,8 @@ func (fake *CFProcessRepository) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.fetchProcessMutex.RLock()
 	defer fake.fetchProcessMutex.RUnlock()
-	fake.fetchProcessesForAppMutex.RLock()
-	defer fake.fetchProcessesForAppMutex.RUnlock()
+	fake.fetchProcessListMutex.RLock()
+	defer fake.fetchProcessListMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/apis/fake/cfroute_repository.go
+++ b/api/apis/fake/cfroute_repository.go
@@ -56,11 +56,12 @@ type CFRouteRepository struct {
 		result1 repositories.RouteRecord
 		result2 error
 	}
-	FetchRouteListStub        func(context.Context, client.Client) ([]repositories.RouteRecord, error)
+	FetchRouteListStub        func(context.Context, client.Client, repositories.FetchRouteListMessage) ([]repositories.RouteRecord, error)
 	fetchRouteListMutex       sync.RWMutex
 	fetchRouteListArgsForCall []struct {
 		arg1 context.Context
 		arg2 client.Client
+		arg3 repositories.FetchRouteListMessage
 	}
 	fetchRouteListReturns struct {
 		result1 []repositories.RouteRecord
@@ -288,19 +289,20 @@ func (fake *CFRouteRepository) FetchRouteReturnsOnCall(i int, result1 repositori
 	}{result1, result2}
 }
 
-func (fake *CFRouteRepository) FetchRouteList(arg1 context.Context, arg2 client.Client) ([]repositories.RouteRecord, error) {
+func (fake *CFRouteRepository) FetchRouteList(arg1 context.Context, arg2 client.Client, arg3 repositories.FetchRouteListMessage) ([]repositories.RouteRecord, error) {
 	fake.fetchRouteListMutex.Lock()
 	ret, specificReturn := fake.fetchRouteListReturnsOnCall[len(fake.fetchRouteListArgsForCall)]
 	fake.fetchRouteListArgsForCall = append(fake.fetchRouteListArgsForCall, struct {
 		arg1 context.Context
 		arg2 client.Client
-	}{arg1, arg2})
+		arg3 repositories.FetchRouteListMessage
+	}{arg1, arg2, arg3})
 	stub := fake.FetchRouteListStub
 	fakeReturns := fake.fetchRouteListReturns
-	fake.recordInvocation("FetchRouteList", []interface{}{arg1, arg2})
+	fake.recordInvocation("FetchRouteList", []interface{}{arg1, arg2, arg3})
 	fake.fetchRouteListMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -314,17 +316,17 @@ func (fake *CFRouteRepository) FetchRouteListCallCount() int {
 	return len(fake.fetchRouteListArgsForCall)
 }
 
-func (fake *CFRouteRepository) FetchRouteListCalls(stub func(context.Context, client.Client) ([]repositories.RouteRecord, error)) {
+func (fake *CFRouteRepository) FetchRouteListCalls(stub func(context.Context, client.Client, repositories.FetchRouteListMessage) ([]repositories.RouteRecord, error)) {
 	fake.fetchRouteListMutex.Lock()
 	defer fake.fetchRouteListMutex.Unlock()
 	fake.FetchRouteListStub = stub
 }
 
-func (fake *CFRouteRepository) FetchRouteListArgsForCall(i int) (context.Context, client.Client) {
+func (fake *CFRouteRepository) FetchRouteListArgsForCall(i int) (context.Context, client.Client, repositories.FetchRouteListMessage) {
 	fake.fetchRouteListMutex.RLock()
 	defer fake.fetchRouteListMutex.RUnlock()
 	argsForCall := fake.fetchRouteListArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *CFRouteRepository) FetchRouteListReturns(result1 []repositories.RouteRecord, result2 error) {

--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -47,7 +47,7 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#apps
 | List App Routes | GET /v3/apps/\<guid>/routes |
 
 #### [List Apps](https://v3-apidocs.cloudfoundry.org/version/3.110.0/index.html#list-apps)
-**Filters:** Currently supports filtering by app `names` and `space_guids`.
+**Query Parameters:** Currently supports filtering by app `names` and `space_guids` and ordering by `name`.
 
 ```bash
 curl "http://localhost:9000/v3/apps?names=app1,app2&space_guids=ad0836b5-09f4-48c0-adb2-2c61e515562f,6030b015-f003-4c9f-8bb4-1ed7ae3d3659"
@@ -154,6 +154,7 @@ Docs: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#processes
 | Get Process Sidecars | GET /v3/processes/\<guid>/sidecars |
 | Scale Process | POST /v3/processes/\<guid>/actions/scale |
 | Get Process Stats | POST /v3/processes/\<guid>/stats |
+| List Process | POST /v3/processes |
 
 #### [Scaling Processes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#scale-a-process)
 ```bash
@@ -166,6 +167,9 @@ curl "http://localhost:9000/v3/processes/<guid>/actions/scale" \
 Currently, we only support fetching stats using the process guid endpoint, i.e., POST /v3/processes/\<guid>/stats.
 This endpoint supports populating only the index and state details on the response.
 Support for populating other fields will come later.
+
+#### [List Processes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-processes)
+**Query Parameters:** Currently supports filtering by `app_guids`.
 
 ### Domain
 
@@ -190,6 +194,9 @@ curl "http://localhost:9000/v3/domains?names=cf-apps.io" \
 | Get Route Destinations | GET /v3/routes/\<guid\>/destinations |
 | Create Route | POST /v3/routes |
 | Add Destinations to Route | POST /v3/routes/\<guid\>/destinations |
+
+#### [List Routes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-routes)
+**Query Parameters:** Currently supports filtering by `app_guids`.
 
 #### [Creating Routes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
 ```bash

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -55,6 +55,7 @@ type AppSetCurrentDroplet struct {
 type AppList struct {
 	Names      string `schema:"names"`
 	SpaceGuids string `schema:"space_guids"`
+	OrderBy    string `schema:"order_by"`
 }
 
 func (a *AppList) ToMessage() repositories.AppListMessage {
@@ -65,5 +66,5 @@ func (a *AppList) ToMessage() repositories.AppListMessage {
 }
 
 func (a *AppList) SupportedFilterKeys() []string {
-	return []string{"names", "space_guids"}
+	return []string{"names", "space_guids", "order_by"}
 }

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -15,3 +15,17 @@ func (p ProcessScale) ToRecord() repositories.ProcessScaleValues {
 		DiskMB:    p.DiskMB,
 	}
 }
+
+type ProcessList struct {
+	AppGUIDs string `schema:"app_guids"`
+}
+
+func (p *ProcessList) ToMessage() repositories.FetchProcessListMessage {
+	return repositories.FetchProcessListMessage{
+		AppGUID: parseArrayParam(p.AppGUIDs),
+	}
+}
+
+func (p *ProcessList) SupportedFilterKeys() []string {
+	return []string{"app_guids"}
+}

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -31,3 +31,17 @@ func (p RouteCreate) ToRecord() repositories.RouteRecord {
 		UpdatedAt:   "",
 	}
 }
+
+type RouteList struct {
+	AppGUIDs string `schema:"app_guids"`
+}
+
+func (p *RouteList) ToMessage() repositories.FetchRouteListMessage {
+	return repositories.FetchRouteListMessage{
+		AppGUIDs: parseArrayParam(p.AppGUIDs),
+	}
+}
+
+func (p *RouteList) SupportedFilterKeys() []string {
+	return []string{"app_guids"}
+}

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -3,6 +3,8 @@ package repositories_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 	"time"
 
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
@@ -196,6 +198,12 @@ var _ = Describe("AppRepository", func() {
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfApp1.Name)}),
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfApp2.Name)}),
 					))
+
+					sortedByName := sort.SliceIsSorted(appList, func(i, j int) bool {
+						return appList[i].Name < appList[j].Name
+					})
+
+					Expect(sortedByName).To(BeTrue(), fmt.Sprintf("AppList was not sorted by Name : App1 : %s , App2: %s", appList[0].Name, appList[1].Name))
 				})
 			})
 		})

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -194,7 +194,7 @@ var _ = Describe("ProcessRepo", func() {
 		})
 	})
 
-	Describe("FetchProcessesForApp", func() {
+	Describe("FetchProcessesList", func() {
 		var (
 			app1GUID string
 			app2GUID string
@@ -228,22 +228,39 @@ var _ = Describe("ProcessRepo", func() {
 		})
 
 		When("on the happy path", func() {
-			It("returns Process records for the AppGUID we request", func() {
-				processes, err := processRepo.FetchProcessesForApp(testCtx, testClient, app1GUID, namespace.Name)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(processes)).To(Equal(2))
-				By("returning a process record for each process of the app", func() {
-					for _, processRecord := range processes {
-						recordMatchesOneProcess := processRecord.GUID == process1GUID || processRecord.GUID == process2GUID
-						Expect(recordMatchesOneProcess).To(BeTrue(), "ProcessRecord GUID did not match one of the expected processes")
-					}
+			When("spaceGUID is not empty", func() {
+				It("returns Process records for the AppGUID we request", func() {
+					processes, err := processRepo.FetchProcessList(testCtx, testClient, FetchProcessListMessage{AppGUID: []string{app1GUID}, SpaceGUID: namespace.Name})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(processes)).To(Equal(2))
+					By("returning a process record for each process of the app", func() {
+						for _, processRecord := range processes {
+							recordMatchesOneProcess := processRecord.GUID == process1GUID || processRecord.GUID == process2GUID
+							Expect(recordMatchesOneProcess).To(BeTrue(), "ProcessRecord GUID did not match one of the expected processes")
+						}
+					})
 				})
 			})
+
+			When("spaceGUID is empty", func() {
+				It("returns Process records for the AppGUID we request", func() {
+					processes, err := processRepo.FetchProcessList(testCtx, testClient, FetchProcessListMessage{AppGUID: []string{app1GUID}})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(processes)).To(Equal(2))
+					By("returning a process record for each process of the app", func() {
+						for _, processRecord := range processes {
+							recordMatchesOneProcess := processRecord.GUID == process1GUID || processRecord.GUID == process2GUID
+							Expect(recordMatchesOneProcess).To(BeTrue(), "ProcessRecord GUID did not match one of the expected processes")
+						}
+					})
+				})
+			})
+
 		})
 
 		When("no Processes exist for an app", func() {
 			It("returns an empty list", func() {
-				processes, err := processRepo.FetchProcessesForApp(testCtx, testClient, app2GUID, namespace.Name)
+				processes, err := processRepo.FetchProcessList(testCtx, testClient, FetchProcessListMessage{AppGUID: []string{app2GUID}, SpaceGUID: namespace.Name})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(processes).To(BeEmpty())
 				Expect(processes).ToNot(BeNil())
@@ -252,7 +269,7 @@ var _ = Describe("ProcessRepo", func() {
 
 		When("the app does not exist", func() {
 			It("returns an empty list", func() {
-				processes, err := processRepo.FetchProcessesForApp(testCtx, testClient, "I don't exist", namespace.Name)
+				processes, err := processRepo.FetchProcessList(testCtx, testClient, FetchProcessListMessage{AppGUID: []string{"I dont exist"}, SpaceGUID: namespace.Name})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(processes).To(BeEmpty())
 				Expect(processes).ToNot(BeNil())


### PR DESCRIPTION
## Is there a related GitHub Issue?
#313 

## What is this change about?
App developer can view apps in a space using `cf apps`
- add support for order_by=name query parameter on GET /v3/apps
  - we have enabled ordering by name as default behaviour
- add support for filtering by app_guids on
   - GET /v3/processes endpoint
   - GET /v3/routes endpoint
- update api docs

## Does this PR introduce a breaking change?
No

## Acceptance Steps
- Deploy cf-k8s-api and cf-k8s-controllers
- Use the `cf cli` to push and app
- Run `cf apps` and verify the output

## Tag your pair, your PM, and/or team
@julian-hj 