### PR TITLE
Adds functionality to support `cf restage`

### DIFF
--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -359,7 +359,10 @@ var _ = Describe("PackageHandler", func() {
 
 					It("calls the package repository with expected arguments", func() {
 						_, _, message := packageRepo.ListPackagesArgsForCall(0)
-						Expect(message).To(Equal(repositories.ListPackagesMessage{AppGUIDs: []string{appGUID}}))
+						Expect(message).To(Equal(repositories.ListPackagesMessage{
+							AppGUIDs: []string{appGUID},
+							States:   []string{},
+						}))
 					})
 				})
 
@@ -389,7 +392,7 @@ var _ = Describe("PackageHandler", func() {
 								AppGUIDs:        []string{},
 								SortBy:          "created_at",
 								DescendingOrder: false,
-								State:           "",
+								States:          []string{},
 							}))
 						})
 
@@ -411,7 +414,7 @@ var _ = Describe("PackageHandler", func() {
 								AppGUIDs:        []string{},
 								SortBy:          "created_at",
 								DescendingOrder: true,
-								State:           "",
+								States:          []string{},
 							}))
 						})
 
@@ -432,6 +435,29 @@ var _ = Describe("PackageHandler", func() {
 						Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
 					})
 				})
+
+				When("the \"states\" parameter is sent", func() {
+					BeforeEach(func() {
+						var err error
+						req, err = http.NewRequestWithContext(ctx, "GET", "/v3/packages?states=READY,AWAITING_UPLOAD", nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("calls repository ListPackage with the correct message object", func() {
+						_, _, message := packageRepo.ListPackagesArgsForCall(0)
+						Expect(message).To(Equal(repositories.ListPackagesMessage{
+							AppGUIDs:        []string{},
+							SortBy:          "",
+							DescendingOrder: false,
+							States:          []string{"READY", "AWAITING_UPLOAD"},
+						}))
+					})
+
+					It("returns status 200", func() {
+						Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+					})
+				})
+
 			})
 			When("no packages exist", func() {
 				BeforeEach(func() {
@@ -486,7 +512,7 @@ var _ = Describe("PackageHandler", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("returns an Unknown key error", func() {
-				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, order_by, per_page'")
+				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, order_by, per_page, states'")
 			})
 		})
 	})

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -363,7 +363,7 @@ var _ = Describe("PackageHandler", func() {
 					})
 				})
 
