### PR TITLE
Add ownerReference fields to CFApp owned objects

### DIFF
--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -112,7 +112,7 @@ func (h *BuildHandler) buildCreateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	buildCreateMessage := payload.ToMessage(packageRecord.AppGUID, packageRecord.SpaceGUID)
+	buildCreateMessage := payload.ToMessage(packageRecord)
 
 	record, err := h.buildRepo.CreateBuild(r.Context(), authInfo, buildCreateMessage)
 	if err != nil {

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
@@ -346,6 +348,7 @@ var _ = Describe("BuildHandler", func() {
 
 		const (
 			packageGUID = "the-package-guid"
+			packageUID  = "the-package-uid"
 			appGUID     = "the-app-guid"
 			buildGUID   = "test-build-guid"
 
@@ -370,6 +373,7 @@ var _ = Describe("BuildHandler", func() {
 				AppGUID:   appGUID,
 				SpaceGUID: spaceGUID,
 				GUID:      packageGUID,
+				UID:       packageUID,
 				State:     "READY",
 				CreatedAt: createdAt,
 				UpdatedAt: updatedAt,
@@ -442,6 +446,14 @@ var _ = Describe("BuildHandler", func() {
 					Expect(actualCreate.Lifecycle.Type).To(Equal(expectedLifecycleType))
 					Expect(actualCreate.Lifecycle.Data.Buildpacks).To(Equal([]string{}))
 					Expect(actualCreate.Lifecycle.Data.Stack).To(Equal(expectedLifecycleStack))
+				})
+				It("fills the OwnerRef with a reference to the CFPackage", func() {
+					Expect(actualCreate.OwnerRef).To(Equal(metav1.OwnerReference{
+						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+						Kind:       "CFPackage",
+						Name:       packageGUID,
+						UID:        packageUID,
+					}))
 				})
 			})
 

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -194,7 +194,7 @@ func (h PackageHandler) packageCreateHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	record, err := h.packageRepo.CreatePackage(r.Context(), authInfo, payload.ToMessage(appRecord.SpaceGUID))
+	record, err := h.packageRepo.CreatePackage(r.Context(), authInfo, payload.ToMessage(appRecord))
 	if err != nil {
 		h.logger.Info("Error creating package with repository", "error", err.Error())
 		writeUnknownErrorResponse(w)

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
@@ -454,6 +456,7 @@ var _ = Describe("PackageHandler", func() {
 		const (
 			packageGUID = "the-package-guid"
 			appGUID     = "the-app-guid"
+			appUID      = "the-app-uid"
 			spaceGUID   = "the-space-guid"
 			validBody   = `{
 				"type": "bits",
@@ -482,6 +485,8 @@ var _ = Describe("PackageHandler", func() {
 
 			appRepo.FetchAppReturns(repositories.AppRecord{
 				SpaceGUID: spaceGUID,
+				GUID:      appGUID,
+				EtcdUID:   appUID,
 			}, nil)
 		})
 
@@ -507,6 +512,12 @@ var _ = Describe("PackageHandler", func() {
 					Type:      "bits",
 					AppGUID:   appGUID,
 					SpaceGUID: spaceGUID,
+					OwnerRef: metav1.OwnerReference{
+						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+						Kind:       "CFApp",
+						Name:       appGUID,
+						UID:        appUID,
+					},
 				}))
 			})
 

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -1,6 +1,9 @@
 package payloads
 
-import "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+import (
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type PackageCreate struct {
 	Type          string                `json:"type" validate:"required,oneof='bits'"`
@@ -11,11 +14,17 @@ type PackageRelationships struct {
 	App *Relationship `json:"app" validate:"required"`
 }
 
-func (m PackageCreate) ToMessage(spaceGUID string) repositories.PackageCreateMessage {
+func (m PackageCreate) ToMessage(record repositories.AppRecord) repositories.PackageCreateMessage {
 	return repositories.PackageCreateMessage{
 		Type:      m.Type,
-		AppGUID:   m.Relationships.App.Data.GUID,
-		SpaceGUID: spaceGUID,
+		AppGUID:   record.GUID,
+		SpaceGUID: record.SpaceGUID,
+		OwnerRef: metav1.OwnerReference{
+			APIVersion: repositories.APIVersion,
+			Kind:       "CFApp",
+			Name:       record.GUID,
+			UID:        record.EtcdUID,
+		},
 	}
 }
 

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -26,6 +26,7 @@ const (
 
 type BuildCreateMessage struct {
 	AppGUID         string
+	OwnerRef        metav1.OwnerReference
 	PackageGUID     string
 	SpaceGUID       string
 	StagingMemoryMB int
@@ -160,6 +161,9 @@ func (b *BuildRepo) buildCreateToCFBuild(message BuildCreateMessage) workloadsv1
 			Namespace:   message.SpaceGUID,
 			Labels:      message.Labels,
 			Annotations: message.Annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				message.OwnerRef,
+			},
 		},
 		Spec: workloadsv1alpha1.CFBuildSpec{
 			PackageRef: corev1.LocalObjectReference{

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -348,6 +348,7 @@ var _ = Describe("BuildRepository", func() {
 	Describe("CreateBuild", func() {
 		const (
 			appGUID     = "the-app-guid"
+			packageUID  = "the-package-uid"
 			packageGUID = "the-package-guid"
 
 			buildStagingState = "STAGING"
@@ -393,6 +394,12 @@ var _ = Describe("BuildRepository", func() {
 				},
 				Labels:      buildCreateLabels,
 				Annotations: buildCreateAnnotations,
+				OwnerRef: metav1.OwnerReference{
+					APIVersion: APIVersion,
+					Kind:       "CFPackage",
+					Name:       packageGUID,
+					UID:        packageUID,
+				},
 			}
 		})
 
@@ -473,6 +480,15 @@ var _ = Describe("BuildRepository", func() {
 					err := k8sClient.Get(context.Background(), cfBuildLookupKey, createdCFBuild)
 					return err == nil
 				}, 5*time.Second, 250*time.Millisecond).Should(BeTrue(), "A CFBuild CR was not eventually created")
+
+				Expect(createdCFBuild.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
+					{
+						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+						Kind:       "CFPackage",
+						Name:       packageGUID,
+						UID:        packageUID,
+					},
+				}))
 			})
 		})
 	})

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -19,6 +19,7 @@ import (
 
 var _ = Describe("PackageRepository", func() {
 	const appGUID = "the-app-guid"
+	const appUID = "the-app-uid"
 
 	var (
 		packageRepo *PackageRepo
@@ -42,6 +43,12 @@ var _ = Describe("PackageRepository", func() {
 				Type:      "bits",
 				AppGUID:   appGUID,
 				SpaceGUID: spaceGUID,
+				OwnerRef: metav1.OwnerReference{
+					APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+					Kind:       "CFApp",
+					Name:       appGUID,
+					UID:        appUID,
+				},
 			}
 
 			Expect(
@@ -84,6 +91,15 @@ var _ = Describe("PackageRepository", func() {
 			Expect(createdCFPackage.Namespace).To(Equal(spaceGUID))
 			Expect(createdCFPackage.Spec.Type).To(Equal(workloadsv1alpha1.PackageType("bits")))
 			Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(appGUID))
+			Expect(createdCFPackage.ObjectMeta.OwnerReferences).To(Equal(
+				[]metav1.OwnerReference{
+					{
+						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+						Kind:       "CFApp",
+						Name:       appGUID,
+						UID:        appUID,
+					},
+				}))
 
 			Expect(cleanupPackage(ctx, k8sClient, packageGUID, spaceGUID)).To(Succeed())
 		})

--- a/controllers/controllers/shared/index.go
+++ b/controllers/controllers/shared/index.go
@@ -12,7 +12,6 @@ import (
 const DestinationAppName = "destinationAppName"
 
 func SetupIndexWithManager(mgr manager.Manager) error {
-
 	// Generate indexes for CFRoute on field spec.Destination.AppRef.Name for efficient querying.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &networkingv1alpha1.CFRoute{}, DestinationAppName,
 		func(rawObj client.Object) []string {

--- a/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfapp_controller_integration_test.go
@@ -145,6 +145,15 @@ var _ = Describe("CFAppReconciler", func() {
 							Expect(createdCFProcess.Spec.Command).To(Equal(process.Command), "cfprocess command does not match with droplet command")
 							Expect(createdCFProcess.Spec.AppRef.Name).To(Equal(cfAppGUID), "cfprocess app ref does not match app-guid")
 							Expect(createdCFProcess.Spec.Ports).To(Equal(droplet.Ports), "cfprocess ports does not match ports on droplet")
+
+							Expect(createdCFProcess.ObjectMeta.OwnerReferences).To(ConsistOf([]metav1.OwnerReference{
+								{
+									APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+									Kind:       "CFApp",
+									Name:       cfApp.Name,
+									UID:        cfApp.GetUID(),
+								},
+							}))
 						}
 					})
 				})


### PR DESCRIPTION
## Is there a related GitHub Issue?
[fixes #336]

## What is this change about?
Add ownerReference fields to CFApp owned objects
- When a CFApp CR is deleted, all derivative objects should also be
  deleted.
- CFProcess, CFBuild, and CFPackage were missing owner references and
  not getting cleaned up.
- This commit fixes that.

## Does this PR introduce a breaking change?
no.

## Acceptance Steps
See #336

## Tag your pair, your PM, and/or team
@akrishna90 
