### PR TITLE
Implement filtering for GET /v3/routes

### DIFF
--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -148,7 +148,7 @@ func (h *RouteHandler) routeGetListHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForRouteList(routes, h.serverURL))
+	responseBody, err := json.Marshal(presenter.ForRouteList(routes, h.serverURL, r.URL))
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -278,10 +278,10 @@ var _ = Describe("RouteHandler", func() {
 					"total_results": 1,
 					"total_pages": 1,
 					"first": {
-						"href": "%[1]s/v3/routes?page=1"
+						"href": "%[1]s/v3/routes"
 					},
 					"last": {
-						"href": "%[1]s/v3/routes?page=1"
+						"href": "%[1]s/v3/routes"
 					},
 					"next": null,
 					"previous": null
@@ -333,7 +333,7 @@ var _ = Describe("RouteHandler", func() {
 				})
 			})
 
-			When("app_guid query parameters are provided", func() {
+			When("app_guids query parameters are provided", func() {
 				BeforeEach(func() {
 					var err error
 					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?app_guids=my-app-guid", nil)
@@ -344,13 +344,19 @@ var _ = Describe("RouteHandler", func() {
 					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
 				})
 
+				It("returns the Pagination Data with the app_guids filter", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/routes?app_guids=my-app-guid"))
+				})
+
 				It("calls route with expected parameters", func() {
+					Expect(routeRepo.FetchRouteListCallCount()).To(Equal(1))
 					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
 					Expect(message.AppGUIDs).To(HaveLen(1))
 					Expect(message.AppGUIDs[0]).To(Equal("my-app-guid"))
 				})
 			})
-			When("space_guid query parameters are provided", func() {
+
+			When("space_guids query parameters are provided", func() {
 				BeforeEach(func() {
 					var err error
 					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?space_guids=my-space-guid", nil)
@@ -361,11 +367,88 @@ var _ = Describe("RouteHandler", func() {
 					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
 				})
 
+				It("returns the Pagination Data with the space_guids filter", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/routes?space_guids=my-space-guid"))
+				})
+
 				It("calls route with expected parameters", func() {
+					Expect(routeRepo.FetchRouteListCallCount()).To(Equal(1))
 					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
 					Expect(message.AppGUIDs).To(HaveLen(0))
 					Expect(message.SpaceGUIDs).To(HaveLen(1))
 					Expect(message.SpaceGUIDs[0]).To(Equal("my-space-guid"))
+				})
+			})
+
+			When("domain_guids query parameters are provided", func() {
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?domain_guids=my-domain-guid", nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				})
+
+				It("returns the Pagination Data with the domain_guids filter", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/routes?domain_guids=my-domain-guid"))
+				})
+
+				It("calls route with expected parameters", func() {
+					Expect(routeRepo.FetchRouteListCallCount()).To(Equal(1))
+					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
+					Expect(message.AppGUIDs).To(HaveLen(0))
+					Expect(message.DomainGUIDs).To(HaveLen(1))
+					Expect(message.DomainGUIDs[0]).To(Equal("my-domain-guid"))
+				})
+			})
+
+			When("hosts query parameters are provided", func() {
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?hosts=my-host", nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				})
+
+				It("returns the Pagination Data with the hosts filter", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/routes?hosts=my-host"))
+				})
+
+				It("calls route with expected parameters", func() {
+					Expect(routeRepo.FetchRouteListCallCount()).To(Equal(1))
+					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
+					Expect(message.AppGUIDs).To(HaveLen(0))
+					Expect(message.Hosts).To(HaveLen(1))
+					Expect(message.Hosts[0]).To(Equal("my-host"))
+				})
+			})
+
+			When("paths query parameters are provided", func() {
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequestWithContext(ctx, "GET", "/v3/routes?paths=/some/path", nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns status 200 OK", func() {
+					Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				})
+
+				It("returns the Pagination Data with the paths filter", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/routes?paths=/some/path"))
+				})
+
+				It("calls route with expected parameters", func() {
+					Expect(routeRepo.FetchRouteListCallCount()).To(Equal(1))
+					_, _, message := routeRepo.FetchRouteListArgsForCall(0)
+					Expect(message.AppGUIDs).To(HaveLen(0))
+					Expect(message.Paths).To(HaveLen(1))
+					Expect(message.Paths[0]).To(Equal("/some/path"))
 				})
 			})
 		})
@@ -390,10 +473,10 @@ var _ = Describe("RouteHandler", func() {
 						"total_results": 0,
 						"total_pages": 1,
 						"first": {
-							"href": "%[1]s/v3/routes?page=1"
+							"href": "%[1]s/v3/routes"
 						},
 						"last": {
-							"href": "%[1]s/v3/routes?page=1"
+							"href": "%[1]s/v3/routes"
 						},
 						"next": null,
 						"previous": null
@@ -433,7 +516,7 @@ var _ = Describe("RouteHandler", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, space_guids'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, space_guids, domain_guids, hosts, paths'")
 			})
 		})
 

--- a/api/docs/api.md
+++ b/api/docs/api.md
@@ -205,7 +205,7 @@ curl "http://localhost:9000/v3/domains?names=cf-apps.io" \
 | Add Destinations to Route | POST /v3/routes/\<guid\>/destinations |
 
 #### [List Routes](https://v3-apidocs.cloudfoundry.org/version/3.111.0/index.html#list-routes)
