### PR TITLE
Add dev support for local container registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,25 @@ deploy: install-crds deploy-controllers deploy-api
 
 deploy-kind: install-crds deploy-controllers-kind deploy-api-kind-auth
 
+deploy-kind-local: install-crds deploy-controllers-kind-local deploy-api-kind-local
+
 deploy-controllers: install-kustomize build-reference-controllers
 	$(KUSTOMIZE) build controllers/config/default | kubectl apply -f -
 
 deploy-controllers-kind: install-kustomize build-reference-controllers
 	$(KUSTOMIZE) build controllers/config/overlays/kind | kubectl apply -f -
 
+deploy-controllers-kind-local: install-kustomize build-reference-controllers
+	$(KUSTOMIZE) build controllers/config/overlays/kind-local-registry | kubectl apply -f -
+
 deploy-api: install-kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/base | kubectl apply -f -
 
 deploy-api-kind-auth: install-kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/overlays/kind-auth-enabled | kubectl apply -f -
+
+deploy-api-kind-local: install-kustomize build-reference-api
+	$(KUSTOMIZE) build api/config/overlays/kind-local-registry | kubectl apply -f -
 
 undeploy-controllers: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build controllers/config/default | kubectl delete -f -

--- a/api/config/overlays/kind-local-registry/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind-local-registry/apiconfig/cf_k8s_api_config.yaml
@@ -1,0 +1,10 @@
+serverURL: http://localhost
+serverPort: 9000
+rootNamespace: cf
+defaultLifecycleConfig:
+  type: buildpack
+  stack: cflinuxfs3
+  stagingMemoryMB: 1024
+  stagingDiskMB: 1024
+packageRegistryBase: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/packages
+packageRegistrySecretName: image-registry-credentials

--- a/api/config/overlays/kind-local-registry/kustomization.yaml
+++ b/api/config/overlays/kind-local-registry/kustomization.yaml
@@ -1,0 +1,24 @@
+configMapGenerator:
+- behavior: merge
+  files:
+  - apiconfig/cf_k8s_api_config.yaml
+  name: config
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patches:
+- target:
+    group: projectcontour.io
+    version: v1
+    kind: HTTPProxy
+    name: proxy
+  patch: |-
+    - op: replace
+      path: /spec/virtualhost/fqdn
+      value: "localhost"
+    - op: remove
+      path: /spec/virtualhost/tls

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,4 +1,4 @@
-kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
+kpackImageTag: localregistry-docker-registry.default.svc.cluster.local:30050/cf-k8s-controllers/kpack/images
 
 clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:

--- a/controllers/config/overlays/kind-local-registry/kustomization.yaml
+++ b/controllers/config/overlays/kind-local-registry/kustomization.yaml
@@ -1,0 +1,11 @@
+configMapGenerator:
+- behavior: merge
+  files:
+  - controllersconfig/cf_k8s_controllers_config.yaml
+  name: config
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default

--- a/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,5 +1,4 @@
 kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
-
 clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
   memoryMB: 500

--- a/controllers/config/samples/cfdomain.yaml
+++ b/controllers/config/samples/cfdomain.yaml
@@ -4,4 +4,4 @@ metadata:
   name: 5b5032ab-7fc8-4da5-b853-821fd1879201
   namespace: cf
 spec:
-  name: cf-apps.io
+  name: vcap.me

--- a/dependencies/kpack/cluster_builder.yaml
+++ b/dependencies/kpack/cluster_builder.yaml
@@ -7,7 +7,7 @@ spec:
     name: kpack-service-account
     namespace: cf
   # Replace with real docker registry
