### PR TITLE
Skip AuthenticationMiddleware for log-cache endpoints

### DIFF
--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -2605,9 +2605,7 @@ var _ = Describe("AppHandler", func() {
 	})
 
 	Describe("the DELETE /v3/apps/:guid endpoint", func() {
-		var (
-			app repositories.AppRecord
-		)
+		var app repositories.AppRecord
 
 		BeforeEach(func() {
 			app = repositories.AppRecord{GUID: appGUID, SpaceGUID: spaceGUID}

--- a/api/apis/authentication_middleware.go
+++ b/api/apis/authentication_middleware.go
@@ -2,6 +2,7 @@ package apis
 
 import (
 	"net/http"
+	"regexp"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"github.com/go-http-utils/headers"
@@ -27,15 +28,16 @@ func NewAuthenticationMiddleware(logger logr.Logger, authInfoParser AuthInfoPars
 		authInfoParser:   authInfoParser,
 		identityProvider: identityProvider,
 		unauthenticatedEndpoints: map[string]interface{}{
-			"/":   struct{}{},
-			"/v3": struct{}{},
+			"/":            struct{}{},
+			"/v3":          struct{}{},
+			"/api/v1/info": struct{}{},
 		},
 	}
 }
 
 func (a *AuthenticationMiddleware) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, authNotRequired := a.unauthenticatedEndpoints[r.URL.Path]; authNotRequired {
+		if a.isUnauthenticatedEndpoint(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -73,4 +75,15 @@ func (a *AuthenticationMiddleware) Middleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// Eventually we will want to authenticate the log-cache read endpoint and go back to using the simple
+// unauthenticatedEndpoints map. For now though we need to do a more complicated regexp match against
+// the path since the log-cache read endpoint includes an arbitrary guid as part of its path
+var logCacheReadEndpointRegexp = regexp.MustCompile(`\/api\/v1\/read\/[0-9a-fA-F\-]*$`)
+
+func (a *AuthenticationMiddleware) isUnauthenticatedEndpoint(p string) bool {
+	_, authNotRequired := a.unauthenticatedEndpoints[p]
+
+	return authNotRequired || logCacheReadEndpointRegexp.MatchString(p)
 }

--- a/api/apis/authentication_middleware_test.go
+++ b/api/apis/authentication_middleware_test.go
@@ -2,6 +2,7 @@ package apis_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
@@ -9,6 +10,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories/provider/fake"
 	"github.com/go-http-utils/headers"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -78,6 +80,39 @@ var _ = Describe("Authentication Middleware", func() {
 			It("does not inject an authorization.Info in the context", func() {
 				_, ok := authorization.InfoFromContext(actualReq.Context())
 				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Describe("/api/v1/info", func() {
+			BeforeEach(func() {
+				requestPath = "/api/v1/info"
+			})
+
+			It("passes through", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+			})
+
+			It("does not inject an authorization.Info in the context", func() {
+				_, ok := authorization.InfoFromContext(actualReq.Context())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Describe("/api/v1/read/:guid", func() {
+			When("given an arbitrary guid", func() {
+				BeforeEach(func() {
+					guid := uuid.NewString()
+					requestPath = fmt.Sprintf("/api/v1/read/%s", guid)
+				})
+
+				It("passes through", func() {
+					Expect(rr).To(HaveHTTPStatus(http.StatusTeapot), fmt.Sprintf("Request path: %s", requestPath))
+				})
+
+				It("does not inject an authorization.Info in the context", func() {
+					_, ok := authorization.InfoFromContext(actualReq.Context())
+					Expect(ok).To(BeFalse(), fmt.Sprintf("Request path: %s", requestPath))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
* https://github.com/cloudfoundry/cf-k8s-controllers/issues/362

## What is this change about?
Right now the CF CLI is omitting the authorization header for the log-cache endpoints for some reason. I've got an open Slack thread about that and will link the issue for it once it exists.

As a mitigation this change omits our hard-coded log-cache endpoints in the `AuthenticationMiddleware`.
- `/api/v1/info` is a discovery endpoint and doesn't require
authentication in general
- `/api/v1/read/<app-guid>` eventually will require authentication, but
doesn't right now since we are returning a hard-coded empty list of
envelopes. Eventually we will want Auth here.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow the A/C on https://github.com/cloudfoundry/cf-k8s-controllers/issues/362 or try to `cf push` an app. You shouldn't see `401` errors anymore while trying to hit log-cache.
