### PR TITLE
Issue 148 - Configure TLS for workloads ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,13 @@ uninstall-crds: manifests-controllers install-kustomize ## Uninstall CRDs from t
 
 deploy: install-crds deploy-controllers deploy-api
 
-deploy-kind: install-crds deploy-controllers deploy-api-kind-auth
+deploy-kind: install-crds deploy-controllers-kind deploy-api-kind-auth
 
 deploy-controllers: install-kustomize build-reference-controllers
 	$(KUSTOMIZE) build controllers/config/default | kubectl apply -f -
+
+deploy-controllers-kind: install-kustomize build-reference-controllers
+	$(KUSTOMIZE) build controllers/config/overlays/kind | kubectl apply -f -
 
 deploy-api: install-kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/base | kubectl apply -f -

--- a/controllers/config/base/kustomization.yaml
+++ b/controllers/config/base/kustomization.yaml
@@ -5,3 +5,6 @@ configMapGenerator:
   - files:
       - controllersconfig/cf_k8s_controllers_config.yaml
     name: config
+
+resources:
+  - workloads_tls_delegation.yaml

--- a/controllers/config/base/workloads_tls_delegation.yaml
+++ b/controllers/config/base/workloads_tls_delegation.yaml
@@ -1,0 +1,13 @@
+#! Is there a way to configure the targetNamespaces list to refer to the namespace in which the delegation resource exists so that we can
+#! cascade permissions through HNC? That way we avoid pollution of or outright incompatibility with
+#! existing Contour configurations
+---
+apiVersion: projectcontour.io/v1
+kind: TLSCertificateDelegation
+metadata:
+  name: workloads-fallback-delegation
+spec:
+  delegations:
+    - secretName: cf-k8s-workloads-ingress-cert
+      targetNamespaces:
+        - "*"

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -11,8 +11,10 @@ import (
 )
 
 type ControllerConfig struct {
-	KpackImageTag     string            `yaml:"kpackImageTag"`
-	CFProcessDefaults CFProcessDefaults `yaml:"cfProcessDefaults"`
+	KpackImageTag            string            `yaml:"kpackImageTag"`
+	CFProcessDefaults        CFProcessDefaults `yaml:"cfProcessDefaults"`
+	CFK8sControllerNamespace string            `yaml:"cfk8s_controller_namespace"`
+	WorkloadsTLSSecretName   string            `yaml:"workloads_tls_secret_name"`
 }
 
 type CFProcessDefaults struct {
@@ -47,4 +49,11 @@ func LoadFromPath(path string) (*ControllerConfig, error) {
 	}
 
 	return &config, nil
+}
+
+func (c ControllerConfig) WorkloadsTLSSecretNameWithNamespace() string {
+	if c.WorkloadsTLSSecretName == "" {
+		return ""
+	}
+	return filepath.Join(c.CFK8sControllerNamespace, c.WorkloadsTLSSecretName)
 }

--- a/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
@@ -3,4 +3,4 @@ cfProcessDefaults:
   memoryMB: 500
   diskQuotaMB: 512
 cfk8s_controller_namespace: cf-k8s-controllers-system
-workloads_tls_secret_name: cf-k8s-workloads-ingress-cert
+workloads_tls_secret_name: ""

--- a/controllers/config/overlays/kind/kustomization.yaml
+++ b/controllers/config/overlays/kind/kustomization.yaml
@@ -1,0 +1,11 @@
+configMapGenerator:
+- behavior: merge
+  files:
+  - controllersconfig/cf_k8s_controllers_config.yaml
+  name: config
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default

--- a/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
+++ b/controllers/controllers/networking/integration/cfroute_controller_integration_test.go
@@ -104,6 +104,7 @@ var _ = Describe("CFRouteReconciler Integration Tests", func() {
 			}).ShouldNot(BeEmpty(), "Timed out waiting for HTTPProxy/%s in namespace %s to be created", testFQDN, testNamespace)
 
 			Expect(proxy.Spec.VirtualHost.Fqdn).To(Equal(testFQDN), "HTTPProxy FQDN mismatch")
+			Expect(proxy.Spec.VirtualHost.TLS.SecretName).To(Equal("cf-k8s-controllers-system/cf-k8s-workloads-ingress-cert"))
 			Expect(proxy.Spec.Includes).To(HaveLen(1), "HTTPProxy doesn't have the expected number of includes")
 			Expect(proxy.Spec.Includes[0]).To(Equal(contourv1.Include{
 				Name:      testRouteGUID,

--- a/controllers/controllers/networking/integration/suite_integration_test.go
+++ b/controllers/controllers/networking/integration/suite_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/config"
 	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/networking"
 
 	. "github.com/onsi/ginkgo"
@@ -81,6 +82,15 @@ var _ = BeforeSuite(func() {
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 		Log:    ctrl.Log.WithName("controllers").WithName("CFRoute"),
+		ControllerConfig: &config.ControllerConfig{
+			KpackImageTag: "image/registry/tag",
+			CFProcessDefaults: config.CFProcessDefaults{
+				MemoryMB:           500,
+				DefaultDiskQuotaMB: 512,
+			},
+			CFK8sControllerNamespace: "cf-k8s-controllers-system",
+			WorkloadsTLSSecretName:   "cf-k8s-workloads-ingress-cert",
+		},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -166,9 +166,10 @@ func main() {
 	}
 
 	if err = (&networkingcontrollers.CFRouteReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CFRoute"),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Log:              ctrl.Log.WithName("controllers").WithName("CFRoute"),
+		ControllerConfig: controllerConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CFRoute")
 		os.Exit(1)

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1545,11 +1545,13 @@ subjects:
 ---
 apiVersion: v1
 data:
-  cf_k8s_controllers_config.yaml: |-
+  cf_k8s_controllers_config.yaml: |
     kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
     cfProcessDefaults:
       memoryMB: 500
       diskQuotaMB: 512
+    cfk8s_controller_namespace: cf-k8s-controllers-system
+    workloads_tls_secret_name: cf-k8s-workloads-ingress-cert
 kind: ConfigMap
 metadata:
   name: cf-k8s-controllers-config
@@ -1704,6 +1706,17 @@ metadata:
   namespace: cf-k8s-controllers-system
 spec:
   selfSigned: {}
+---
+apiVersion: projectcontour.io/v1
+kind: TLSCertificateDelegation
+metadata:
+  name: cf-k8s-controllers-workloads-fallback-delegation
+  namespace: cf-k8s-controllers-system
+spec:
+  delegations:
+  - secretName: cf-k8s-workloads-ingress-cert
+    targetNamespaces:
+    - '*'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
## Is there a related GitHub Issue?
#148 

## What is this change about?
Operators can now configure TLS for their workloads. If they leave the default behavior, all routes will respond to HTTP only.  If they follow the new instructions in the readme, then routes will respond to HTTPS requests using the cert they configure, and HTTP requests will be redirected to HTTPS.

## Does this PR introduce a breaking change?
No. The behavior is the same by default, and TLS is only enabled if they take manual action.

## Acceptance Steps
Follow the README instructions to deploy the app normally, then deploy an app and create a route for it. Confirm that you can curl the app via http, but not via https.
Tear down the cluster from the first part, then deploy a new cluster following the README instructions for adding TLS to workloads. Deploy an app and create a route. Confirm that you can curl the app via HTTPS, and that HTTP requests are redirected to HTTPS.

## Tag your pair, your PM, and/or team
@acosta11 