### PR TITLE
Implements `cf restart` (using controllers)

### DIFF
--- a/controllers/apis/workloads/v1alpha1/cfapp_types.go
+++ b/controllers/apis/workloads/v1alpha1/cfapp_types.go
@@ -51,6 +51,8 @@ type DesiredState string
 type CFAppStatus struct {
 	// Conditions capture the current status of the App
 	Conditions []metav1.Condition `json:"conditions"`
+
+	ObservedDesiredState DesiredState `json:"observedDesiredState"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/apis/workloads/v1alpha1/cfapp_webhook_test.go
+++ b/controllers/apis/workloads/v1alpha1/cfapp_webhook_test.go
@@ -1,6 +1,8 @@
 package v1alpha1_test
 
 import (
+	"strconv"
+
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
@@ -10,9 +12,10 @@ import (
 
 var _ = Describe("CFAppMutatingWebhook Unit Tests", func() {
 	const (
-		cfAppGUID     = "test-app-guid"
-		cfAppLabelKey = "workloads.cloudfoundry.org/app-guid"
-		namespace     = "default"
+		cfAppGUID        = "test-app-guid"
+		cfAppLabelKey    = "workloads.cloudfoundry.org/app-guid"
+		cfAppRevisionKey = "workloads.cloudfoundry.org/app-rev"
+		namespace        = "default"
 	)
 
 	When("there are no existing labels on the CFAPP record", func() {
@@ -37,6 +40,7 @@ var _ = Describe("CFAppMutatingWebhook Unit Tests", func() {
 
 			cfApp.Default()
 			Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfAppGUID))
+			Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, "0"))
 		})
 	})
 
@@ -53,6 +57,9 @@ var _ = Describe("CFAppMutatingWebhook Unit Tests", func() {
 					Labels: map[string]string{
 						"anotherLabel": "app-label",
 					},
+					Annotations: map[string]string{
+						"someAnnotation": "blah",
+					},
 				},
 				Spec: v1alpha1.CFAppSpec{
 					Name:         "test-app",
@@ -66,6 +73,116 @@ var _ = Describe("CFAppMutatingWebhook Unit Tests", func() {
 			cfApp.Default()
 			Expect(cfApp.ObjectMeta.Labels).To(HaveLen(2))
 			Expect(cfApp.ObjectMeta.Labels).To(HaveKeyWithValue("anotherLabel", "app-label"))
+			Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, "0"))
+		})
+	})
+
+	When("the app desiredState STARTED->STOPPED and status.observedDesiredState is STARTED and", func() {
+		When("rev is set to an integer value", func() {
+			const (
+				revisionValue = 7
+			)
+			var cfApp *v1alpha1.CFApp
+			BeforeEach(func() {
+				cfApp = initializeCFAppCR(cfAppGUID, namespace)
+				cfApp.Spec.DesiredState = v1alpha1.StoppedState
+				cfApp.Annotations[v1alpha1.CFAppRevisionKey] = strconv.Itoa(revisionValue)
+				cfApp.Status.ObservedDesiredState = v1alpha1.StartedState
+			})
+
+			It("should increment the rev", func() {
+				cfApp.Default()
+				Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, strconv.Itoa(revisionValue+1)))
+			})
+		})
+
+		When("rev is set to some non-integer value", func() {
+			var cfApp *v1alpha1.CFApp
+			BeforeEach(func() {
+				cfApp = initializeCFAppCR(cfAppGUID, namespace)
+				cfApp.Spec.DesiredState = v1alpha1.StoppedState
+				cfApp.Annotations[v1alpha1.CFAppRevisionKey] = "some-weird-value"
+				cfApp.Status.ObservedDesiredState = v1alpha1.StartedState
+			})
+
+			It("should set the rev to be the default value", func() {
+				cfApp.Default()
+				Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, v1alpha1.CFAppRevisionKeyDefault))
+			})
+		})
+	})
+
+	When("the app desiredState STOPPED->STARTED and status.observedDesiredState is STOPPED and", func() {
+		When("rev is set to an integer value", func() {
+			const (
+				revisionValue = 7
+			)
+			var cfApp *v1alpha1.CFApp
+			BeforeEach(func() {
+				cfApp = initializeCFAppCR(cfAppGUID, namespace)
+				cfApp.Spec.DesiredState = v1alpha1.StartedState
+				cfApp.Annotations[v1alpha1.CFAppRevisionKey] = strconv.Itoa(revisionValue)
+				cfApp.Status.ObservedDesiredState = v1alpha1.StoppedState
+			})
+
+			It("should leave the rev alone", func() {
+				cfApp.Default()
+				Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, strconv.Itoa(revisionValue)))
+			})
+		})
+
+		When("rev is set to some non-integer value", func() {
+			const (
+				weirdRevValue = "some-weird-value"
+			)
+			var cfApp *v1alpha1.CFApp
+			BeforeEach(func() {
+				cfApp = initializeCFAppCR(cfAppGUID, namespace)
+				cfApp.Spec.DesiredState = v1alpha1.StartedState
+				cfApp.Annotations[v1alpha1.CFAppRevisionKey] = weirdRevValue
+				cfApp.Status.ObservedDesiredState = v1alpha1.StoppedState
+			})
+
+			It("should leave the rev alone", func() {
+				cfApp.Default()
+				Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, weirdRevValue))
+			})
+		})
+
+		When("rev is not set", func() {
+			var cfApp *v1alpha1.CFApp
+			BeforeEach(func() {
+				cfApp = initializeCFAppCR(cfAppGUID, namespace)
+				cfApp.Spec.DesiredState = v1alpha1.StartedState
+				cfApp.Status.ObservedDesiredState = v1alpha1.StoppedState
+			})
+
+			It("should set it to the default value", func() {
+				cfApp.Default()
+				Expect(cfApp.ObjectMeta.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, v1alpha1.CFAppRevisionKeyDefault))
+			})
 		})
 	})
 })
+
+func initializeCFAppCR(appGUID, namespace string) *v1alpha1.CFApp {
+	return &v1alpha1.CFApp{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CFApp",
+			APIVersion: v1alpha1.GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        appGUID,
+			Namespace:   namespace,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Spec: v1alpha1.CFAppSpec{
+			Name:         "test-app",
+			DesiredState: "STOPPED",
+			Lifecycle: v1alpha1.Lifecycle{
+				Type: "buildpack",
+			},
+		},
+	}
+}

--- a/controllers/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/cfapp_webhook_integration_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
@@ -16,8 +17,9 @@ import (
 var _ = Describe("CFAppMutatingWebhook Integration Tests", func() {
 	When("a CFApp record is created", func() {
 		const (
-			cfAppLabelKey = "workloads.cloudfoundry.org/app-guid"
-			namespace     = "default"
+			cfAppLabelKey    = "workloads.cloudfoundry.org/app-guid"
+			cfAppRevisionKey = "workloads.cloudfoundry.org/app-rev"
+			namespace        = "default"
 		)
 
 		var cfAppGUID string
@@ -25,6 +27,7 @@ var _ = Describe("CFAppMutatingWebhook Integration Tests", func() {
 		It(" should add a metadata label on it and it matches metadata.name", func() {
 			testCtx := context.Background()
 			cfAppGUID = GenerateGUID()
+			cfAppName := cfAppGUID + "-app"
 			cfApp := &v1alpha1.CFApp{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CFApp",
@@ -35,7 +38,7 @@ var _ = Describe("CFAppMutatingWebhook Integration Tests", func() {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.CFAppSpec{
-					Name:         "test-app",
+					Name:         cfAppName,
 					DesiredState: "STOPPED",
 					Lifecycle: v1alpha1.Lifecycle{
 						Type: "buildpack",
@@ -56,7 +59,79 @@ var _ = Describe("CFAppMutatingWebhook Integration Tests", func() {
 			}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFApp resource does not have any metadata.labels")
 
 			Expect(createdCFApp.ObjectMeta.Labels).To(HaveKeyWithValue(cfAppLabelKey, cfAppGUID))
+			Expect(createdCFApp.Annotations).To(HaveKeyWithValue(cfAppRevisionKey, "0"))
+
 			Expect(k8sClient.Delete(testCtx, cfApp)).To(Succeed())
+		})
+	})
+
+	When("a CFApp is updated from desiredState STARTED -> STOPPED", func() {
+		const (
+			cfAppRevisionKey = "workloads.cloudfoundry.org/app-rev"
+			namespace        = "default"
+			revisionValue    = 8
+		)
+
+		var (
+			cfAppGUID string
+			cfApp     *v1alpha1.CFApp
+		)
+
+		BeforeEach(func() {
+			testCtx := context.Background()
+			cfAppGUID = GenerateGUID()
+			cfAppName := cfAppGUID + "-app"
+			cfApp = &v1alpha1.CFApp{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CFApp",
+					APIVersion: v1alpha1.GroupVersion.Identifier(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfAppGUID,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						cfAppRevisionKey: strconv.Itoa(revisionValue),
+					},
+				},
+				Spec: v1alpha1.CFAppSpec{
+					Name:         cfAppName,
+					DesiredState: "STARTED",
+					Lifecycle: v1alpha1.Lifecycle{
+						Type: "buildpack",
+					},
+				},
+			}
+			Expect(k8sClient.Create(testCtx, cfApp)).To(Succeed())
+			cfApp.Status.Conditions = []metav1.Condition{}
+			cfApp.Status.ObservedDesiredState = cfApp.Spec.DesiredState
+			Expect(k8sClient.Status().Update(testCtx, cfApp)).To(Succeed())
+
+			Eventually(func() string {
+				updatedCFApp := &v1alpha1.CFApp{}
+				err := cfAppValidatingWebhookClient.Get(context.Background(), types.NamespacedName{Name: cfAppGUID, Namespace: namespace}, updatedCFApp)
+				if err != nil {
+					return ""
+				}
+				return string(updatedCFApp.Status.ObservedDesiredState)
+			}).Should(Equal(string(cfApp.Spec.DesiredState)))
+
+			cfApp.Spec.DesiredState = v1alpha1.StoppedState
+			Expect(k8sClient.Update(testCtx, cfApp)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(context.Background(), cfApp)).To(Succeed())
+		})
+
+		It("should eventually increment the rev annotation by 1", func() {
+			Eventually(func() string {
+				updatedCFApp := &v1alpha1.CFApp{}
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cfAppGUID, Namespace: namespace}, updatedCFApp)
+				if err != nil {
+					return ""
+				}
+				return getMapKeyValue(updatedCFApp.Annotations, v1alpha1.CFAppRevisionKey)
+			}).Should(Equal(strconv.Itoa(revisionValue + 1)))
 		})
 	})
 })

--- a/controllers/apis/workloads/v1alpha1/integration/webhook_suite_integration_test.go
+++ b/controllers/apis/workloads/v1alpha1/integration/webhook_suite_integration_test.go
@@ -43,9 +43,10 @@ import (
 )
 
 var (
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	k8sClient client.Client
+	cancel                       context.CancelFunc
+	testEnv                      *envtest.Environment
+	k8sClient                    client.Client
+	cfAppValidatingWebhookClient client.Client
 )
 
 func TestWorkloadsMutatingWebhooks(t *testing.T) {
@@ -94,7 +95,8 @@ var _ = BeforeSuite(func() {
 
 	Expect((&workloadsv1alpha1.CFApp{}).SetupWebhookWithManager(mgr)).To(Succeed())
 
-	cfAppValidatingWebhook := &workloads.CFAppValidation{Client: mgr.GetClient()}
+	cfAppValidatingWebhookClient = mgr.GetClient()
+	cfAppValidatingWebhook := &workloads.CFAppValidation{Client: cfAppValidatingWebhookClient}
 	Expect(cfAppValidatingWebhook.SetupWebhookWithManager(mgr)).To(Succeed())
 
 	Expect(workloads.NewSubnamespaceAnchorValidation(
@@ -135,3 +137,13 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func getMapKeyValue(m map[string]string, k string) string {
+	if m == nil {
+		return ""
+	}
+	if v, has := m[k]; has {
+		return v
+	}
+	return ""
+}

--- a/controllers/apis/workloads/v1alpha1/shared_types.go
+++ b/controllers/apis/workloads/v1alpha1/shared_types.go
@@ -5,14 +5,16 @@ import (
 )
 
 const (
-	CFAppGUIDLabelKey      = "workloads.cloudfoundry.org/app-guid"
-	CFPackageGUIDLabelKey  = "workloads.cloudfoundry.org/package-guid"
-	CFBuildGUIDLabelKey    = "workloads.cloudfoundry.org/build-guid"
-	CFProcessGUIDLabelKey  = "workloads.cloudfoundry.org/process-guid"
-	CFProcessTypeLabelKey  = "workloads.cloudfoundry.org/process-type"
-	StagingConditionType   = "Staging"
-	ReadyConditionType     = "Ready"
-	SucceededConditionType = "Succeeded"
+	CFAppGUIDLabelKey       = "workloads.cloudfoundry.org/app-guid"
+	CFAppRevisionKey        = "workloads.cloudfoundry.org/app-rev"
+	CFAppRevisionKeyDefault = "0"
+	CFPackageGUIDLabelKey   = "workloads.cloudfoundry.org/package-guid"
+	CFBuildGUIDLabelKey     = "workloads.cloudfoundry.org/build-guid"
+	CFProcessGUIDLabelKey   = "workloads.cloudfoundry.org/process-guid"
+	CFProcessTypeLabelKey   = "workloads.cloudfoundry.org/process-type"
+	StagingConditionType    = "Staging"
+	ReadyConditionType      = "Ready"
+	SucceededConditionType  = "Succeeded"
 )
 
 type Lifecycle struct {

--- a/controllers/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
+++ b/controllers/config/crd/bases/workloads.cloudfoundry.org_cfapps.yaml
@@ -128,8 +128,15 @@ spec:
                   - type
                   type: object
                 type: array
+              observedDesiredState:
+                description: DesiredState defines the desired state of CFApp.
+                enum:
+                - STOPPED
+                - STARTED
+                type: string
             required:
             - conditions
+            - observedDesiredState
             type: object
         type: object
     served: true

--- a/controllers/controllers/workloads/cfapp_controller_test.go
+++ b/controllers/controllers/workloads/cfapp_controller_test.go
@@ -137,7 +137,7 @@ var _ = Describe("CFAppReconciler", func() {
 				cast, ok := updatedCFApp.(*workloadsv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to workloadsv1alpha1.CFApp failed")
 				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRunning)).To(BeTrue(), "Status Condition "+StatusConditionRunning+" was not False as expected")
-				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRestarting)).To(BeTrue(), "Status Condition "+StatusConditionRestarting+" was not False as expected")
+				Expect(cast.Status.ObservedDesiredState).To(Equal(cast.Spec.DesiredState))
 			})
 		})
 
@@ -216,7 +216,6 @@ var _ = Describe("CFAppReconciler", func() {
 				cast, ok := updatedCFApp.(*workloadsv1alpha1.CFApp)
 				Expect(ok).To(BeTrue(), "Cast to workloadsv1alpha1.CFApp failed")
 				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRunning)).To(BeTrue(), "Status Condition "+StatusConditionRunning+" was not False as expected")
-				Expect(meta.IsStatusConditionFalse(cast.Status.Conditions, StatusConditionRestarting)).To(BeTrue(), "Status Condition "+StatusConditionRestarting+" was not False as expected")
 			})
 		})
 

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -61,19 +61,17 @@ var _ = Describe("CFAppReconciler", func() {
 			cfAppLookupKey := types.NamespacedName{Name: cfAppGUID, Namespace: namespaceGUID}
 			createdCFApp := new(workloadsv1alpha1.CFApp)
 
-			Eventually(func() []metav1.Condition {
+			Eventually(func() string {
 				err := k8sClient.Get(ctx, cfAppLookupKey, createdCFApp)
 				if err != nil {
-					return nil
+					return ""
 				}
-				return createdCFApp.Status.Conditions
-			}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty())
+				return string(createdCFApp.Status.ObservedDesiredState)
+			}, 10*time.Second, 250*time.Millisecond).Should(Equal(string(cfApp.Spec.DesiredState)))
 
 			runningConditionFalse := meta.IsStatusConditionFalse(createdCFApp.Status.Conditions, "Running")
 			Expect(runningConditionFalse).To(BeTrue())
-
-			restartingConditionFalse := meta.IsStatusConditionFalse(createdCFApp.Status.Conditions, "Restarting")
-			Expect(restartingConditionFalse).To(BeTrue())
+			Expect(createdCFApp.Status.ObservedDesiredState).To(Equal(createdCFApp.Spec.DesiredState))
 		})
 	})
 	When("a CFApp resource exists and", func() {

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -179,3 +179,13 @@ func patchAppWithDroplet(ctx context.Context, k8sClient client.Client, appGUID, 
 	Expect(k8sClient.Patch(ctx, patchedCFApp, client.MergeFrom(baseCFApp))).To(Succeed())
 	return baseCFApp
 }
+
+func getMapKeyValue(m map[string]string, k string) string {
+	if m == nil {
+		return ""
+	}
+	if v, has := m[k]; has {
+		return v
+	}
+	return ""
+}

--- a/controllers/controllers/workloads/shared.go
+++ b/controllers/controllers/workloads/shared.go
@@ -36,4 +36,14 @@ func generateGUID() string {
 	return uuid.NewString()
 }
 
+func getMapKeyValue(m map[string]string, k string) string {
+	if m == nil {
+		return ""
+	}
+	if v, has := m[k]; has {
+		return v
+	}
+	return ""
+}
+
 //counterfeiter:generate -o fake -fake-name StatusWriter sigs.k8s.io/controller-runtime/pkg/client.StatusWriter

--- a/controllers/controllers/workloads/testutils/shared_test_utils.go
+++ b/controllers/controllers/workloads/testutils/shared_test_utils.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	CFAppLabelKey         = "workloads.cloudfoundry.org/app-guid"
+	cfAppRevisionKey      = "workloads.cloudfoundry.org/app-rev"
 	CFProcessGUIDLabelKey = "workloads.cloudfoundry.org/process-guid"
 	CFProcessTypeLabelKey = "workloads.cloudfoundry.org/process-type"
 )
@@ -35,6 +36,9 @@ func BuildCFAppCRObject(appGUID string, spaceGUID string) *workloadsv1alpha1.CFA
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appGUID,
 			Namespace: spaceGUID,
+			Annotations: map[string]string{
+				cfAppRevisionKey: "0",
+			},
 		},
 		Spec: workloadsv1alpha1.CFAppSpec{
 			Name:         "test-app-name",

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -178,8 +178,15 @@ spec:
                   - type
                   type: object
                 type: array
+              observedDesiredState:
+                description: DesiredState defines the desired state of CFApp.
+                enum:
+                - STOPPED
+                - STARTED
+                type: string
             required:
             - conditions
+            - observedDesiredState
             type: object
         type: object
     served: true


### PR DESCRIPTION
## Is there a related GitHub Issue?
#260 

## What is this change about?
Implements the logic to enable `cf restart <app>` 

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow instruction in README to deploy `cf-k8s-api` and `cf-k8s-controller`
Push an app using CF CLI
Try restarting the app using `cf restart <app-name>` and verify if new pods are created

## Tag your pair, your PM, and/or team
@gnovv @Birdrock @julian-hj @davewalter 