### PR TITLE
Fix controller deployment resource req and limit

### DIFF
--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -45,11 +45,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 500m
+            memory: 500Mi
         env:
         - name: CONTROLLERSCONFIG
           value: "/etc/cf-k8s-controllers-config"

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1646,11 +1646,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 500m
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:


### PR DESCRIPTION
Co-authored-by: Ashwin Krishna <krishnaas@vmware.com>

## Is there a related GitHub Issue?
No

## What is this change about?
Update cf-on-k8s controller deployment to set resource request and limit to more reasonable values to prevent OoM crashloop.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
deploy the controllers and CRDs, for example:
`kubectl apply -f controllers/reference/cf-k8s-controllers.yaml`

## Tag your pair, your PM, and/or team
@akrishna90 