-				When("the \"order_by\" parameter is sent", func() {
+				When("an invalid \"order_by\" parameter is sent", func() {
 					BeforeEach(func() {
 						var err error
 						req, err = http.NewRequestWithContext(ctx, "GET", "/v3/packages?order_by=some_weird_value", nil)
@@ -372,6 +372,52 @@ var _ = Describe("PackageHandler", func() {
 
 					It("ignores it and returns status 200", func() {
 						Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+					})
+				})
+
+				When("an valid \"order_by\" parameter is sent", func() {
+					When("sort order is ascending", func() {
+						BeforeEach(func() {
+							var err error
+							req, err = http.NewRequestWithContext(ctx, "GET", "/v3/packages?order_by=created_at", nil)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("calls repository ListPackage with the correct message object", func() {
+							_, _, message := packageRepo.ListPackagesArgsForCall(0)
+							Expect(message).To(Equal(repositories.ListPackagesMessage{
+								AppGUIDs:        []string{},
+								SortBy:          "created_at",
+								DescendingOrder: false,
+								State:           "",
+							}))
+						})
+
+						It("returns status 200", func() {
+							Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+						})
+					})
+
+					When("sort order is descending", func() {
+						BeforeEach(func() {
+							var err error
+							req, err = http.NewRequestWithContext(ctx, "GET", "/v3/packages?order_by=-created_at", nil)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("calls repository ListPackage with the correct message object", func() {
+							_, _, message := packageRepo.ListPackagesArgsForCall(0)
+							Expect(message).To(Equal(repositories.ListPackagesMessage{
+								AppGUIDs:        []string{},
+								SortBy:          "created_at",
+								DescendingOrder: true,
+								State:           "",
+							}))
+						})
+
+						It("returns status 200", func() {
+							Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+						})
 					})
 				})
 

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
@@ -31,15 +33,23 @@ func (m PackageCreate) ToMessage(record repositories.AppRecord) repositories.Cre
 
 type PackageListQueryParameters struct {
 	AppGUIDs string `schema:"app_guids"`
+	OrderBy  string `schema:"order_by"`
 
 	// Below parameters are ignored, but must be included to ignore as query parameters
-	OrderBy string `schema:"order_by"`
 	PerPage string `schema:"per_page"`
 }
 
 func (p *PackageListQueryParameters) ToMessage() repositories.ListPackagesMessage {
+	var descendingOrder bool
+
+	if strings.HasPrefix(p.OrderBy, "-") {
+		descendingOrder = true
+	}
+
 	return repositories.ListPackagesMessage{
-		AppGUIDs: parseArrayParam(p.AppGUIDs),
+		AppGUIDs:        parseArrayParam(p.AppGUIDs),
+		SortBy:          strings.TrimPrefix(p.OrderBy, "-"),
+		DescendingOrder: descendingOrder,
 	}
 }
 

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -34,6 +34,7 @@ func (m PackageCreate) ToMessage(record repositories.AppRecord) repositories.Cre
 type PackageListQueryParameters struct {
 	AppGUIDs string `schema:"app_guids"`
 	OrderBy  string `schema:"order_by"`
+	States   string `schema:"states"`
 
 	// Below parameters are ignored, but must be included to ignore as query parameters
 	PerPage string `schema:"per_page"`
@@ -50,11 +51,12 @@ func (p *PackageListQueryParameters) ToMessage() repositories.ListPackagesMessag
 		AppGUIDs:        parseArrayParam(p.AppGUIDs),
 		SortBy:          strings.TrimPrefix(p.OrderBy, "-"),
 		DescendingOrder: descendingOrder,
+		States:          parseArrayParam(p.States),
 	}
 }
 
 func (p *PackageListQueryParameters) SupportedQueryParameters() []string {
-	return []string{"app_guids", "order_by", "per_page"}
+	return []string{"app_guids", "order_by", "per_page", "states"}
 }
 
 type PackageListDropletsQueryParameters struct {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -53,7 +53,7 @@ type ListPackagesMessage struct {
 	AppGUIDs        []string
 	SortBy          string
 	DescendingOrder bool
-	State           string
+	States          []string
 }
 
 type CreatePackageMessage struct {
@@ -119,36 +119,56 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 		return []PackageRecord{}, err
 	}
 
-	filteredPackages := applyPackageFiltersAndOrder(packageList.Items, message)
+	orderedPackages := orderPackages(packageList.Items, message)
 
-	return returnPackageList(filteredPackages), nil
+	packageRecords := convertToPackageRecords(orderedPackages)
+
+	return applyPackageFilter(packageRecords, message), nil
+
 }
 
-func applyPackageFiltersAndOrder(packages []workloadsv1alpha1.CFPackage, message ListPackagesMessage) []workloadsv1alpha1.CFPackage {
-	var filtered []workloadsv1alpha1.CFPackage
+func orderPackages(packages []workloadsv1alpha1.CFPackage, message ListPackagesMessage) []workloadsv1alpha1.CFPackage {
+	sort.Slice(packages, func(i, j int) bool {
+		if message.SortBy == "created_at" && message.DescendingOrder {
+			return !packages[i].CreationTimestamp.Before(&packages[j].CreationTimestamp)
+		}
+		// For now, we order by created_at by default- if you really want to optimize runtime you can use bucketsort
+		return packages[i].CreationTimestamp.Before(&packages[j].CreationTimestamp)
+	})
+
+	return packages
+}
+
+func applyPackageFilter(packages []PackageRecord, message ListPackagesMessage) []PackageRecord {
+	var appFiltered []PackageRecord
 	if len(message.AppGUIDs) > 0 {
 		for _, currentPackage := range packages {
 			for _, appGUID := range message.AppGUIDs {
-				if currentPackage.Spec.AppRef.Name == appGUID {
-					filtered = append(filtered, currentPackage)
+				if currentPackage.AppGUID == appGUID {
+					appFiltered = append(appFiltered, currentPackage)
 					break
 				}
 			}
 		}
 	} else {
-		filtered = packages
+		appFiltered = packages
 	}
 
-	// TODO: use the future message.Order fields to reorder the list of results
-	sort.Slice(filtered, func(i, j int) bool {
-		if message.SortBy == "created_at" && message.DescendingOrder {
-			return !filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)
+	var stateFiltered []PackageRecord
+	if len(message.States) > 0 {
+		for _, currentPackage := range appFiltered {
+			for _, state := range message.States {
+				if currentPackage.State == state {
+					stateFiltered = append(stateFiltered, currentPackage)
+					break
+				}
+			}
 		}
-		// For now, we order by created_at by default- if you really want to optimize runtime you can use bucketsort
-		return filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)
-	})
+	} else {
+		stateFiltered = appFiltered
+	}
 
-	return filtered
+	return stateFiltered
 }
 
 func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authorization.Info, message UpdatePackageSourceMessage) (PackageRecord, error) {
@@ -210,7 +230,7 @@ func returnPackage(packages []workloadsv1alpha1.CFPackage) (PackageRecord, error
 	return cfPackageToPackageRecord(packages[0]), nil
 }
 
-func returnPackageList(packages []workloadsv1alpha1.CFPackage) []PackageRecord {
+func convertToPackageRecords(packages []workloadsv1alpha1.CFPackage) []PackageRecord {
 	packageRecords := make([]PackageRecord, 0, len(packages))
 
 	for _, currentPackage := range packages {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -50,7 +50,10 @@ type PackageRecord struct {
 }
 
 type ListPackagesMessage struct {
-	AppGUIDs []string
+	AppGUIDs        []string
+	SortBy          string
+	DescendingOrder bool
+	State           string
 }
 
 type CreatePackageMessage struct {
@@ -137,9 +140,12 @@ func applyPackageFiltersAndOrder(packages []workloadsv1alpha1.CFPackage, message
 	}
 
 	// TODO: use the future message.Order fields to reorder the list of results
-	// For now, we order by created_at by default- if you really want to optimize runtime you can use bucketsort
 	sort.Slice(filtered, func(i, j int) bool {
-		return !filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)
+		if message.SortBy == "created_at" && message.DescendingOrder {
+			return !filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)
+		}
+		// For now, we order by created_at by default- if you really want to optimize runtime you can use bucketsort
+		return filtered[i].CreationTimestamp.Before(&filtered[j].CreationTimestamp)
 	})
 
 	return filtered

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -351,6 +351,9 @@ var _ = Describe("PackageRepository", func() {
 				}
 				Expect(k8sClient.Create(context.Background(), package1)).To(Succeed())
 
+				// add a small delay to test ordering on created_by
+				time.Sleep(1 * time.Second)
+
 				package2 = &workloadsv1alpha1.CFPackage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      package2GUID,
@@ -417,19 +420,28 @@ var _ = Describe("PackageRepository", func() {
 						Expect(k8sClient.Delete(context.Background(), package3)).To(Succeed())
 					})
 
-					It("orders the results in descending created_at order by default", func() {
+					It("orders the results in ascending created_at order by default", func() {
 						packageList, err := packageRepo.ListPackages(context.Background(), authInfo, ListPackagesMessage{})
 						Expect(err).NotTo(HaveOccurred())
 						Expect(packageList).To(HaveLen(3))
-						for i := 0; i < len(packageList)-1; i++ {
-							currentRecordCreatedAt, err := time.Parse(time.RFC3339, packageList[i].CreatedAt)
-							Expect(err).NotTo(HaveOccurred())
+						Expect(packageList).To(ConsistOf(
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package1GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package2GUID),
+								"AppGUID": Equal(appGUID2),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package3GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+						))
 
-							nextRecordCreatedAt, err := time.Parse(time.RFC3339, packageList[i+1].CreatedAt)
-							Expect(err).NotTo(HaveOccurred())
-
-							Expect(currentRecordCreatedAt).To(BeTemporally(">=", nextRecordCreatedAt))
-						}
+						Expect(packageList[0].GUID).To(Equal(package1GUID))
+						Expect(packageList[1].GUID).To(Equal(package2GUID))
+						Expect(packageList[2].GUID).To(Equal(package3GUID))
 					})
 				})
 			})
@@ -446,6 +458,89 @@ var _ = Describe("PackageRepository", func() {
 						}),
 					)
 				})
+			})
+
+			When("SortBy is provided and value is created_at", func() {
+				var (
+					package3GUID string
+					package3     *workloadsv1alpha1.CFPackage
+				)
+				BeforeEach(func() {
+					package3GUID = generateGUID()
+					package3 = &workloadsv1alpha1.CFPackage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      package3GUID,
+							Namespace: namespace2.Name,
+						},
+						Spec: workloadsv1alpha1.CFPackageSpec{
+							Type: "bits",
+							AppRef: corev1.LocalObjectReference{
+								Name: appGUID1,
+							},
+						},
+					}
+					// add a small delay to test ordering on created_by
+					time.Sleep(1 * time.Second)
+
+					Expect(k8sClient.Create(context.Background(), package3)).To(Succeed())
+
+					DeferCleanup(func() {
+						_ = k8sClient.Delete(context.Background(), package3)
+					})
+				})
+
+				When("descending order is false", func() {
+					It("fetches packages sorted by created_at in ascending order", func() {
+						packageList, err := packageRepo.ListPackages(context.Background(), authInfo, ListPackagesMessage{SortBy: "created_at", DescendingOrder: false})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(packageList).To(ConsistOf(
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package1GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package2GUID),
+								"AppGUID": Equal(appGUID2),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package3GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+						))
+
+						Expect(packageList[0].GUID).To(Equal(package1GUID))
+						Expect(packageList[1].GUID).To(Equal(package2GUID))
+						Expect(packageList[2].GUID).To(Equal(package3GUID))
+					})
+				})
+
+				When("descending order is true", func() {
+					It("fetches packages sorted by created_at in descending order", func() {
+						packageList, err := packageRepo.ListPackages(context.Background(), authInfo, ListPackagesMessage{SortBy: "created_at", DescendingOrder: true})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(packageList).To(ConsistOf(
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package1GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package2GUID),
+								"AppGUID": Equal(appGUID2),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"GUID":    Equal(package3GUID),
+								"AppGUID": Equal(appGUID1),
+							}),
+						))
+
+						Expect(packageList[0].GUID).To(Equal(package3GUID))
+						Expect(packageList[1].GUID).To(Equal(package2GUID))
+						Expect(packageList[2].GUID).To(Equal(package1GUID))
+					})
+				})
+
 			})
 		})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#407 

## What is this change about?
Adds support to `states` query parameter to the List Package endpoint.
We also implemented `Order_by` support to the endpoint
- support for only `created_at` and `-created_at`
- default order is ascending i.e. `created_at`

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Follow acceptance steps on #407 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@matt-royal 