### PR TITLE
Make notes to the submitter HTML comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,27 @@
-> Thanks for contributing!
->
-> We've designed this PR template to speed up the PR review and merge process - please use it.
+<!--
+Thanks for contributing!
+
+We've designed this PR template to speed up the PR review and merge process - please use it.
+-->
 
 ## Is there a related GitHub Issue?
-> _If there is a corresponding GitHub Issue, please link it here._
+<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
 
 ## What is this change about?
-> _Please describe the change here._
+<!-- _Please describe the change here._ -->
 
 ## Does this PR introduce a breaking change?
-> _Please let us know if we should expect breaking changes in this PR._
+<!-- _Please let us know if we should expect breaking changes in this PR._ -->
 
 ## Acceptance Steps
-> _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._
+<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
 
 ## Tag your pair, your PM, and/or team
-> _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
+<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
 
 ## Things to remember
+<!--
 - Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
 - Is there anything else of note that the reviewers should know about this change?
 - This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
+-->


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, this came out of a Retro action item

## What is this change about?
Make the instructions in the PR template into HTML comments so they can be left in without being visible in the PR

## Does this PR introduce a breaking change?
No

## Acceptance Steps
After merging, start a PR and confirm that the preview doesn't show any of the instructions


## Tag your pair, your PM, and/or team
@julian-hj 