### PR TITLE
Ensure there is always a "web" process

### DIFF
--- a/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfbuild_controller_integration_test.go
@@ -87,94 +87,92 @@ var _ = Describe("CFBuildReconciler", func() {
 			Expect(k8sClient.Delete(afterCtx, newNamespace)).To(Succeed())
 		})
 
-		When("on the happy path", func() {
-			When("kpack image with CFBuild GUID doesn't exist", func() {
-				It("should eventually create a Kpack Image", func() {
-					testCtx := context.Background()
-					kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
-					createdKpackImage := new(buildv1alpha2.Image)
-					Eventually(func() bool {
-						err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
-						return err == nil
-					}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
-					kpackImageTag := "image/registry/tag" + "/" + cfBuildGUID
-					Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
-					Expect(createdKpackImage.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
-						UID:        desiredCFBuild.UID,
-						Kind:       "CFBuild",
-						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
-						Name:       desiredCFBuild.Name,
-					}))
-					Expect(createdKpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder"))
-					Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
-				})
-
-				It("eventually sets the status conditions on CFBuild", func() {
-					testCtx := context.Background()
-					cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
-					createdCFBuild := new(workloadsv1alpha1.CFBuild)
-					Eventually(func() []metav1.Condition {
-						err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
-						if err != nil {
-							return nil
-						}
-						return createdCFBuild.Status.Conditions
-					}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFBuild status conditions were empty")
-				})
+		When("kpack image with CFBuild GUID doesn't exist", func() {
+			It("eventually creates a Kpack Image", func() {
+				testCtx := context.Background()
+				kpackImageLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdKpackImage := new(buildv1alpha2.Image)
+				Eventually(func() bool {
+					err := k8sClient.Get(testCtx, kpackImageLookupKey, createdKpackImage)
+					return err == nil
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(), "could not retrieve the kpack image")
+				kpackImageTag := "image/registry/tag" + "/" + cfBuildGUID
+				Expect(createdKpackImage.Spec.Tag).To(Equal(kpackImageTag))
+				Expect(createdKpackImage.GetOwnerReferences()).To(ConsistOf(metav1.OwnerReference{
+					UID:        desiredCFBuild.UID,
+					Kind:       "CFBuild",
+					APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+					Name:       desiredCFBuild.Name,
+				}))
+				Expect(createdKpackImage.Spec.Builder.Name).To(Equal("cf-kpack-builder"))
+				Expect(k8sClient.Delete(testCtx, createdKpackImage)).To(Succeed())
 			})
 
-			When("kpack image with CFBuild GUID already exists", func() {
-				var (
-					newCFBuildGUID     string
-					existingKpackImage *buildv1alpha2.Image
-					newCFBuild         *workloadsv1alpha1.CFBuild
-				)
-
-				BeforeEach(func() {
-					beforeCtx := context.Background()
-					newCFBuildGUID = GenerateGUID()
-					existingKpackImage = &buildv1alpha2.Image{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      newCFBuildGUID,
-							Namespace: namespaceGUID,
-						},
-						Spec: buildv1alpha2.ImageSpec{
-							Tag: "my-tag-string",
-							Builder: corev1.ObjectReference{
-								Name: "my-builder",
-							},
-							ServiceAccountName: "my-service-account",
-							Source: corev1alpha1.SourceConfig{
-								Registry: &corev1alpha1.Registry{
-									Image:            "not-an-image",
-									ImagePullSecrets: nil,
-								},
-							},
-						},
+			It("eventually sets the status conditions on CFBuild", func() {
+				testCtx := context.Background()
+				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
+				createdCFBuild := new(workloadsv1alpha1.CFBuild)
+				Eventually(func() []metav1.Condition {
+					err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
+					if err != nil {
+						return nil
 					}
-					Expect(k8sClient.Create(beforeCtx, existingKpackImage)).To(Succeed())
-					newCFBuild = BuildCFBuildObject(newCFBuildGUID, namespaceGUID, cfPackageGUID, cfAppGUID)
-					Expect(k8sClient.Create(beforeCtx, newCFBuild)).To(Succeed())
-				})
+					return createdCFBuild.Status.Conditions
+				}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFBuild status conditions were empty")
+			})
+		})
 
-				AfterEach(func() {
-					afterCtx := context.Background()
-					Expect(k8sClient.Delete(afterCtx, existingKpackImage)).To(Succeed())
-					Expect(k8sClient.Delete(afterCtx, newCFBuild)).To(Succeed())
-				})
+		When("kpack image with CFBuild GUID already exists", func() {
+			var (
+				newCFBuildGUID     string
+				existingKpackImage *buildv1alpha2.Image
+				newCFBuild         *workloadsv1alpha1.CFBuild
+			)
 
-				It("eventually sets the status conditions on CFBuild", func() {
-					testCtx := context.Background()
-					cfBuildLookupKey := types.NamespacedName{Name: newCFBuildGUID, Namespace: namespaceGUID}
-					createdCFBuild := new(workloadsv1alpha1.CFBuild)
-					Eventually(func() []metav1.Condition {
-						err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
-						if err != nil {
-							return nil
-						}
-						return createdCFBuild.Status.Conditions
-					}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFBuild status conditions were empty")
-				})
+			BeforeEach(func() {
+				beforeCtx := context.Background()
+				newCFBuildGUID = GenerateGUID()
+				existingKpackImage = &buildv1alpha2.Image{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      newCFBuildGUID,
+						Namespace: namespaceGUID,
+					},
+					Spec: buildv1alpha2.ImageSpec{
+						Tag: "my-tag-string",
+						Builder: corev1.ObjectReference{
+							Name: "my-builder",
+						},
+						ServiceAccountName: "my-service-account",
+						Source: corev1alpha1.SourceConfig{
+							Registry: &corev1alpha1.Registry{
+								Image:            "not-an-image",
+								ImagePullSecrets: nil,
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(beforeCtx, existingKpackImage)).To(Succeed())
+				newCFBuild = BuildCFBuildObject(newCFBuildGUID, namespaceGUID, cfPackageGUID, cfAppGUID)
+				Expect(k8sClient.Create(beforeCtx, newCFBuild)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				afterCtx := context.Background()
+				Expect(k8sClient.Delete(afterCtx, existingKpackImage)).To(Succeed())
+				Expect(k8sClient.Delete(afterCtx, newCFBuild)).To(Succeed())
+			})
+
+			It("eventually sets the status conditions on CFBuild", func() {
+				testCtx := context.Background()
+				cfBuildLookupKey := types.NamespacedName{Name: newCFBuildGUID, Namespace: namespaceGUID}
+				createdCFBuild := new(workloadsv1alpha1.CFBuild)
+				Eventually(func() []metav1.Condition {
+					err := k8sClient.Get(testCtx, cfBuildLookupKey, createdCFBuild)
+					if err != nil {
+						return nil
+					}
+					return createdCFBuild.Status.Conditions
+				}, 10*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty(), "CFBuild status conditions were empty")
 			})
 		})
 	})
@@ -241,7 +239,7 @@ var _ = Describe("CFBuildReconciler", func() {
 				Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
 			})
 
-			It("should eventually set the status condition for Type Succeeded on CFBuild to False", func() {
+			It("eventually sets the status condition for Type Succeeded on CFBuild to False", func() {
 				testCtx := context.Background()
 				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
 				createdCFBuild := new(workloadsv1alpha1.CFBuild)
@@ -290,7 +288,7 @@ var _ = Describe("CFBuildReconciler", func() {
 				Expect(k8sClient.Status().Update(testCtx, createdKpackImage)).To(Succeed())
 			})
 
-			It("should eventually set the status condition for Type Succeeded on CFBuild to True", func() {
+			It("eventually sets the status condition for Type Succeeded on CFBuild to True", func() {
 				testCtx := context.Background()
 				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
 				createdCFBuild := new(workloadsv1alpha1.CFBuild)
@@ -304,7 +302,7 @@ var _ = Describe("CFBuildReconciler", func() {
 				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
 			})
 
-			It("should eventually set BuildStatusDroplet object", func() {
+			It("eventually sets BuildStatusDroplet object", func() {
 				testCtx := context.Background()
 				cfBuildLookupKey := types.NamespacedName{Name: cfBuildGUID, Namespace: namespaceGUID}
 				createdCFBuild := new(workloadsv1alpha1.CFBuild)


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#374

## What is this change about?
<!-- _Please describe the change here._ -->
This change ensures that a `web` process is always present, even when none is created as part of staging. This solves problems for go apps, which name their processes after the package being compiled.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
This is a behavior change for apps of some languages, such as go, but it brings the behavior in line with cf-for-vms and cf-for-k8s so I wouldn't consider it breaking. Apps that worked before this change should work after it, and some apps that didn't work should work now.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Follow the steps in the issue

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
