### PR TITLE
App Dev/Operator can list routes with `cf routes`

### DIFF
--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -696,7 +696,7 @@ var _ = Describe("AppHandler", func() {
 			})
 
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'names, space_guids, order_by'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'names, guids, space_guids, order_by'")
 			})
 		})
 

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -333,7 +333,7 @@ var _ = Describe("RouteHandler", func() {
 				})
 			})
 
-			When("query parameters are provided", func() {
+			When("app_guid query parameters are provided", func() {
 				BeforeEach(func() {
 					var err error
 					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?app_guids=my-app-guid", nil)
@@ -348,6 +348,24 @@ var _ = Describe("RouteHandler", func() {
 					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
 					Expect(message.AppGUIDs).To(HaveLen(1))
 					Expect(message.AppGUIDs[0]).To(Equal("my-app-guid"))
+				})
+			})
+			When("space_guid query parameters are provided", func() {
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?space_guids=my-space-guid", nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				})
+
+				It("calls route with expected parameters", func() {
+					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
+					Expect(message.AppGUIDs).To(HaveLen(0))
+					Expect(message.SpaceGUIDs).To(HaveLen(1))
+					Expect(message.SpaceGUIDs[0]).To(Equal("my-space-guid"))
 				})
 			})
 		})
@@ -415,7 +433,7 @@ var _ = Describe("RouteHandler", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, space_guids'")
 			})
 		})
 

--- a/api/apis/service_route_binding_handler.go
+++ b/api/apis/service_route_binding_handler.go
@@ -1,0 +1,48 @@
+package apis
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/go-logr/logr"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	ServiceRouteBindingsListEndpoint = "/v3/service_route_bindings"
+)
+
+type ServiceRouteBindingHandler struct {
+	logger    logr.Logger
+	serverURL url.URL
+}
+
+func NewServiceRouteBindingHandler(
+	logger logr.Logger,
+	serverURL url.URL) *ServiceRouteBindingHandler {
+	return &ServiceRouteBindingHandler{
+		logger:    logger,
+		serverURL: serverURL,
+	}
+}
+
+func (h *ServiceRouteBindingHandler) serviceRouteBindingsListHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	responseBody, err := json.Marshal(presenter.ForServiceRouteBindingsList(h.serverURL))
+	if err != nil {
+		h.logger.Error(err, "Failed to render response")
+		writeUnknownErrorResponse(w)
+		return
+	}
+
+	_, _ = w.Write(responseBody)
+}
+
+func (h *ServiceRouteBindingHandler) RegisterRoutes(router *mux.Router) {
+	router.Path(ServiceRouteBindingsListEndpoint).Methods("GET").HandlerFunc(h.serviceRouteBindingsListHandler)
+}

