### PR TITLE
Use eirini version label selector when fetching pods for app

### DIFF
--- a/api/actions/fetch_process_stats.go
+++ b/api/actions/fetch_process_stats.go
@@ -40,6 +40,7 @@ func (a *FetchProcessStats) Invoke(ctx context.Context, authInfo authorization.I
 		AppGUID:     processRecord.AppGUID,
 		Instances:   processRecord.DesiredInstances,
 		ProcessType: processRecord.Type,
+		AppRevision: appRecord.Revision,
 	}
 	return a.podRepo.FetchPodStatsByAppGUID(ctx, authInfo, message)
 }

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -51,6 +51,7 @@ type AppRecord struct {
 	Name          string
 	GUID          string
 	EtcdUID       types.UID
+	Revision      string
 	SpaceGUID     string
 	DropletGUID   string
 	Labels        map[string]string
@@ -417,6 +418,7 @@ func cfAppToAppRecord(cfApp workloadsv1alpha1.CFApp) AppRecord {
 	return AppRecord{
 		GUID:        cfApp.Name,
 		EtcdUID:     cfApp.GetUID(),
+		Revision:    getLabelOrAnnotation(cfApp.GetAnnotations(), workloadsv1alpha1.CFAppRevisionKey),
 		Name:        cfApp.Spec.Name,
 		SpaceGUID:   cfApp.Namespace,
 		DropletGUID: cfApp.Spec.CurrentDropletRef.Name,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -21,6 +21,11 @@ import (
 	"sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
+const (
+	CFAppRevisionKey   = "workloads.cloudfoundry.org/app-rev"
+	CFAppRevisionValue = "1"
+)
+
 var _ = Describe("AppRepository", func() {
 	var (
 		testCtx                context.Context
@@ -66,6 +71,7 @@ var _ = Describe("AppRepository", func() {
 
 				Expect(app.GUID).To(Equal(cfApp2.Name))
 				Expect(app.EtcdUID).To(Equal(cfApp2.GetUID()))
+				Expect(app.Revision).To(Equal(CFAppRevisionValue))
 				Expect(app.Name).To(Equal(cfApp2.Spec.Name))
 				Expect(app.SpaceGUID).To(Equal(space2.Name))
 				Expect(app.State).To(Equal(DesiredState("STOPPED")))
@@ -885,6 +891,9 @@ func createAppWithGUID(space, guid string) *workloadsv1alpha1.CFApp {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      guid,
 			Namespace: space,
+			Annotations: map[string]string{
+				CFAppRevisionKey: CFAppRevisionValue,
+			},
 		},
 		Spec: workloadsv1alpha1.CFAppSpec{
 			Name:         generateGUID(),

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -20,9 +20,10 @@ import (
 const (
 	workloadsContainerName = "opi"
 	cfInstanceIndexKey     = "CF_INSTANCE_INDEX"
+	eiriniLabelVersionKey  = "workloads.cloudfoundry.org/version"
 	RunningState           = "RUNNING"
+	pendingState           = "STARTING"
 	// All below statuses changed to "DOWN" until we decide what statuses we want to support in the future
-	pendingState = "STARTING"
 	crashedState = "DOWN"
 	unknownState = "DOWN"
 )
@@ -36,6 +37,7 @@ type PodStatsRecord struct {
 type FetchPodStatsMessage struct {
 	Namespace   string
 	AppGUID     string
+	AppRevision string
 	Instances   int
 	ProcessType string
 }
@@ -49,7 +51,10 @@ func NewPodRepo(privilegedClient client.Client) *PodRepo {
 }
 
 func (r *PodRepo) FetchPodStatsByAppGUID(ctx context.Context, authInfo authorization.Info, message FetchPodStatsMessage) ([]PodStatsRecord, error) {
-	labelSelector, err := labels.ValidatedSelectorFromSet(map[string]string{workloadsv1alpha1.CFAppGUIDLabelKey: message.AppGUID})
+	labelSelector, err := labels.ValidatedSelectorFromSet(map[string]string{
+		workloadsv1alpha1.CFAppGUIDLabelKey: message.AppGUID,
+		eiriniLabelVersionKey:               message.AppRevision,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -53,6 +53,13 @@ func getConditionValue(conditions *[]metav1.Condition, conditionType string) met
 	return conditionStatusValue
 }
 
+func getLabelOrAnnotation(mapObj map[string]string, key string) string {
+	if mapObj == nil {
+		return ""
+	}
+	return mapObj[key]
+}
+
 type NotFoundError struct {
 	Err          error
 	ResourceType string


### PR DESCRIPTION
## Is there a related GitHub Issue?
#352 

## What is this change about?
Adds an additional label selector (eirini version label) when fetching pods. 
This fix keeps `cf restart` from existing early. 

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Push an app using `cf push`
Try restarting the app using `cf restart`
`cf restart` should exit only when new pods become available.

## Tag your pair, your PM, and/or team
@davewalter 