-  tag: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/akira/builder
+  tag: localregistry-docker-registry.default.svc.cluster.local:30050/kpack/stuff
   stack:
     name: cf-default-stack
     kind: ClusterStack

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -48,6 +48,7 @@ EOF
 }
 
 ensure_local_registry() {
+  helm repo add twuni https://helm.twun.io
   helm upgrade --install localregistry twuni/docker-registry --set service.type=NodePort,service.nodePort=30050,service.port=30050
 
   # TODO-maybe we don't need to add the /etc/hosts hack if we configure the mirror below to redirect to 127.0.0.1?

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -77,7 +77,7 @@ EOF
 deploy_cf_k8s_controllers() {
   pushd $ROOT_DIR >/dev/null
   {
-    if [ -n "$use_local_registry" ]; then
+    if [[ -n "$use_local_registry" ]]; then
       export DOCKER_SERVER="localregistry-docker-registry.default.svc.cluster.local:30050"
       export DOCKER_USERNAME="whatevs"
       export DOCKER_PASSWORD="whatevs"
@@ -94,7 +94,7 @@ deploy_cf_k8s_controllers() {
     fi
     kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     make install-crds
-    if [ -n "$use_local_registry" ]; then
+    if [[ -n "$use_local_registry" ]]; then
       make deploy-controllers-kind-local
     else
       make deploy-controllers-kind
@@ -112,7 +112,7 @@ deploy_cf_k8s_api() {
       make docker-build-api
     fi
     kind load docker-image --name "$cluster" "$IMG_API"
-    if [ -n "$use_local_registry" ]; then
+    if [[ -n "$use_local_registry" ]]; then
       make deploy-api-kind-local
     else
       make deploy-api-kind-auth
@@ -123,8 +123,8 @@ deploy_cf_k8s_api() {
 
 cluster=${1:?specify cluster name}
 ensure_kind_cluster "$cluster"
-use_local_registry=${2}
-if [ -n "$use_local_registry" ]; then
+use_local_registry=${2:-}
+if [[ -n "$use_local_registry" ]]; then
   ensure_local_registry
 fi
 export KUBECONFIG="$HOME/.kube/$cluster.yml"

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -47,9 +47,41 @@ EOF
   kind export kubeconfig --name "$cluster" --kubeconfig "$HOME/.kube/$cluster.yml"
 }
 
+ensure_local_registry() {
+  helm upgrade --install localregistry twuni/docker-registry --set service.type=NodePort,service.nodePort=30050,service.port=30050
+
+  # TODO-maybe we don't need to add the /etc/hosts hack if we configure the mirror below to redirect to 127.0.0.1?
+  docker exec "${cluster}-control-plane" bash -c 'echo "127.0.0.1 localregistry-docker-registry.default.svc.cluster.local" >> /etc/hosts'
+
+  # reconfigure containerd to allow insecure connection to our local registry
+  docker cp ${cluster}-control-plane:/etc/containerd/config.toml /tmp/config.toml
+  if ! grep -q localregistry-docker-registry\.default\.svc\.cluster\.local /tmp/config.toml; then
+    cat <<EOF >> /tmp/config.toml
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localregistry-docker-registry.default.svc.cluster.local:30050"]
+      endpoint = ["http://localregistry-docker-registry.default.svc.cluster.local:30050"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."localregistry-docker-registry.default.svc.cluster.local:30050".tls]
+      insecure_skip_verify = true
+EOF
+    docker cp /tmp/config.toml ${cluster}-control-plane:/etc/containerd/config.toml
+    docker exec "${cluster}-control-plane" bash -c "systemctl restart containerd"
+    echo "waiting for containerd to restart..."
+    sleep 30
+  fi
+}
+
 deploy_cf_k8s_controllers() {
   pushd $ROOT_DIR >/dev/null
   {
+    if [ -n "$use_local_registry" ]; then
+      export DOCKER_SERVER="localregistry-docker-registry.default.svc.cluster.local:30050"
+      export DOCKER_USERNAME="whatevs"
+      export DOCKER_PASSWORD="whatevs"
+    fi
+
     "$SCRIPT_DIR/install-dependencies.sh"
     export KUBEBUILDER_ASSETS=$ROOT_DIR/testbin/bin
     echo $PWD
@@ -61,7 +93,11 @@ deploy_cf_k8s_controllers() {
     fi
     kind load docker-image --name "$cluster" "$IMG_CONTROLLERS"
     make install-crds
-    make deploy-controllers
+    if [ -n "$use_local_registry" ]; then
+      make deploy-controllers-kind-local
+    else
+      make deploy-controllers-kind
+    fi
   }
   popd >/dev/null
 }
@@ -75,13 +111,21 @@ deploy_cf_k8s_api() {
       make docker-build-api
     fi
     kind load docker-image --name "$cluster" "$IMG_API"
-    make deploy-api-kind-auth
+    if [ -n "$use_local_registry" ]; then
+      make deploy-api-kind-local
+    else
+      make deploy-api-kind-auth
+    fi
   }
   popd >/dev/null
 }
 
 cluster=${1:?specify cluster name}
 ensure_kind_cluster "$cluster"
+use_local_registry=${2}
+if [ -n "$use_local_registry" ]; then
+  ensure_local_registry
+fi
 export KUBECONFIG="$HOME/.kube/$cluster.yml"
 deploy_cf_k8s_controllers
 deploy_cf_k8s_api


### PR DESCRIPTION
## Is there a related GitHub Issue?
Nope

## What is this change about?
It adds a local container registry option to the deploy-on-kind developer script.
- `deploy-on-kind.sh` can now take a second argument that tells it to
  deploy and use a local container registry.
- this requires some hackery to get the registry address to work from
  within the kind node, but saves us from having to specify an external
  registry.


## Does this PR introduce a breaking change?
no

## Acceptance Steps
To use it:

```
./scripts/deploy-on-kind.sh cluster local
```

The existence of the second argument tells the script to wire up the local registry.

Once the script is done, create a CFDomain object, and your cluster will be ready to push and run apps.

## Tag your pair, your PM, and/or team
@Birdrock @tcdowney @PureMunky PTAL
