### PR TITLE
Implement minimal GET app delete job

### DIFF
--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -2605,9 +2605,7 @@ var _ = Describe("AppHandler", func() {
 	})
 
 	Describe("the DELETE /v3/apps/:guid endpoint", func() {
-		var (
-			app repositories.AppRecord
-		)
+		var app repositories.AppRecord
 
 		BeforeEach(func() {
 			app = repositories.AppRecord{GUID: appGUID, SpaceGUID: spaceGUID}

--- a/api/presenter/job.go
+++ b/api/presenter/job.go
@@ -13,12 +13,13 @@ type JobResponse struct {
 	Links     JobLinks `json:"links"`
 }
 
+// TODO: Generalize job links or just omit missing links for jobs that do not require them?
 type JobLinks struct {
-	Self  Link `json:"self"`
-	Space Link `json:"space"`
+	Self  Link  `json:"self"`
+	Space *Link `json:"space,omitempty"`
 }
 
-func ForJob(jobGUID string, spaceGUID string, baseURL url.URL) JobResponse {
+func ForManifestApplyJob(jobGUID string, spaceGUID string, baseURL url.URL) JobResponse {
 	return JobResponse{
 		GUID:      jobGUID,
 		Errors:    nil,
@@ -31,8 +32,25 @@ func ForJob(jobGUID string, spaceGUID string, baseURL url.URL) JobResponse {
 			Self: Link{
 				HREF: buildURL(baseURL).appendPath("/v3/jobs", jobGUID).build(),
 			},
-			Space: Link{
+			Space: &Link{
 				HREF: buildURL(baseURL).appendPath("/v3/spaces", spaceGUID).build(),
+			},
+		},
+	}
+}
+
+func ForAppDeleteJob(jobGUID string, baseURL url.URL) JobResponse {
+	return JobResponse{
+		GUID:      jobGUID,
+		Errors:    nil,
+		Warnings:  nil,
+		Operation: "app.delete",
+		State:     "COMPLETE",
+		CreatedAt: "",
+		UpdatedAt: "",
+		Links: JobLinks{
+			Self: Link{
+				HREF: buildURL(baseURL).appendPath("/v3/jobs", jobGUID).build(),
 			},
 		},
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#335](https://github.com/cloudfoundry/cf-k8s-controllers/issues/335)

## What is this change about?
Add a minimal implementation of the GET jobs endpoint for app delete jobs.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See related issue.

## Tag your pair, your PM, and/or team
paired with @Birdrock 
