### PR TITLE
Clone config before creating new k8s user client and introduce --race flag to ginkgo tests

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -30,4 +30,4 @@ if [[ -n "$GINKGO_NODES" ]]; then
   extra_args+=("--procs=${GINKGO_NODES}")
 fi
 
-ginkgo -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+ginkgo --race -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
#437

## What is this change about?
When testing authorization for creating apps, we noticed some tests were flaky when run in parallel. Further investigation showed the authenticated user names were being mixed up. One test would appear to be using the user from another test.

The problem is in the user client factory. It takes a pointer to rest.Config, and although it copies this on instantiation, it mutates the same pointer when producing clients. This means if clients are produced simultaneously, there is a potential race condition and their identities can be mixed up. The fix is to clone the config before producing the client.

The mitigation to stop future races is to turn the `--race` flag on in ginkgo. This PR also does that.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
New test is green. I don't think you could easily reproduce this manually.

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
