### PR TITLE
Properly handle route destination protocol

### DIFF
--- a/api/payloads/destination.go
+++ b/api/payloads/destination.go
@@ -13,7 +13,7 @@ type DestinationListCreate struct {
 type Destination struct {
 	App      *AppResource `json:"app" validate:"required"`
 	Port     *int         `json:"port"`
-	Protocol string       `json:"protocol" validate:"oneof=http http1"`
+	Protocol *string      `json:"protocol" validate:"omitempty,oneof=http1"`
 }
 
 type AppResource struct {
@@ -38,11 +38,17 @@ func (dc DestinationListCreate) ToMessage(routeRecord repositories.RouteRecord) 
 			port = *destination.Port
 		}
 
+		protocol := "http1"
+		if destination.Protocol != nil {
+			protocol = *destination.Protocol
+		}
+
 		destinationRecords = append(destinationRecords, repositories.DestinationRecord{
 			GUID:        uuid.NewString(),
 			AppGUID:     destination.App.GUID,
 			ProcessType: processType,
 			Port:        port,
+			Protocol:    protocol,
 		})
 	}
 	return repositories.RouteAddDestinationsMessage{

--- a/api/presenter/route.go
+++ b/api/presenter/route.go
@@ -170,7 +170,7 @@ func forDestination(destination repositories.DestinationRecord) routeDestination
 		},
 		Weight:   nil,
 		Port:     destination.Port,
-		Protocol: "http1",
+		Protocol: destination.Protocol,
 	}
 }
 

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -29,7 +29,8 @@ type DestinationRecord struct {
 	AppGUID     string
 	ProcessType string
 	Port        int
-	// Weight and Protocol intentionally omitted as experimental features
+	Protocol    string
+	// Weight intentionally omitted as experimental features
 }
 
 type RouteRecord struct {

--- a/controllers/config/samples/cfdomain.yaml
+++ b/controllers/config/samples/cfdomain.yaml
@@ -3,8 +3,5 @@ kind: CFDomain
 metadata:
   name: 5b5032ab-7fc8-4da5-b853-821fd1879201
   namespace: cf
-  # workloads.cloudfoundry.org/ labels are all managed by a mutating webhook
-  labels:
-    workloads.cloudfoundry.org/domainGUID: 5b5032ab-7fc8-4da5-b853-821fd1879201
 spec:
   name: cf-apps.io


### PR DESCRIPTION
## Is there a related GitHub Issue?
#330 

## What is this change about?
This PR properly handles route destination protocol

- move defaulting of the protocol value from the presenter to the
  message
- allow the client to specify a destination protocol
- clean up confusing test values (http vs http1)
- remove label from sample CFDomain resource

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #330 

## Tag your pair, your PM, and/or team
@acosta11 