### PR TITLE
Fixed pagination links in list responses

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -117,14 +116,11 @@ func (h *AppHandler) appGetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForApp(app, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForApp(app, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -173,15 +169,11 @@ func (h *AppHandler) appCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForApp(appRecord, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForApp(appRecord, h.serverURL), http.StatusCreated)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "App Name", payload.Name)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	w.WriteHeader(http.StatusCreated)
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
@@ -232,14 +224,11 @@ func (h *AppHandler) appListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForAppList(appList, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForAppList(appList, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.Request) {
@@ -302,14 +291,11 @@ func (h *AppHandler) appSetCurrentDropletHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForCurrentDroplet(currentDroplet, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForCurrentDroplet(currentDroplet, h.serverURL), http.StatusOK)
 	if err != nil { // untested
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appGetCurrentDropletHandler(w http.ResponseWriter, r *http.Request) {
@@ -356,13 +342,11 @@ func (h *AppHandler) appGetCurrentDropletHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForDroplet(droplet, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForDroplet(droplet, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "dropletGUID", app.DropletGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appStartHandler(w http.ResponseWriter, r *http.Request) {
@@ -409,14 +393,11 @@ func (h *AppHandler) appStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForApp(app, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForApp(app, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appStopHandler(w http.ResponseWriter, r *http.Request) {
@@ -458,14 +439,11 @@ func (h *AppHandler) appStopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForApp(app, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForApp(app, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Request) {
@@ -508,14 +486,11 @@ func (h *AppHandler) getProcessesForAppHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForAppProcessList(processList, h.serverURL, appGUID))
+	err = writeJsonResponse(w, presenter.ForAppProcessList(processList, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil { // untested
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) getRoutesForAppHandler(w http.ResponseWriter, r *http.Request) {
@@ -553,14 +528,11 @@ func (h *AppHandler) getRoutesForAppHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForAppRouteList(routes, h.serverURL, app.GUID))
+	err = writeJsonResponse(w, presenter.ForAppRouteList(routes, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -600,14 +572,11 @@ func (h *AppHandler) appScaleProcessHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcess(processRecord, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForProcess(processRecord, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "ProcessGUID", appGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
@@ -683,14 +652,11 @@ func (h *AppHandler) appRestartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForApp(app, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForApp(app, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *AppHandler) lookupAppRouteAndDomainList(ctx context.Context, authInfo authorization.Info, appGUID, spaceGUID string) ([]repositories.RouteRecord, error) {

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -460,10 +460,10 @@ var _ = Describe("AppHandler", func() {
 				  "total_results": 2,
 				  "total_pages": 1,
 				  "first": {
-					"href": "%[1]s/v3/apps?page=1"
+					"href": "%[1]s/v3/apps"
 				  },
 				  "last": {
-					"href": "%[1]s/v3/apps?page=1"
+					"href": "%[1]s/v3/apps"
 				  },
 				  "next": null,
 				  "previous": null
@@ -642,6 +642,10 @@ var _ = Describe("AppHandler", func() {
 					Expect(message.Names).To(ConsistOf("app1", "app2"))
 					Expect(message.SpaceGuids).To(ConsistOf("space1", "space2"))
 				})
+
+				It("correctly sets query parameters in response pagination links", func() {
+					Expect(rr.Body.String()).To(ContainSubstring("https://api.example.org/v3/apps?names=app1,app2&space_guids=space1,space2"))
+				})
 			})
 		})
 
@@ -665,10 +669,10 @@ var _ = Describe("AppHandler", func() {
 				  "total_results": 0,
 				  "total_pages": 1,
 				  "first": {
-					"href": "%[1]s/v3/apps?page=1"
+					"href": "%[1]s/v3/apps"
 				  },
 				  "last": {
-					"href": "%[1]s/v3/apps?page=1"
+					"href": "%[1]s/v3/apps"
 				  },
 				  "next": null,
 				  "previous": null
@@ -1439,10 +1443,10 @@ var _ = Describe("AppHandler", func() {
 						  "total_results": 2,
 						  "total_pages": 1,
 						  "first": {
-							"href": "%[1]s/v3/apps/%[2]s/processes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/processes"
 						  },
 						  "last": {
-							"href": "%[1]s/v3/apps/%[2]s/processes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/processes"
 						  },
 						  "next": null,
 						  "previous": null
@@ -1562,10 +1566,10 @@ var _ = Describe("AppHandler", func() {
 						  "total_results": 0,
 						  "total_pages": 1,
 						  "first": {
-							"href": "%[1]s/v3/apps/%[2]s/processes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/processes"
 						  },
 						  "last": {
-							"href": "%[1]s/v3/apps/%[2]s/processes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/processes"
 						  },
 						  "next": null,
 						  "previous": null
@@ -1950,10 +1954,10 @@ var _ = Describe("AppHandler", func() {
 							"total_results": 1,
 							"total_pages": 1,
 							"first": {
-								"href": "%[1]s/v3/apps/%[2]s/routes?page=1"
+								"href": "%[1]s/v3/apps/%[2]s/routes"
 							},
 							"last": {
-								"href": "%[1]s/v3/apps/%[2]s/routes?page=1"
+								"href": "%[1]s/v3/apps/%[2]s/routes"
 							},
 							"next": null,
 							"previous": null
@@ -2023,10 +2027,10 @@ var _ = Describe("AppHandler", func() {
 						  "total_results": 0,
 						  "total_pages": 1,
 						  "first": {
-							"href": "%[1]s/v3/apps/%[2]s/routes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/routes"
 						  },
 						  "last": {
-							"href": "%[1]s/v3/apps/%[2]s/routes?page=1"
+							"href": "%[1]s/v3/apps/%[2]s/routes"
 						  },
 						  "next": null,
 						  "previous": null

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -76,13 +75,11 @@ func (h *BuildHandler) buildGetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForBuild(build, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForBuild(build, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "BuildGUID", buildGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-	_, _ = w.Write(responseBody)
 }
 
 func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Request) {
@@ -124,13 +121,10 @@ func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	res := presenter.ForBuild(record, h.serverURL)
-	w.WriteHeader(http.StatusCreated)
-	err = json.NewEncoder(w).Encode(res)
+	err = writeJsonResponse(w, presenter.ForBuild(record, h.serverURL), http.StatusCreated)
 	if err != nil { // untested
 		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
-		return
 	}
 }
 

--- a/api/apis/domain_handler.go
+++ b/api/apis/domain_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -95,14 +94,11 @@ func (h *DomainHandler) DomainListHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForDomainList(domainList, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForDomainList(domainList, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *DomainHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/domain_handler_test.go
+++ b/api/apis/domain_handler_test.go
@@ -66,10 +66,10 @@ var _ = Describe("DomainHandler", func() {
 					"total_results": 1,
 					"total_pages": 1,
 					"first": {
-						"href": "%[1]s/v3/domains?page=1"
+						"href": "%[1]s/v3/domains"
 					},
 					"last": {
-						"href": "%[1]s/v3/domains?page=1"
+						"href": "%[1]s/v3/domains"
 					},
 					"next": null,
 					"previous": null
@@ -133,10 +133,10 @@ var _ = Describe("DomainHandler", func() {
 						"total_results": 0,
 						"total_pages": 1,
 						"first": {
-							"href": "%[1]s/v3/domains?page=1"
+							"href": "%[1]s/v3/domains"
 						},
 						"last": {
-							"href": "%[1]s/v3/domains?page=1"
+							"href": "%[1]s/v3/domains"
 						},
 						"next": null,
 						"previous": null

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -69,13 +68,11 @@ func (h *DropletHandler) dropletGetHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForDroplet(droplet, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForDroplet(droplet, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "dropletGUID", dropletGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-	_, _ = w.Write(responseBody)
 }
 
 func (h *DropletHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/job_handler.go
+++ b/api/apis/job_handler.go
@@ -1,7 +1,6 @@
 package apis
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,15 +41,11 @@ func (h *JobHandler) jobGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForJob(jobGUID, spaceGUID, h.serverURL))
+	err := writeJsonResponse(w, presenter.ForJob(jobGUID, spaceGUID, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "Job GUID", jobGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(responseBody)
 }
 
 func getSpaceGUID(jobGUID string) string {

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -90,8 +90,11 @@ func (h *OrgHandler) orgCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgResponse := presenter.ForCreateOrg(record, h.apiBaseURL)
-	writeResponse(w, http.StatusCreated, orgResponse)
+	err = writeJsonResponse(w, presenter.ForCreateOrg(record, h.apiBaseURL), http.StatusCreated)
+	if err != nil {
+		h.logger.Error(err, "Failed to render response")
+		writeUnknownErrorResponse(w)
+	}
 }
 
 func (h *OrgHandler) orgListHandler(w http.ResponseWriter, r *http.Request) {
@@ -134,8 +137,11 @@ func (h *OrgHandler) orgListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgList := presenter.ForOrgList(orgs, h.apiBaseURL)
-	writeResponse(w, http.StatusOK, orgList)
+	err = writeJsonResponse(w, presenter.ForOrgList(orgs, h.apiBaseURL, *r.URL), http.StatusOK)
+	if err != nil {
+		h.logger.Error(err, "Failed to render response")
+		writeUnknownErrorResponse(w)
+	}
 }
 
 func (h *OrgHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -367,10 +367,10 @@ var _ = Describe("OrgHandler", func() {
                         "total_results": 2,
                         "total_pages": 1,
                         "first": {
-                            "href": "%[1]s/v3/organizations?page=1"
+                            "href": "%[1]s/v3/organizations"
                         },
                         "last": {
-                            "href": "%[1]s/v3/organizations?page=1"
+                            "href": "%[1]s/v3/organizations"
                         },
                         "next": null,
                         "previous": null

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"mime/multipart"
 	"net/http"
@@ -103,12 +102,10 @@ func (h PackageHandler) packageGetHandler(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	res := presenter.ForPackage(record, h.serverURL)
-	err = json.NewEncoder(w).Encode(res)
+	err = writeJsonResponse(w, presenter.ForPackage(record, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
-		return
 	}
 }
 
@@ -160,12 +157,10 @@ func (h PackageHandler) packageListHandler(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	res := presenter.ForPackageList(records, h.serverURL)
-	err = json.NewEncoder(w).Encode(res)
+	err = writeJsonResponse(w, presenter.ForPackageList(records, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Error encoding JSON response", "error")
 		writeUnknownErrorResponse(w)
-		return
 	}
 }
 
@@ -206,13 +201,10 @@ func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	res := presenter.ForPackage(record, h.serverURL)
-	w.WriteHeader(http.StatusCreated)
-	err = json.NewEncoder(w).Encode(res)
+	err = writeJsonResponse(w, presenter.ForPackage(record, h.serverURL), http.StatusCreated)
 	if err != nil { // untested
 		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
-		return
 	}
 }
 
@@ -287,12 +279,10 @@ func (h PackageHandler) packageUploadHandler(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	res := presenter.ForPackage(record, h.serverURL)
-	err = json.NewEncoder(w).Encode(res)
+	err = writeJsonResponse(w, presenter.ForPackage(record, h.serverURL), http.StatusOK)
 	if err != nil { // untested
 		h.logger.Info("Error encoding JSON response", "error", err.Error())
 		writeUnknownErrorResponse(w)
-		return
 	}
 }
 
@@ -360,15 +350,11 @@ func (h PackageHandler) packageListDropletsHandler(w http.ResponseWriter, req *h
 	}
 
 	dropletBaseURL := "/v3/packages/" + packageGUID + "/droplets"
-	responseBody, err := json.Marshal(presenter.ForDropletList(dropletList, h.serverURL, dropletBaseURL))
-	if err != nil {
-		// Untested
+	err = writeJsonResponse(w, presenter.ForDropletList(dropletList, h.serverURL, dropletBaseURL), http.StatusOK)
+	if err != nil { // Untested
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *PackageHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -88,14 +87,11 @@ func (h *ProcessHandler) processGetHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcess(process, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForProcess(process, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) processGetSidecarsHandler(w http.ResponseWriter, r *http.Request) {
@@ -123,10 +119,10 @@ func (h *ProcessHandler) processGetSidecarsHandler(w http.ResponseWriter, r *htt
 						"total_results": 0,
 						"total_pages": 1,
 						"first": {
-							"href": "%[1]s/v3/processes/%[2]s/sidecars?page=1"
+							"href": "%[1]s/v3/processes/%[2]s/sidecars"
 						},
 						"last": {
-							"href": "%[1]s/v3/processes/%[2]s/sidecars?page=1"
+							"href": "%[1]s/v3/processes/%[2]s/sidecars"
 						},
 						"next": null,
 						"previous": null
@@ -170,14 +166,11 @@ func (h *ProcessHandler) processScaleHandler(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcess(processRecord, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForProcess(processRecord, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "ProcessGUID", processGUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) processGetStatsHandler(w http.ResponseWriter, r *http.Request) {
@@ -200,13 +193,10 @@ func (h *ProcessHandler) processGetStatsHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcessStats(records))
+	err = writeJsonResponse(w, presenter.ForProcessStats(records), http.StatusOK)
 	if err != nil {
 		h.LogError(w, processGUID, err)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) processListHandler(w http.ResponseWriter, r *http.Request) {
@@ -258,14 +248,11 @@ func (h *ProcessHandler) processListHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForProcessList(processList, h.serverURL, *processListFilter))
+	err = writeJsonResponse(w, presenter.ForProcessList(processList, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *ProcessHandler) LogError(w http.ResponseWriter, processGUID string, err error) {

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -223,10 +223,10 @@ var _ = Describe("ProcessHandler", func() {
 						"total_results": 0,
 						"total_pages": 1,
 						"first": {
-							"href": "%[1]s/v3/processes/%[2]s/sidecars?page=1"
+							"href": "%[1]s/v3/processes/%[2]s/sidecars"
 						},
 						"last": {
-							"href": "%[1]s/v3/processes/%[2]s/sidecars?page=1"
+							"href": "%[1]s/v3/processes/%[2]s/sidecars"
 						},
 						"next": null,
 						"previous": null
@@ -710,10 +710,10 @@ var _ = Describe("ProcessHandler", func() {
 					"total_results": 1,
 					"total_pages": 1,
 					"first": {
-						"href": "`+baseURL+`/v3/processes?page=1"
+						"href": "`+baseURL+`/v3/processes"
 					},
 					"last": {
-						"href": "`+baseURL+`/v3/processes?page=1"
+						"href": "`+baseURL+`/v3/processes"
 					},
 					"next": null,
 					"previous": null

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -90,8 +90,11 @@ func (h *RoleHandler) roleCreateHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	roleResponse := presenter.ForCreateRole(record, h.apiBaseURL)
-	writeResponse(w, http.StatusCreated, roleResponse)
+	err = writeJsonResponse(w, presenter.ForCreateRole(record, h.apiBaseURL), http.StatusCreated)
+	if err != nil {
+		h.logger.Error(err, "Failed to render response", "User/Role", role.User+"/"+role.Type)
+		writeUnknownErrorResponse(w)
+	}
 }
 
 func (h *RoleHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/root_handler.go
+++ b/api/apis/root_handler.go
@@ -1,7 +1,6 @@
 package apis
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
@@ -23,14 +22,12 @@ func NewRootHandler(logger logr.Logger, serverURL string) *RootHandler {
 }
 
 func (h *RootHandler) rootGetHandler(w http.ResponseWriter, r *http.Request) {
-	body, err := json.Marshal(presenter.GetRootResponse(h.serverURL))
+	w.Header().Set("Content-Type", "application/json")
+	err := writeJsonResponse(w, presenter.GetRootResponse(h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(body))
 }
 
 func (h *RootHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -2,12 +2,9 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
-
-	"github.com/gorilla/schema"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
@@ -17,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/schema"
 )
 
 const (
@@ -89,14 +87,11 @@ func (h *RouteHandler) routeGetHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForRoute(route, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForRoute(route, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "Route Host", route.Host)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) routeGetListHandler(w http.ResponseWriter, r *http.Request) {
@@ -148,14 +143,11 @@ func (h *RouteHandler) routeGetListHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForRouteList(routes, h.serverURL, r.URL))
+	err = writeJsonResponse(w, presenter.ForRouteList(routes, h.serverURL, *r.URL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) routeGetDestinationsHandler(w http.ResponseWriter, r *http.Request) {
@@ -186,14 +178,11 @@ func (h *RouteHandler) routeGetDestinationsHandler(w http.ResponseWriter, r *htt
 		}
 	}
 
-	responseBody, err := json.Marshal(presenter.ForRouteDestinations(route, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForRouteDestinations(route, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "Route Host", route.Host)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) routeCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -259,14 +248,11 @@ func (h *RouteHandler) routeCreateHandler(w http.ResponseWriter, r *http.Request
 
 	responseRouteRecord = responseRouteRecord.UpdateDomainRef(domain)
 
-	responseBody, err := json.Marshal(presenter.ForRoute(responseRouteRecord, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForRoute(responseRouteRecord, h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "Route Host", routeCreateMessage.Host)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *http.Request) {
@@ -311,14 +297,11 @@ func (h *RouteHandler) routeAddDestinationsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	responseBody, err := json.Marshal(presenter.ForRouteDestinations(responseRouteRecord, h.serverURL))
+	err = writeJsonResponse(w, presenter.ForRouteDestinations(responseRouteRecord, h.serverURL), http.StatusOK)
 	if err != nil { // untested
 		h.logger.Error(err, "Failed to render response", "Route GUID", routeRecord.GUID)
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *RouteHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/service_route_binding_handler.go
+++ b/api/apis/service_route_binding_handler.go
@@ -1,14 +1,12 @@
 package apis
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 
-	"github.com/go-logr/logr"
-
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 )
 
@@ -33,14 +31,11 @@ func NewServiceRouteBindingHandler(
 func (h *ServiceRouteBindingHandler) serviceRouteBindingsListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	responseBody, err := json.Marshal(presenter.ForServiceRouteBindingsList(h.serverURL))
+	err := writeJsonResponse(w, presenter.ForServiceRouteBindingsList(h.serverURL), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response")
 		writeUnknownErrorResponse(w)
-		return
 	}
-
-	_, _ = w.Write(responseBody)
 }
 
 func (h *ServiceRouteBindingHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/shared.go
+++ b/api/apis/shared.go
@@ -224,9 +224,25 @@ func writeResponse(w http.ResponseWriter, status int, responseBody interface{}) 
 
 	err := json.NewEncoder(w).Encode(responseBody)
 	if err != nil {
-		Logger.Error(err, "failed to encode and wire response")
+		Logger.Error(err, "failed to encode and write response")
 		return
 	}
+}
+
+func writeJsonResponse(w http.ResponseWriter, payload interface{}, successStatus int) error {
+	responseBody := strings.Builder{}
+	encoder := json.NewEncoder(&responseBody)
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	w.WriteHeader(successStatus)
+	_, _ = w.Write([]byte(responseBody.String()))
+
+	return nil
 }
 
 // Custom field validators

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -135,7 +135,7 @@ func (h *SpaceHandler) SpaceListHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	spaceList := presenter.ForSpaceList(spaces, h.apiBaseURL)
+	spaceList := presenter.ForSpaceList(spaces, h.apiBaseURL, *r.URL)
 	writeResponse(w, http.StatusOK, spaceList)
 }
 

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -248,10 +248,10 @@ var _ = Describe("Spaces", func() {
                     "total_results": 2,
                     "total_pages": 1,
                     "first": {
-                        "href": "%[1]s/v3/spaces?page=1"
+                        "href": "%[1]s/v3/spaces"
                     },
                     "last": {
-                        "href": "%[1]s/v3/spaces?page=1"
+                        "href": "%[1]s/v3/spaces"
                     },
                     "next": null,
                     "previous": null

--- a/api/apis/whoami_handler.go
+++ b/api/apis/whoami_handler.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -53,12 +52,10 @@ func (h *WhoAmIHandler) whoAmIHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	identityResponse := presenter.ForWhoAmI(identity)
-
-	err = json.NewEncoder(w).Encode(identityResponse)
+	err = writeJsonResponse(w, presenter.ForWhoAmI(identity), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to write response")
+		writeUnknownErrorResponse(w)
 	}
 }
 

--- a/api/presenter/app.go
+++ b/api/presenter/app.go
@@ -115,7 +115,7 @@ func ForApp(responseApp repositories.AppRecord, baseURL url.URL) AppResponse {
 	}
 }
 
-func ForAppList(appRecordList []repositories.AppRecord, baseURL url.URL) AppListResponse {
+func ForAppList(appRecordList []repositories.AppRecord, baseURL, requestURL url.URL) AppListResponse {
 	appResponses := make([]AppResponse, 0, len(appRecordList))
 	for _, app := range appRecordList {
 		appResponses = append(appResponses, ForApp(app, baseURL))
@@ -126,10 +126,10 @@ func ForAppList(appRecordList []repositories.AppRecord, baseURL url.URL) AppList
 			TotalResults: len(appResponses),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(baseURL).appendPath(appsBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(baseURL).appendPath(appsBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 		},
 		Resources: appResponses,

--- a/api/presenter/domain.go
+++ b/api/presenter/domain.go
@@ -82,7 +82,7 @@ func ForDomain(responseDomain repositories.DomainRecord, baseURL url.URL) Domain
 	}
 }
 
-func ForDomainList(domainListRecords []repositories.DomainRecord, baseURL url.URL) DomainListResponse {
+func ForDomainList(domainListRecords []repositories.DomainRecord, baseURL, requestURL url.URL) DomainListResponse {
 	domainResponses := make([]DomainResponse, 0, len(domainListRecords))
 	for _, domain := range domainListRecords {
 		domainResponses = append(domainResponses, ForDomain(domain, baseURL))
@@ -93,10 +93,10 @@ func ForDomainList(domainListRecords []repositories.DomainRecord, baseURL url.UR
 			TotalResults: len(domainResponses),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(baseURL).appendPath(domainsBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(baseURL).appendPath(domainsBase).setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 		},
 		Resources: domainResponses,

--- a/api/presenter/org.go
+++ b/api/presenter/org.go
@@ -61,7 +61,7 @@ func ForCreateOrg(org repositories.OrgRecord, apiBaseURL url.URL) OrgResponse {
 	return toOrgResponse(org, apiBaseURL)
 }
 
-func ForOrgList(orgs []repositories.OrgRecord, apiBaseURL url.URL) OrgListResponse {
+func ForOrgList(orgs []repositories.OrgRecord, apiBaseURL, requestURL url.URL) OrgListResponse {
 	orgResponses := []OrgResponse{}
 
 	for _, org := range orgs {
@@ -73,10 +73,10 @@ func ForOrgList(orgs []repositories.OrgRecord, apiBaseURL url.URL) OrgListRespon
 			TotalResults: len(orgs),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(apiBaseURL).appendPath(orgsBase).setQuery("page=1").build(),
+				HREF: buildURL(apiBaseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(apiBaseURL).appendPath(orgsBase).setQuery("page=1").build(),
+				HREF: buildURL(apiBaseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 		},
 		Resources: orgResponses,
@@ -87,14 +87,14 @@ func ForCreateSpace(space repositories.SpaceRecord, apiBaseURL url.URL) SpaceRes
 	return toSpaceResponse(space, apiBaseURL)
 }
 
-func ForSpaceList(spaces []repositories.SpaceRecord, apiBaseURL url.URL) SpaceListResponse {
+func ForSpaceList(spaces []repositories.SpaceRecord, apiBaseURL, requestURL url.URL) SpaceListResponse {
 	spaceResponses := []SpaceResponse{}
 
 	for _, space := range spaces {
 		spaceResponses = append(spaceResponses, toSpaceResponse(space, apiBaseURL))
 	}
 
-	paginationURL := buildURL(apiBaseURL).appendPath(spacesBase).setQuery("page=1").build()
+	paginationURL := buildURL(apiBaseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build()
 	return SpaceListResponse{
 		Pagination: PaginationData{
 			TotalResults: len(spaces),

--- a/api/presenter/process.go
+++ b/api/presenter/process.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
-
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 )
 
@@ -151,7 +149,7 @@ func ForProcess(responseProcess repositories.ProcessRecord, baseURL url.URL) Pro
 	}
 }
 
-func ForAppProcessList(processRecordList []repositories.ProcessRecord, baseURL url.URL, appGUID string) ProcessListResponse {
+func ForAppProcessList(processRecordList []repositories.ProcessRecord, baseURL, requestURL url.URL) ProcessListResponse {
 	processResponses := make([]ProcessResponse, 0, len(processRecordList))
 	for _, process := range processRecordList {
 		processResponse := ForProcess(process, baseURL)
@@ -159,7 +157,7 @@ func ForAppProcessList(processRecordList []repositories.ProcessRecord, baseURL u
 		processResponses = append(processResponses, processResponse)
 	}
 
-	pageHREF := buildURL(baseURL).appendPath(appsBase, appGUID, "processes").setQuery("page=1").build()
+	pageHREF := buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build()
 	processListResponse := ProcessListResponse{
 		PaginationData: PaginationData{
 			TotalResults: len(processResponses),
@@ -177,14 +175,7 @@ func ForAppProcessList(processRecordList []repositories.ProcessRecord, baseURL u
 	return processListResponse
 }
 
-func ForProcessList(processRecordList []repositories.ProcessRecord, baseURL url.URL, processListFilter payloads.ProcessList) ProcessListResponse {
-	var queryParameter string
-	if processListFilter.AppGUIDs != "" {
-		queryParameter = "app_guids=" + processListFilter.AppGUIDs + "&page=1"
-	} else {
-		queryParameter = "page=1"
-	}
-
+func ForProcessList(processRecordList []repositories.ProcessRecord, baseURL, requestURL url.URL) ProcessListResponse {
 	processResponses := make([]ProcessResponse, 0, len(processRecordList))
 	for _, process := range processRecordList {
 		processResponse := ForProcess(process, baseURL)
@@ -192,7 +183,7 @@ func ForProcessList(processRecordList []repositories.ProcessRecord, baseURL url.
 		processResponses = append(processResponses, processResponse)
 	}
 
-	pageHREF := buildURL(baseURL).appendPath(processesBase).setQuery(queryParameter).build()
+	pageHREF := buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build()
 	processListResponse := ProcessListResponse{
 		PaginationData: PaginationData{
 			TotalResults: len(processResponses),

--- a/api/presenter/route.go
+++ b/api/presenter/route.go
@@ -113,7 +113,7 @@ func ForRoute(route repositories.RouteRecord, baseURL url.URL) RouteResponse {
 	}
 }
 
-func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL, requestURI *url.URL) RouteListResponse {
+func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL, requestURL url.URL) RouteListResponse {
 	routeResponses := make([]RouteResponse, 0, len(routeRecordList))
 	for _, routeRecord := range routeRecordList {
 		routeResponses = append(routeResponses, ForRoute(routeRecord, baseURL))
@@ -124,10 +124,10 @@ func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL, r
 			TotalResults: len(routeResponses),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(baseURL).appendPath(requestURI.Path).setQuery(requestURI.RawQuery).build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(baseURL).appendPath(requestURI.Path).setQuery(requestURI.RawQuery).build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 		},
 		Resources: routeResponses,
@@ -136,7 +136,7 @@ func ForRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL, r
 	return routeListResponse
 }
 
-func ForAppRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL, appGUID string) RouteListResponse {
+func ForAppRouteList(routeRecordList []repositories.RouteRecord, baseURL, requestURL url.URL) RouteListResponse {
 	routeResponses := make([]RouteResponse, 0, len(routeRecordList))
 	for _, routeRecord := range routeRecordList {
 		routeResponses = append(routeResponses, ForRoute(routeRecord, baseURL))
@@ -147,10 +147,10 @@ func ForAppRouteList(routeRecordList []repositories.RouteRecord, baseURL url.URL
 			TotalResults: len(routeResponses),
 			TotalPages:   1,
 			First: PageRef{
-				HREF: buildURL(baseURL).appendPath(appsBase, appGUID, "routes").setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 			Last: PageRef{
-				HREF: buildURL(baseURL).appendPath(appsBase, appGUID, "routes").setQuery("page=1").build(),
+				HREF: buildURL(baseURL).appendPath(requestURL.Path).setQuery(requestURL.RawQuery).build(),
 			},
 		},
 		Resources: routeResponses,


### PR DESCRIPTION
## Is there a related GitHub Issue?
fixes #324

## What is this change about?
Fixed pagination links in list responses
- pagination links previously included ?page=1 querystring parameters,
  which would cause failures when followed
- some links also did not include the querystring parameters from the
  request, which would lead to incorrect results if used.
- we also noticed that our json serialization html encoded string
  values, leading to incorrect URLs. We added a utility method to
  marshal json without encoding it, and inserted that everywhere.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
see issue #324

## Tag your pair, your PM, and/or team
@davewalter 