-**Query Parameters:** Currently supports filtering by `app_guids`.
+**Query Parameters:** Currently supports filtering by `app_guids`, `space_guids`, `domain_guids`, `hosts` and `paths`.
 
 #### [Creating Routes](https://v3-apidocs.cloudfoundry.org/version/3.107.0/index.html#create-a-route)
 ```bash

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -33,17 +33,23 @@ func (p RouteCreate) ToRecord() repositories.RouteRecord {
 }
 
 type RouteList struct {
-	AppGUIDs string `schema:"app_guids"`
-	SpaceGUIDs string `schema:"space_guids"`
+	AppGUIDs    string `schema:"app_guids"`
+	SpaceGUIDs  string `schema:"space_guids"`
+	DomainGUIDs string `schema:"domain_guids"`
+	Hosts       string `schema:"hosts"`
+	Paths       string `schema:"paths"`
 }
 
 func (p *RouteList) ToMessage() repositories.FetchRouteListMessage {
 	return repositories.FetchRouteListMessage{
-		AppGUIDs: parseArrayParam(p.AppGUIDs),
-		SpaceGUIDs: parseArrayParam(p.SpaceGUIDs),
+		AppGUIDs:    parseArrayParam(p.AppGUIDs),
+		SpaceGUIDs:  parseArrayParam(p.SpaceGUIDs),
+		DomainGUIDs: parseArrayParam(p.DomainGUIDs),
+		Hosts:       parseArrayParam(p.Hosts),
+		Paths:       parseArrayParam(p.Paths),
 	}
 }
 
 func (p *RouteList) SupportedFilterKeys() []string {
-	return []string{"app_guids", "space_guids"}
+	return []string{"app_guids", "space_guids", "domain_guids", "hosts", "paths"}
 }

--- a/api/presenter/route.go
+++ b/api/presenter/route.go
@@ -113,7 +113,7 @@ func ForRoute(route repositories.RouteRecord, baseURL url.URL) RouteResponse {
 	}
 }
 
-func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL) RouteListResponse {
+func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL, requestURI *url.URL) RouteListResponse {
 	routeResponses := make([]RouteResponse, 0, len(routeRecordList))
 	for _, routeRecord := range routeRecordList {
 		routeResponses = append(routeResponses, ForRoute(routeRecord, baseURL))
@@ -124,10 +124,10 @@ func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL) R
 			TotalResults: len(routeResponses),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(baseURL).appendPath(routesBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURI.Path).setQuery(requestURI.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(baseURL).appendPath(routesBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURI.Path).setQuery(requestURI.RawQuery).build(),
 			},
 		},
 		Resources: routeResponses,

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -251,7 +251,7 @@ var _ = Describe("RouteRepository", func() {
 					},
 					Spec: networkingv1alpha1.CFRouteSpec{
 						Host:     "my-subdomain-2",
-						Path:     "",
+						Path:     "/some/path",
 						Protocol: "http",
 						DomainRef: corev1.LocalObjectReference{
 							Name: domainGUID,
@@ -373,6 +373,34 @@ var _ = Describe("RouteRepository", func() {
 						Expect(routeRecords).To(HaveLen(2))
 					})
 				})
+
+				When("domain_guid filters are provided", func() {
+					BeforeEach(func() {
+						message = FetchRouteListMessage{DomainGUIDs: []string{domainGUID}}
+					})
+					It("eventually returns a list of routeRecords for each CFRoute CR", func() {
+						Expect(routeRecords).To(HaveLen(2))
+					})
+				})
+
+				When("host filters are provided", func() {
+					BeforeEach(func() {
+						message = FetchRouteListMessage{Hosts: []string{"my-subdomain-1"}}
+					})
+					It("eventually returns a list of routeRecords for one of the CFRoute CRs", func() {
+						Expect(routeRecords).To(HaveLen(1))
+					})
+				})
+
+				When("path filters are provided", func() {
+					BeforeEach(func() {
+						message = FetchRouteListMessage{Paths: []string{"/some/path"}}
+					})
+					It("eventually returns a list of routeRecords for one of the CFRoute CRs", func() {
+						Expect(routeRecords).To(HaveLen(1))
+					})
+				})
+
 				When("app_guid filters are provided", func() {
 					BeforeEach(func() {
 						message = FetchRouteListMessage{AppGUIDs: []string{"some-app-guid"}}
@@ -410,9 +438,19 @@ var _ = Describe("RouteRepository", func() {
 					})
 				})
 			})
+
 			When("non-matching space_guid filters are provided", func() {
 				It("eventually returns a list of routeRecords for each CFRoute CR", func() {
 					message := FetchRouteListMessage{SpaceGUIDs: []string{"something-not-matching"}}
+					routeRecords, err := routeRepo.FetchRouteList(testCtx, authInfo, message)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(routeRecords).To(BeEmpty())
+				})
+			})
+
+			When("non-matching domain_guid filters are provided", func() {
+				It("eventually returns a list of routeRecords for each CFRoute CR", func() {
+					message := FetchRouteListMessage{DomainGUIDs: []string{"something-not-matching"}}
 					routeRecords, err := routeRepo.FetchRouteList(testCtx, authInfo, message)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(routeRecords).To(BeEmpty())


### PR DESCRIPTION
## Is there a related GitHub Issue?
#309

## What is this change about?
This PR implements filtering by domain_guids, hosts and paths for the GET /v3/routes endpoint as required for the `cf map-route` command.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #309

## Tag your pair, your PM, and/or team
@julian-hj 