### PR TITLE
Platform Operator can configure name of ClusterBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,13 @@ ln -s /usr/local/opt/openssl@3/bin/openssl /usr/local/bin/openssl
 ```
 
 ## Configure cf-k8s-controllers
-Configuration file for cf-k8s-controllers is at `config/base/controllersconfig/cf_k8s_controllers_k8s.yaml`
+Configuration file for cf-k8s-controllers is at `controllers/config/base/controllersconfig/cf_k8s_controllers_k8s.yaml`
 
-Note: Edit this file and set the `kpackImageTag` to be the registry location you want for storing the images.
+### Configure kpack
+
+Edit the configuration file 
+- (required) set the `kpackImageTag` to be the registry location you want for storing the images.
+- (optional) set the `clusterBuilderName`, if you want to use a different cluster builder with kpack.  
 
 ### Configure Workload Ingress TLS Certificate Secret
 Generate a self-signed certificate. If you are using openssl, or libressl v3.1.0 or later:

--- a/controllers/config/base/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,4 +1,5 @@
 kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
+clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
   memoryMB: 500
   diskQuotaMB: 512

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -12,6 +12,7 @@ import (
 
 type ControllerConfig struct {
 	KpackImageTag            string            `yaml:"kpackImageTag"`
+	ClusterBuilderName       string            `yaml:"clusterBuilderName"`
 	CFProcessDefaults        CFProcessDefaults `yaml:"cfProcessDefaults"`
 	CFK8sControllerNamespace string            `yaml:"cfk8s_controller_namespace"`
 	WorkloadsTLSSecretName   string            `yaml:"workloads_tls_secret_name"`

--- a/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,4 +1,5 @@
 kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
+clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
   memoryMB: 500
   diskQuotaMB: 512

--- a/controllers/controllers/networking/integration/suite_integration_test.go
+++ b/controllers/controllers/networking/integration/suite_integration_test.go
@@ -83,7 +83,8 @@ var _ = BeforeSuite(func() {
 		Scheme: k8sManager.GetScheme(),
 		Log:    ctrl.Log.WithName("controllers").WithName("CFRoute"),
 		ControllerConfig: &config.ControllerConfig{
-			KpackImageTag: "image/registry/tag",
+			KpackImageTag:      "image/registry/tag",
+			ClusterBuilderName: "cf-kpack-builder",
 			CFProcessDefaults: config.CFProcessDefaults{
 				MemoryMB:           500,
 				DefaultDiskQuotaMB: 512,

--- a/controllers/controllers/workloads/cfbuild_controller.go
+++ b/controllers/controllers/workloads/cfbuild_controller.go
@@ -47,11 +47,10 @@ import (
 )
 
 const (
-	kpackReadyConditionType   = "Ready"
-	clusterBuilderKind        = "ClusterBuilder"
-	clusterBuilderAPIVersion  = "kpack.io/v1alpha2"
-	kpackServiceAccount       = "kpack-service-account"
-	cfKpackClusterBuilderName = "cf-kpack-cluster-builder"
+	kpackReadyConditionType  = "Ready"
+	clusterBuilderKind       = "ClusterBuilder"
+	clusterBuilderAPIVersion = "kpack.io/v1alpha2"
+	kpackServiceAccount      = "kpack-service-account"
 )
 
 //counterfeiter:generate -o fake -fake-name RegistryAuthFetcher . RegistryAuthFetcher
@@ -217,7 +216,7 @@ func (r *CFBuildReconciler) createKpackImageAndUpdateStatus(ctx context.Context,
 			Tag: kpackImageTag,
 			Builder: corev1.ObjectReference{
 				Kind:       clusterBuilderKind,
-				Name:       cfKpackClusterBuilderName,
+				Name:       r.ControllerConfig.ClusterBuilderName,
 				APIVersion: clusterBuilderAPIVersion,
 			},
 			ServiceAccountName: serviceAccountName,

--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -105,6 +105,7 @@ var _ = Describe("CFBuildReconciler", func() {
 						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
 						Name:       desiredCFBuild.Name,
 					}))
+					Expect(createdKpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder"))
 					Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
 				})
 

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1547,6 +1547,7 @@ apiVersion: v1
 data:
   cf_k8s_controllers_config.yaml: |
     kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
+    clusterBuilderName: cf-kpack-cluster-builder
     cfProcessDefaults:
       memoryMB: 500
       diskQuotaMB: 512


### PR DESCRIPTION
## Is there a related GitHub Issue?
#329 

## What is this change about?
This change allows the platform operator to specify a different cluster builder to be used for kpack builds.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow acceptance on #329 

## Tag your pair, your PM, and/or team
@acosta11 