### PR TITLE
Issue 264 create space service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,48 +342,6 @@ kubectl create secret tls \
 **NOTE**: If you choose to generate a self-signed certificate, you will need to
 skip TLS validation when connecting to the API.
 
-### Creating a CF Space
-As the current implementation of HNC does not correctly propagate ServiceAccounts, when we `cf create-space`, the ServiceAccount required for image building is absent. We must create the
-ServiceAccount ourselves with a reference to the image registry credentials.
-
-1. Pre-req: Have a local copy of the required ServiceAccount resources
-
-    ```
-    cat <<EOF >> service-accounts.yml
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: eirini
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: kpack-service-account
-    imagePullSecrets:
-    - name: image-registry-credentials
-    secrets:
-    - name: image-registry-credentials
-    EOF
-    ```
-
-1. Create the cf space
-    ```
-    cf create-org <org_name>
-    cf target -o <org_name>
-    cf create-space <space_name>
-    ```
-
-1. Get the cf space guid which corresponds to the kubernetes namespace in which we create the ServiceAccount
-    ```
-    cf space <space_name> —guid
-    ```
-
-1. Apply the `service-accounts.yml` to that namespace
-    ```
-    kubectl apply -f service-accounts.yml -n <space_guid>
-    ```
-
 ### Running Tests
 make
 ```sh

--- a/api/apis/fake/cfrole_repository.go
+++ b/api/apis/fake/cfrole_repository.go
@@ -10,11 +10,11 @@ import (
 )
 
 type CFRoleRepository struct {
-	CreateRoleStub        func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)
+	CreateRoleStub        func(context.Context, repositories.RoleCreateMessage) (repositories.RoleRecord, error)
 	createRoleMutex       sync.RWMutex
 	createRoleArgsForCall []struct {
 		arg1 context.Context
-		arg2 repositories.RoleRecord
+		arg2 repositories.RoleCreateMessage
 	}
 	createRoleReturns struct {
 		result1 repositories.RoleRecord
@@ -28,12 +28,12 @@ type CFRoleRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFRoleRepository) CreateRole(arg1 context.Context, arg2 repositories.RoleRecord) (repositories.RoleRecord, error) {
+func (fake *CFRoleRepository) CreateRole(arg1 context.Context, arg2 repositories.RoleCreateMessage) (repositories.RoleRecord, error) {
 	fake.createRoleMutex.Lock()
 	ret, specificReturn := fake.createRoleReturnsOnCall[len(fake.createRoleArgsForCall)]
 	fake.createRoleArgsForCall = append(fake.createRoleArgsForCall, struct {
 		arg1 context.Context
-		arg2 repositories.RoleRecord
+		arg2 repositories.RoleCreateMessage
 	}{arg1, arg2})
 	stub := fake.CreateRoleStub
 	fakeReturns := fake.createRoleReturns
@@ -54,13 +54,13 @@ func (fake *CFRoleRepository) CreateRoleCallCount() int {
 	return len(fake.createRoleArgsForCall)
 }
 
-func (fake *CFRoleRepository) CreateRoleCalls(stub func(context.Context, repositories.RoleRecord) (repositories.RoleRecord, error)) {
+func (fake *CFRoleRepository) CreateRoleCalls(stub func(context.Context, repositories.RoleCreateMessage) (repositories.RoleRecord, error)) {
 	fake.createRoleMutex.Lock()
 	defer fake.createRoleMutex.Unlock()
 	fake.CreateRoleStub = stub
 }
 
-func (fake *CFRoleRepository) CreateRoleArgsForCall(i int) (context.Context, repositories.RoleRecord) {
+func (fake *CFRoleRepository) CreateRoleArgsForCall(i int) (context.Context, repositories.RoleCreateMessage) {
 	fake.createRoleMutex.RLock()
 	defer fake.createRoleMutex.RUnlock()
 	argsForCall := fake.createRoleArgsForCall[i]

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -52,7 +52,7 @@ func (h *OrgHandler) orgCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	org := payload.ToRecord()
+	org := payload.ToMessage()
 	org.GUID = uuid.NewString()
 
 	orgRepo, err := h.orgRepoProvider.OrgRepoForRequest(r)

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -56,10 +56,16 @@ var _ = Describe("OrgHandler", func() {
 		}
 
 		BeforeEach(func() {
-			orgRepo.CreateOrgStub = func(_ context.Context, record repositories.OrgRecord) (repositories.OrgRecord, error) {
-				record.GUID = "t-h-e-o-r-g"
-				record.CreatedAt = now
-				record.UpdatedAt = now
+			orgRepo.CreateOrgStub = func(_ context.Context, message repositories.OrgCreateMessage) (repositories.OrgRecord, error) {
+				record := repositories.OrgRecord{
+					Name:        message.Name,
+					GUID:        "t-h-e-o-r-g",
+					Suspended:   message.Suspended,
+					Labels:      message.Labels,
+					Annotations: message.Annotations,
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				}
 				return record, nil
 			}
 		})

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -39,7 +39,7 @@ const (
 //counterfeiter:generate -o fake -fake-name CFRoleRepository . CFRoleRepository
 
 type CFRoleRepository interface {
-	CreateRole(ctx context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error)
+	CreateRole(ctx context.Context, role repositories.RoleCreateMessage) (repositories.RoleRecord, error)
 }
 
 type RoleHandler struct {
@@ -68,7 +68,7 @@ func (h *RoleHandler) roleCreateHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	role := payload.ToRecord()
+	role := payload.ToMessage()
 	role.GUID = uuid.NewString()
 
 	record, err := h.roleRepo.CreateRole(r.Context(), role)

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -91,12 +91,19 @@ var _ = Describe("RoleHandler", func() {
 		var createRoleRequestBody string
 
 		BeforeEach(func() {
-			roleRepo.CreateRoleStub = func(_ context.Context, role repositories.RoleRecord) (repositories.RoleRecord, error) {
-				role.GUID = "t-h-e-r-o-l-e"
-				role.CreatedAt = now
-				role.UpdatedAt = now
+			roleRepo.CreateRoleStub = func(_ context.Context, message repositories.RoleCreateMessage) (repositories.RoleRecord, error) {
+				roleRecord := repositories.RoleRecord{
+					GUID:      "t-h-e-r-o-l-e",
+					CreatedAt: now,
+					UpdatedAt: now,
+					Type:      message.Type,
+					Space:     message.Space,
+					Org:       message.Org,
+					User:      message.User,
+					Kind:      message.Kind,
+				}
 
-				return role, nil
+				return roleRecord, nil
 			}
 
 			createRoleRequestBody = `{

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -37,7 +37,7 @@ func NewSpaceHandler(apiBaseURL url.URL, spaceRepoProvider SpaceRepositoryProvid
 	return &SpaceHandler{
 		apiBaseURL:        apiBaseURL,
 		spaceRepoProvider: spaceRepoProvider,
-		logger:            controllerruntime.Log.WithName("Org Handler"),
+		logger:            controllerruntime.Log.WithName("Space Handler"),
 	}
 }
 
@@ -52,7 +52,8 @@ func (h *SpaceHandler) SpaceCreateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	space := payload.ToRecord()
+	space := payload.ToMessage()
+	// TODO: Move this GUID generation down to the repository layer?
 	space.GUID = uuid.NewString()
 
 	spaceRepo, err := h.spaceRepoProvider.SpaceRepoForRequest(r)
@@ -77,6 +78,7 @@ func (h *SpaceHandler) SpaceCreateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// TODO: Convert space to a SpaceRecord or update repo to accept message payload?
 	record, err := spaceRepo.CreateSpace(ctx, space)
 	if err != nil {
 		if workloads.HasErrorCode(err, workloads.DuplicateSpaceNameError) {

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -21,6 +21,7 @@ import (
 
 var _ = Describe("Spaces", func() {
 	const spacesBase = "/v3/spaces"
+	const registryCredentialsSecretName = "image-registry-credentials"
 
 	var (
 		now               time.Time
@@ -39,7 +40,7 @@ var _ = Describe("Spaces", func() {
 		spaceRepo = new(repositoriesfake.CFSpaceRepository)
 		spaceRepoProvider = new(fake.SpaceRepositoryProvider)
 		spaceRepoProvider.SpaceRepoForRequestReturns(spaceRepo, nil)
-		spaceHandler = apis.NewSpaceHandler(*serverURL, spaceRepoProvider)
+		spaceHandler = apis.NewSpaceHandler(*serverURL, registryCredentialsSecretName, spaceRepoProvider)
 		spaceHandler.RegisterRoutes(router)
 	})
 

--- a/api/config/base/rbac/role.yaml
+++ b/api/config/base/rbac/role.yaml
@@ -42,6 +42,8 @@ rules:
   - secrets
   - serviceaccounts
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch

--- a/api/main.go
+++ b/api/main.go
@@ -170,8 +170,8 @@ func main() {
 		apis.NewLogCacheHandler(),
 
 		apis.NewOrgHandler(*serverURL, wireOrgRepoProvider(orgRepo, privilegedCRClient, config.AuthEnabled, identityProvider)),
-		// TODO: Pass through config.PackageRegistrySecretName here
-		apis.NewSpaceHandler(*serverURL, wireSpaceRepoProvider(orgRepo, privilegedCRClient, config.AuthEnabled, identityProvider)),
+		// TODO: Pass through config.PackageRegistrySecretName here (do we use the SpaceRepoProvider or the Handler?
+		apis.NewSpaceHandler(*serverURL, config.PackageRegistrySecretName, wireSpaceRepoProvider(orgRepo, privilegedCRClient, config.AuthEnabled, identityProvider)),
 
 		apis.NewSpaceManifestHandler(
 			ctrl.Log.WithName("SpaceManifestHandler"),

--- a/api/main.go
+++ b/api/main.go
@@ -170,6 +170,7 @@ func main() {
 		apis.NewLogCacheHandler(),
 
 		apis.NewOrgHandler(*serverURL, wireOrgRepoProvider(orgRepo, privilegedCRClient, config.AuthEnabled, identityProvider)),
+		// TODO: Pass through config.PackageRegistrySecretName here
 		apis.NewSpaceHandler(*serverURL, wireSpaceRepoProvider(orgRepo, privilegedCRClient, config.AuthEnabled, identityProvider)),
 
 		apis.NewSpaceManifestHandler(

--- a/api/payloads/org.go
+++ b/api/payloads/org.go
@@ -1,8 +1,6 @@
 package payloads
 
-import (
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
-)
+import "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
 type OrgCreate struct {
 	Name      string   `json:"name" validate:"required"`
@@ -10,8 +8,8 @@ type OrgCreate struct {
 	Metadata  Metadata `json:"metadata"`
 }
 
-func (p OrgCreate) ToRecord() repositories.OrgRecord {
-	return repositories.OrgRecord{
+func (p OrgCreate) ToMessage() repositories.OrgCreateMessage {
+	return repositories.OrgCreateMessage{
 		Name:        p.Name,
 		Suspended:   p.Suspended,
 		Labels:      p.Metadata.Labels,

--- a/api/payloads/role.go
+++ b/api/payloads/role.go
@@ -26,8 +26,8 @@ type RoleRelationships struct {
 	Organization             *Relationship     `json:"organization"`
 }
 
-func (p RoleCreate) ToRecord() repositories.RoleRecord {
-	record := repositories.RoleRecord{
+func (p RoleCreate) ToMessage() repositories.RoleCreateMessage {
+	record := repositories.RoleCreateMessage{
 		Type: p.Type,
 	}
 

--- a/api/payloads/space.go
+++ b/api/payloads/space.go
@@ -1,8 +1,6 @@
 package payloads
 
-import (
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
-)
+import "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
 type SpaceCreate struct {
 	Name          string             `json:"name" validate:"required"`
@@ -14,11 +12,9 @@ type SpaceRelationships struct {
 	Org Relationship `json:"organization" validate:"required"`
 }
 
-func (p SpaceCreate) ToRecord() repositories.SpaceRecord {
-	return repositories.SpaceRecord{
+func (p SpaceCreate) ToMessage() repositories.SpaceCreateMessage {
+	return repositories.SpaceCreateMessage{
 		Name:             p.Name,
 		OrganizationGUID: p.Relationships.Org.Data.GUID,
-		Labels:           p.Metadata.Labels,
-		Annotations:      p.Metadata.Annotations,
 	}
 }

--- a/api/payloads/space.go
+++ b/api/payloads/space.go
@@ -12,9 +12,10 @@ type SpaceRelationships struct {
 	Org Relationship `json:"organization" validate:"required"`
 }
 
-func (p SpaceCreate) ToMessage() repositories.SpaceCreateMessage {
+func (p SpaceCreate) ToMessage(imageRegistryCredentialSecret string) repositories.SpaceCreateMessage {
 	return repositories.SpaceCreateMessage{
-		Name:             p.Name,
-		OrganizationGUID: p.Relationships.Org.Data.GUID,
+		Name:                     p.Name,
+		OrganizationGUID:         p.Relationships.Org.Data.GUID,
+		ImageRegistryCredentials: imageRegistryCredentialSecret,
 	}
 }

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -51,6 +51,8 @@ rules:
   - secrets
   - serviceaccounts
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch

--- a/api/repositories/fake/cforg_repository.go
+++ b/api/repositories/fake/cforg_repository.go
@@ -9,11 +9,11 @@ import (
 )
 
 type CFOrgRepository struct {
-	CreateOrgStub        func(context.Context, repositories.OrgRecord) (repositories.OrgRecord, error)
+	CreateOrgStub        func(context.Context, repositories.OrgCreateMessage) (repositories.OrgRecord, error)
 	createOrgMutex       sync.RWMutex
 	createOrgArgsForCall []struct {
 		arg1 context.Context
-		arg2 repositories.OrgRecord
+		arg2 repositories.OrgCreateMessage
 	}
 	createOrgReturns struct {
 		result1 repositories.OrgRecord
@@ -41,12 +41,12 @@ type CFOrgRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFOrgRepository) CreateOrg(arg1 context.Context, arg2 repositories.OrgRecord) (repositories.OrgRecord, error) {
+func (fake *CFOrgRepository) CreateOrg(arg1 context.Context, arg2 repositories.OrgCreateMessage) (repositories.OrgRecord, error) {
 	fake.createOrgMutex.Lock()
 	ret, specificReturn := fake.createOrgReturnsOnCall[len(fake.createOrgArgsForCall)]
 	fake.createOrgArgsForCall = append(fake.createOrgArgsForCall, struct {
 		arg1 context.Context
-		arg2 repositories.OrgRecord
+		arg2 repositories.OrgCreateMessage
 	}{arg1, arg2})
 	stub := fake.CreateOrgStub
 	fakeReturns := fake.createOrgReturns
@@ -67,13 +67,13 @@ func (fake *CFOrgRepository) CreateOrgCallCount() int {
 	return len(fake.createOrgArgsForCall)
 }
 
-func (fake *CFOrgRepository) CreateOrgCalls(stub func(context.Context, repositories.OrgRecord) (repositories.OrgRecord, error)) {
+func (fake *CFOrgRepository) CreateOrgCalls(stub func(context.Context, repositories.OrgCreateMessage) (repositories.OrgRecord, error)) {
 	fake.createOrgMutex.Lock()
 	defer fake.createOrgMutex.Unlock()
 	fake.CreateOrgStub = stub
 }
 
-func (fake *CFOrgRepository) CreateOrgArgsForCall(i int) (context.Context, repositories.OrgRecord) {
+func (fake *CFOrgRepository) CreateOrgArgsForCall(i int) (context.Context, repositories.OrgCreateMessage) {
 	fake.createOrgMutex.RLock()
 	defer fake.createOrgMutex.RUnlock()
 	argsForCall := fake.createOrgArgsForCall[i]

--- a/api/repositories/fake/cfspace_repository.go
+++ b/api/repositories/fake/cfspace_repository.go
@@ -9,11 +9,11 @@ import (
 )
 
 type CFSpaceRepository struct {
-	CreateSpaceStub        func(context.Context, repositories.SpaceRecord) (repositories.SpaceRecord, error)
+	CreateSpaceStub        func(context.Context, repositories.SpaceCreateMessage) (repositories.SpaceRecord, error)
 	createSpaceMutex       sync.RWMutex
 	createSpaceArgsForCall []struct {
 		arg1 context.Context
-		arg2 repositories.SpaceRecord
+		arg2 repositories.SpaceCreateMessage
 	}
 	createSpaceReturns struct {
 		result1 repositories.SpaceRecord
@@ -42,12 +42,12 @@ type CFSpaceRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *CFSpaceRepository) CreateSpace(arg1 context.Context, arg2 repositories.SpaceRecord) (repositories.SpaceRecord, error) {
+func (fake *CFSpaceRepository) CreateSpace(arg1 context.Context, arg2 repositories.SpaceCreateMessage) (repositories.SpaceRecord, error) {
 	fake.createSpaceMutex.Lock()
 	ret, specificReturn := fake.createSpaceReturnsOnCall[len(fake.createSpaceArgsForCall)]
 	fake.createSpaceArgsForCall = append(fake.createSpaceArgsForCall, struct {
 		arg1 context.Context
-		arg2 repositories.SpaceRecord
+		arg2 repositories.SpaceCreateMessage
 	}{arg1, arg2})
 	stub := fake.CreateSpaceStub
 	fakeReturns := fake.createSpaceReturns
@@ -68,13 +68,13 @@ func (fake *CFSpaceRepository) CreateSpaceCallCount() int {
 	return len(fake.createSpaceArgsForCall)
 }
 
-func (fake *CFSpaceRepository) CreateSpaceCalls(stub func(context.Context, repositories.SpaceRecord) (repositories.SpaceRecord, error)) {
+func (fake *CFSpaceRepository) CreateSpaceCalls(stub func(context.Context, repositories.SpaceCreateMessage) (repositories.SpaceRecord, error)) {
 	fake.createSpaceMutex.Lock()
 	defer fake.createSpaceMutex.Unlock()
 	fake.CreateSpaceStub = stub
 }
 
-func (fake *CFSpaceRepository) CreateSpaceArgsForCall(i int) (context.Context, repositories.SpaceRecord) {
+func (fake *CFSpaceRepository) CreateSpaceArgsForCall(i int) (context.Context, repositories.SpaceCreateMessage) {
 	fake.createSpaceMutex.RLock()
 	defer fake.createSpaceMutex.RUnlock()
 	argsForCall := fake.createSpaceArgsForCall[i]

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -18,12 +18,12 @@ import (
 //counterfeiter:generate -o fake -fake-name CFSpaceRepository . CFSpaceRepository
 
 type CFOrgRepository interface {
-	CreateOrg(context context.Context, org OrgRecord) (OrgRecord, error)
+	CreateOrg(context context.Context, org OrgCreateMessage) (OrgRecord, error)
 	FetchOrgs(context context.Context, orgNames []string) ([]OrgRecord, error)
 }
 
 type CFSpaceRepository interface {
-	CreateSpace(context.Context, SpaceRecord) (SpaceRecord, error)
+	CreateSpace(context.Context, SpaceCreateMessage) (SpaceRecord, error)
 	FetchSpaces(context.Context, []string, []string) ([]SpaceRecord, error)
 }
 
@@ -31,6 +31,20 @@ const (
 	OrgNameLabel   = "cloudfoundry.org/org-name"
 	SpaceNameLabel = "cloudfoundry.org/space-name"
 )
+
+type OrgCreateMessage struct {
+	Name        string
+	GUID        string
+	Suspended   bool
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+type SpaceCreateMessage struct {
+	Name             string
+	GUID             string
+	OrganizationGUID string
+}
 
 type OrgRecord struct {
 	Name        string
@@ -66,7 +80,7 @@ func NewOrgRepo(rootNamespace string, privilegedClient client.WithWatch, timeout
 	}
 }
 
-func (r *OrgRepo) CreateOrg(ctx context.Context, org OrgRecord) (OrgRecord, error) {
+func (r *OrgRepo) CreateOrg(ctx context.Context, org OrgCreateMessage) (OrgRecord, error) {
 	anchor, err := r.createSubnamespaceAnchor(ctx, &v1alpha2.SubnamespaceAnchor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      org.GUID,
@@ -80,20 +94,26 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, org OrgRecord) (OrgRecord, erro
 		return OrgRecord{}, err
 	}
 
-	org.GUID = anchor.Name
-	org.CreatedAt = anchor.CreationTimestamp.Time
-	org.UpdatedAt = anchor.CreationTimestamp.Time
+	orgRecord := OrgRecord{
+		Name:        org.Name,
+		GUID:        anchor.Name,
+		Suspended:   org.Suspended,
+		Labels:      org.Labels,
+		Annotations: org.Annotations,
+		CreatedAt:   anchor.CreationTimestamp.Time,
+		UpdatedAt:   anchor.CreationTimestamp.Time,
+	}
 
-	return org, nil
+	return orgRecord, nil
 }
 
-func (r *OrgRepo) CreateSpace(ctx context.Context, space SpaceRecord) (SpaceRecord, error) {
+func (r *OrgRepo) CreateSpace(ctx context.Context, message SpaceCreateMessage) (SpaceRecord, error) {
 	anchor, err := r.createSubnamespaceAnchor(ctx, &v1alpha2.SubnamespaceAnchor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      space.GUID,
-			Namespace: space.OrganizationGUID,
+			Name:      message.GUID,
+			Namespace: message.OrganizationGUID,
 			Labels: map[string]string{
-				SpaceNameLabel: space.Name,
+				SpaceNameLabel: message.Name,
 			},
 		},
 	})
@@ -101,11 +121,19 @@ func (r *OrgRepo) CreateSpace(ctx context.Context, space SpaceRecord) (SpaceReco
 		return SpaceRecord{}, err
 	}
 
-	space.GUID = anchor.Name
-	space.CreatedAt = anchor.CreationTimestamp.Time
-	space.UpdatedAt = anchor.CreationTimestamp.Time
+	// TODO: Insert Service Account creation
+	// createKpackServiceAccount()
+	// createEiriniServiceAccount()
 
-	return space, nil
+	record := SpaceRecord{
+		Name:             message.Name,
+		GUID:             anchor.Name,
+		OrganizationGUID: message.OrganizationGUID,
+		CreatedAt:        anchor.CreationTimestamp.Time,
+		UpdatedAt:        anchor.CreationTimestamp.Time,
+	}
+
+	return record, nil
 }
 
 func (r *OrgRepo) createSubnamespaceAnchor(ctx context.Context, anchor *v1alpha2.SubnamespaceAnchor) (*v1alpha2.SubnamespaceAnchor, error) {

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -119,6 +119,19 @@ func createSpaceAnchorAndNamespace(ctx context.Context, orgName, name string) *h
 	return space
 }
 
+func createNamespace(ctx context.Context, orgName, name string) *corev1.Namespace {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				hnsv1alpha2.SubnamespaceOf: orgName,
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+	return namespace
+}
+
 func createSpaceDeveloperClusterRole(ctx context.Context) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Is there a related GitHub Issue?
#264

## What is this change about?
Automatically create the service accounts necessary for builds in new cf space namespaces

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Install the API and dependencies according to the README, install cf cli v8, follow test cases listed in the acceptance criteria on related issue.

## Tag your pair, your PM, and/or team
paired w/ @julian-hj @akrishna90 
