### PR TITLE
Expose PORT, VCAP_APP_PORT, VCAP_APP_HOST env to app

### DIFF
--- a/controllers/controllers/workloads/cfprocess_controller.go
+++ b/controllers/controllers/workloads/cfprocess_controller.go
@@ -21,6 +21,10 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
+	"strconv"
+
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/shared"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -76,13 +80,11 @@ func (r *CFProcessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if foundValue, ok := cfApp.GetAnnotations()[workloadsv1alpha1.CFAppRevisionKey]; ok {
 		cfAppRev = foundValue
 	}
-
 	lrpsForProcess, err := r.fetchLRPsForProcess(ctx, cfProcess)
 	if err != nil {
 		r.Log.Error(err, fmt.Sprintf("Error when trying to fetch LRPs for Process %s/%s", req.Namespace, cfProcess.Name))
 		return ctrl.Result{}, err
 	}
-
 	if cfApp.Spec.DesiredState == workloadsv1alpha1.StartedState {
 
 		cfBuild := workloadsv1alpha1.CFBuild{}
@@ -105,6 +107,12 @@ func (r *CFProcessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{}, err
 			}
 		}
+		var appPort int
+		appPort, err = r.getPort(ctx, cfProcess, cfApp)
+		if err != nil {
+			r.Log.Error(err, fmt.Sprintf("Error when trying to fetch routes for CFApp %s/%s", req.Namespace, cfApp.Spec.Name))
+			return ctrl.Result{}, err
+		}
 
 		actualLRP := &eiriniv1.LRP{
 			ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +122,7 @@ func (r *CFProcessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		var desiredLRP *eiriniv1.LRP
-		desiredLRP, err = r.generateLRP(*actualLRP, cfApp, cfProcess, cfBuild, appEnvSecret)
+		desiredLRP, err = r.generateLRP(*actualLRP, cfApp, cfProcess, cfBuild, appEnvSecret, appPort)
 		if err != nil {
 			// untested
 			r.Log.Error(err, "Error when initializing LRP")
@@ -167,7 +175,7 @@ func lrpMutateFunction(actuallrp, desiredlrp *eiriniv1.LRP) controllerutil.Mutat
 	}
 }
 
-func (r *CFProcessReconciler) generateLRP(actualLRP eiriniv1.LRP, cfApp workloadsv1alpha1.CFApp, cfProcess workloadsv1alpha1.CFProcess, cfBuild workloadsv1alpha1.CFBuild, appEnvSecret corev1.Secret) (*eiriniv1.LRP, error) {
+func (r *CFProcessReconciler) generateLRP(actualLRP eiriniv1.LRP, cfApp workloadsv1alpha1.CFApp, cfProcess workloadsv1alpha1.CFProcess, cfBuild workloadsv1alpha1.CFBuild, appEnvSecret corev1.Secret, appPort int) (*eiriniv1.LRP, error) {
 	var desiredLRP eiriniv1.LRP
 	actualLRP.DeepCopyInto(&desiredLRP)
 
@@ -199,7 +207,7 @@ func (r *CFProcessReconciler) generateLRP(actualLRP eiriniv1.LRP, cfApp workload
 	desiredLRP.Spec.Image = cfBuild.Status.BuildDropletStatus.Registry.Image
 	desiredLRP.Spec.Ports = cfProcess.Spec.Ports
 	desiredLRP.Spec.Instances = cfProcess.Spec.DesiredInstances
-	desiredLRP.Spec.Env = secretDataToEnvMap(appEnvSecret.Data)
+	desiredLRP.Spec.Env = generateEnvMap(appEnvSecret.Data, appPort)
 	desiredLRP.Spec.Health = eiriniv1.Healthcheck{
 		Type:      string(cfProcess.Spec.HealthCheck.Type),
 		Port:      lrpHealthCheckPort,
@@ -240,11 +248,37 @@ func (r *CFProcessReconciler) fetchLRPsForProcess(ctx context.Context, cfProcess
 	return lrpsForProcess, err
 }
 
-func secretDataToEnvMap(secretData map[string][]byte) map[string]string {
+func (r *CFProcessReconciler) getPort(ctx context.Context, cfProcess workloadsv1alpha1.CFProcess, cfApp workloadsv1alpha1.CFApp) (int, error) {
+	// Get Routes for the process
+	var cfRoutesForProcess networkingv1alpha1.CFRouteList
+	err := r.Client.List(ctx, &cfRoutesForProcess, client.InNamespace(cfApp.GetNamespace()), client.MatchingFields{shared.DestinationAppName: cfApp.Name})
+	if err != nil {
+		return 0, err
+	}
+	// Filter those destinations
+	for _, cfRoute := range cfRoutesForProcess.Items {
+		for _, destination := range cfRoute.Status.Destinations {
+			if destination.ProcessType == cfProcess.Spec.ProcessType && destination.Port != 0 {
+				// Just use the first candidate port
+				return destination.Port, nil
+			}
+		}
+	}
+
+	return 8080, nil
+}
+
+func generateEnvMap(secretData map[string][]byte, port int) map[string]string {
 	convertedMap := make(map[string]string)
 	for k, v := range secretData {
 		convertedMap[k] = string(v)
 	}
+
+	portString := strconv.Itoa(port)
+	convertedMap["VCAP_APP_HOST"] = "0.0.0.0"
+	convertedMap["VCAP_APP_PORT"] = portString
+	convertedMap["PORT"] = portString
+
 	return convertedMap
 }
 

--- a/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfprocess_controller_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/workloads/testutils"
 
@@ -144,6 +146,9 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 			Expect(lrp.Spec.CPUWeight).To(BeZero(), "expected cpu to always be 0")
 			Expect(lrp.Spec.Sidecars).To(BeNil(), "expected sidecars to always be nil")
 			Expect(lrp.Spec.Env).To(HaveKeyWithValue("test-env-key", "test-env-val"))
+			Expect(lrp.Spec.Env).To(HaveKeyWithValue("VCAP_APP_HOST", "0.0.0.0"))
+			Expect(lrp.Spec.Env).To(HaveKeyWithValue("VCAP_APP_PORT", "8080"))
+			Expect(lrp.Spec.Env).To(HaveKeyWithValue("PORT", "8080"))
 			Expect(lrp.Spec.Command).To(ConsistOf("/cnb/lifecycle/launcher", processTypeWebCommand))
 		})
 
@@ -192,6 +197,77 @@ var _ = Describe("CFProcessReconciler Integration Tests", func() {
 					return true
 				}, 10*time.Second).Should(BeTrue(), "Timed out waiting for deletion of LRP/%s in namespace %s to cause NotFound error", testProcessGUID, testNamespace)
 			})
+		})
+	})
+
+	When("a CFRoute destination specififying a different port already exists before the app is started", func() {
+		BeforeEach(func() {
+			destination := networkingv1alpha1.Destination{
+				AppRef:      corev1.LocalObjectReference{Name: cfApp.Name},
+				ProcessType: processTypeWeb,
+				Port:        port9000,
+				Protocol:    "http1",
+			}
+			cfRoute := &networkingv1alpha1.CFRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GenerateGUID(),
+					Namespace: testNamespace,
+				},
+				Spec: networkingv1alpha1.CFRouteSpec{
+					Host:     "test-host",
+					Path:     "",
+					Protocol: "http",
+					DomainRef: corev1.LocalObjectReference{
+						Name: GenerateGUID(),
+					},
+					Destinations: []networkingv1alpha1.Destination{destination},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), cfRoute)).To(Succeed())
+			cfRoute.Status = networkingv1alpha1.CFRouteStatus{
+				CurrentStatus: "valid",
+				Description:   "ok",
+				Destinations:  []networkingv1alpha1.Destination{destination},
+			}
+			Expect(k8sClient.Status().Update(context.Background(), cfRoute)).To(Succeed())
+
+			Eventually(func() int {
+				var cfRoutesForProcess networkingv1alpha1.CFRouteList
+				err := k8sClient.List(context.Background(), &cfRoutesForProcess, client.InNamespace(testNamespace))
+				Expect(err).NotTo(HaveOccurred())
+				if len(cfRoutesForProcess.Items) > 0 && len(cfRoutesForProcess.Items[0].Status.Destinations) > 0 {
+					return cfRoutesForProcess.Items[0].Status.Destinations[0].Port
+				}
+				return -1
+			}, 5*time.Second).Should(Equal(9000), "Timed out waiting for route to be updated")
+
+			cfApp.Spec.DesiredState = workloadsv1alpha1.StartedState
+			Expect(
+				k8sClient.Create(context.Background(), cfApp),
+			).To(Succeed())
+		})
+		var lrp eiriniv1.LRP
+
+		It("eventually reconciles the CFProcess into an LRP with VCAP env set according to the destination port", func() {
+			Eventually(func() string {
+				var lrps eiriniv1.LRPList
+				err := k8sClient.List(context.Background(), &lrps, client.InNamespace(testNamespace))
+				if err != nil {
+					return ""
+				}
+
+				for _, currentLRP := range lrps.Items {
+					if getMapKeyValue(currentLRP.Labels, workloadsv1alpha1.CFProcessGUIDLabelKey) == testProcessGUID {
+						lrp = currentLRP
+						return lrp.GetName()
+					}
+				}
+
+				return ""
+			}, 5*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Timed out waiting for LRP/%s in namespace %s to be created", testProcessGUID, testNamespace))
+
+			Expect(lrp.Spec.Env).To(HaveKeyWithValue("VCAP_APP_PORT", "9000"))
+			Expect(lrp.Spec.Env).To(HaveKeyWithValue("PORT", "9000"))
 		})
 	})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#331

## What is this change about?
<!-- _Please describe the change here._ -->
Previously, we were not setting the PORT, VCAP_APP_PORT, VCAP_APP_HOST environment variables when creating an LRP, leaving some apps to choose their own port, which didn't work.

This change adds the standard environment variables.
If there is an existing route with a destination that matches our app
and a port set, we use that port. Otherwise we use port 8080

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See #331 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@acosta11 

