### PR TITLE
Install dependencies works for different environments

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -86,8 +86,14 @@ kubectl -n kpack wait --for condition=established --timeout=60s crd/clusterstack
 
 kubectl apply -f "${DEP_DIR}/kpack/service_account.yaml"
 kubectl apply -f "${DEP_DIR}/kpack/cluster_stack.yaml" \
-  -f "${DEP_DIR}/kpack/cluster_store.yaml" \
-  -f "${DEP_DIR}/kpack/cluster_builder.yaml"
+  -f "${DEP_DIR}/kpack/cluster_store.yaml"
+
+if [[ -n "${DOCKER_SERVER:=}" ]]; then
+  cat dependencies/kpack/cluster_builder.yaml | sed "s/tag: gcr.io/tag: ${DOCKER_SERVER}/g" > /tmp/clusterbuilder.yml
+  kubectl apply -f /tmp/clusterbuilder.yml
+else
+  kubectl apply -f "${DEP_DIR}/kpack/cluster_builder.yaml"
+fi
 
 echo "*******************"
 echo "Installing Contour"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No

## What is this change about?
<!-- _Please describe the change here._ -->
 installations using gcr.io and local registry require different tags for
  the kpack configuration. This change swaps in the hostname of the
  docker registry instead of gcr.io if it has been set in the
  DOCKER_SERVER environment variable.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

- `./scripts/deploy-on-kind.sh kind local`
- Check the status of your clusterbuilder. You should see that it becomes ready
- Do the same thing, only using gcr (omit the last arg to the script)

## Tag your pair, your PM, and/or team
@akrishna90 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