--- a/api/apis/service_route_binding_handler_test.go
+++ b/api/apis/service_route_binding_handler_test.go
@@ -1,0 +1,56 @@
+package apis_test
+
+import (
+	"fmt"
+	"net/http"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceRouteBinding", func() {
+	Describe("the GET /v3/service_route_binding endpoint", func() {
+		BeforeEach(func() {
+			req, err := http.NewRequest("GET", "/v3/service_route_bindings", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			apiHandler := apis.NewServiceRouteBindingHandler(
+				logf.Log.WithName("ServiceRouteBinding"),
+				*serverURL)
+
+			apiHandler.RegisterRoutes(router)
+
+			router.ServeHTTP(rr, req)
+		})
+
+		It("returns status 200 OK", func() {
+			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+		})
+
+		It("returns Content-Type as JSON in header", func() {
+			contentTypeHeader := rr.Header().Get("Content-Type")
+			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+		})
+
+		It("matches the expected response body format", func() {
+			Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+				"pagination": {
+				  "total_results": 0,
+				  "total_pages": 1,
+				  "first": {
+					"href": "%[1]s/v3/service_route_bindings"
+				  },
+				  "last": {
+					"href": "%[1]s/v3/service_route_bindings"
+				  },
+				  "next": null,
+				  "previous": null
+				},
+				"resources": []
+			}`, defaultServerURL)), "Response body matches LogCacheHandler response:")
+		})
+	})
+})

--- a/api/main.go
+++ b/api/main.go
@@ -125,6 +125,10 @@ func main() {
 			repositories.NewDomainRepo(privilegedCRClient),
 			repositories.NewAppRepo(privilegedCRClient, buildUserClient),
 		),
+		apis.NewServiceRouteBindingHandler(
+			ctrl.Log.WithName("ServiceRouteBinding"),
+			*serverURL,
+		),
 		apis.NewPackageHandler(
 			ctrl.Log.WithName("PackageHandler"),
 			*serverURL,

--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -54,6 +54,7 @@ type AppSetCurrentDroplet struct {
 
 type AppList struct {
 	Names      string `schema:"names"`
+	GUIDs      string `schema:"guids"`
 	SpaceGuids string `schema:"space_guids"`
 	OrderBy    string `schema:"order_by"`
 }
@@ -61,10 +62,11 @@ type AppList struct {
 func (a *AppList) ToMessage() repositories.AppListMessage {
 	return repositories.AppListMessage{
 		Names:      parseArrayParam(a.Names),
+		Guids:      parseArrayParam(a.GUIDs),
 		SpaceGuids: parseArrayParam(a.SpaceGuids),
 	}
 }
 
 func (a *AppList) SupportedFilterKeys() []string {
-	return []string{"names", "space_guids", "order_by"}
+	return []string{"names", "guids", "space_guids", "order_by"}
 }

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -34,14 +34,16 @@ func (p RouteCreate) ToRecord() repositories.RouteRecord {
 
 type RouteList struct {
 	AppGUIDs string `schema:"app_guids"`
+	SpaceGUIDs string `schema:"space_guids"`
 }
 
 func (p *RouteList) ToMessage() repositories.FetchRouteListMessage {
 	return repositories.FetchRouteListMessage{
 		AppGUIDs: parseArrayParam(p.AppGUIDs),
+		SpaceGUIDs: parseArrayParam(p.SpaceGUIDs),
 	}
 }
 
 func (p *RouteList) SupportedFilterKeys() []string {
-	return []string{"app_guids"}
+	return []string{"app_guids", "space_guids"}
 }

--- a/api/presenter/service_route_binding.go
+++ b/api/presenter/service_route_binding.go
@@ -1,0 +1,30 @@
+package presenter
+
+import "net/url"
+
+const (
+	serviceRouteBindingsBase = "/v3/service_route_bindings"
+)
+
+type ServiceRouteBinding struct{}
+
+type ServiceRouteBindingsResponse struct {
+	PaginationData PaginationData        `json:"pagination"`
+	Resources      []ServiceRouteBinding `json:"resources"`
+}
+
+func ForServiceRouteBindingsList(baseURL url.URL) ServiceRouteBindingsResponse {
+	return ServiceRouteBindingsResponse{
+		PaginationData: PaginationData{
+			TotalResults: 0,
+			TotalPages:   1,
+			First: PageRef{
+				HREF: buildURL(baseURL).appendPath(serviceRouteBindingsBase).build(),
+			},
+			Last: PageRef{
+				HREF: buildURL(baseURL).appendPath(serviceRouteBindingsBase).build(),
+			},
+		},
+		Resources: []ServiceRouteBinding{},
+	}
+}

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -232,6 +232,40 @@ var _ = Describe("AppRepository", func() {
 				})
 			})
 
+			When("a guid filter is provided", func() {
+				When("no Apps exist that match the filter", func() {
+					BeforeEach(func() {
+						createApp(space1.Name)
+						createApp(space2.Name)
+					})
+
+					It("returns an empty list of apps", func() {
+						message = AppListMessage{Guids: []string{"some-other-app-guid"}}
+						appList, err := appRepo.FetchAppList(testCtx, authInfo, message)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(appList).To(BeEmpty())
+					})
+				})
+
+				When("some Apps match the filter", func() {
+					BeforeEach(func() {
+						createApp(space1.Name)
+						cfApp2 = createAppWithGUID(space2.Name, "app-guid-2")
+						cfApp3 = createAppWithGUID(space1.Name, "app-guid-3")
+					})
+
+					It("returns the matching apps", func() {
+						message = AppListMessage{Guids: []string{"app-guid-2", "app-guid-3"}}
+						appList, err := appRepo.FetchAppList(testCtx, authInfo, message)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(appList).To(ConsistOf(
+							MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfApp2.Name)}),
+							MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfApp3.Name)}),
+						))
+					})
+				})
+			})
+
 			When("a space filter is provided", func() {
 				When("no Apps exist that match the filter", func() {
 					BeforeEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#308 

## What is this change about?
App Developer can run `cf routes` to list routes

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow README to deploy `cf-k8s-api` and `cf-k8s-controllers`
and then follow acceptance steps on #308 

## Tag your pair, your PM, and/or team
@acosta11 @julian-hj 