### PR TITLE
Generate workload ingress secret in install-dependencies

### DIFF
--- a/scripts/generate-workload-ingress-certs-secret.sh
+++ b/scripts/generate-workload-ingress-certs-secret.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+echo "Will now generate tls.ca tls.crt and tls.key files"
+
+keys="$(mktemp -d)"
+trap 'rm -rf "${keys}"' EXIT
+
+readonly CONTROLLERS_NAMESPACE=cf-k8s-controllers-system
+otherDNS="$1"
+
+pushd "${keys}"
+{
+  kubectl create namespace "${CONTROLLERS_NAMESPACE}" || true
+
+  openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -addext "subjectAltName = DNS:${otherDNS}" -days 365
+
+  for secret_name in cf-k8s-workloads-ingress-cert; do
+    if kubectl -n "${CONTROLLERS_NAMESPACE}" get secret "${secret_name}" >/dev/null 2>&1; then
+      kubectl delete secret -n "${CONTROLLERS_NAMESPACE}" "${secret_name}"
+    fi
+
+    echo "Creating the ${secret_name} secret in your kubernetes cluster..."
+    kubectl create secret -n "${CONTROLLERS_NAMESPACE}" generic "${secret_name}" --from-file=tls.crt=./tls.crt --from-file=tls.ca=./tls.crt --from-file=tls.key=./tls.key
+  done
+
+  echo "Done!"
+}
+popd

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -153,6 +153,11 @@ helm template eirini-controller "${EIRINI_DIR}/deployment/helm" \
   --set "images.eirini_controller=eirini/eirini-controller@sha256:42e22b3222e9b3788782f5c141d260a5e163da4f4032e2926752ef2e5bae0685" \
   --namespace "eirini-controller" | kubectl apply -f -
 
+echo "*******************"
+echo "Configuring CF-K8S controllers"
+echo "*******************"
+"${SCRIPT_DIR}/generate-workload-ingress-certs-secret.sh" "localhost"
+
 echo "******"
 echo "Done"
 echo "******"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Generate the workload ingress secret when running `install-dependencies.sh` as [described](https://github.com/cloudfoundry/cf-k8s-controllers/#configure-workload-ingress-tls-certificate-secret) in the README

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Run `install-dependencies.sh`
2. See the `cf-k8s-workloads-ingress-cert` secret is create 