### PR TITLE
Require space-developer role for create app

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/gorilla/schema"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
@@ -154,6 +156,13 @@ func (h *AppHandler) appCreateHandler(authInfo authorization.Info, w http.Respon
 			writeUniquenessError(w, errorDetail)
 			return
 		}
+
+		if k8serrors.IsForbidden(err) {
+			h.logger.Error(err, "Not authorized to create app", "App Name", payload.Name)
+			writeNotAuthorizedErrorResponse(w)
+			return
+		}
+
 		h.logger.Error(err, "Failed to create app", "App Name", payload.Name)
 		writeUnknownErrorResponse(w)
 		return

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -378,6 +379,20 @@ var _ = Describe("AppHandler", func() {
 
 			It("returns an error", func() {
 				expectUnknownError()
+			})
+		})
+
+		When("the action errors due to an authorization error", func() {
+			BeforeEach(func() {
+				repoError := k8serrors.NewForbidden(schema.GroupResource{}, "forbidden", errors.New("foo"))
+				appRepo.CreateAppReturns(repositories.AppRecord{}, repoError)
+
+				requestBody := initializeCreateAppRequestBody(testAppName, spaceGUID, nil, nil, nil)
+				queuePostRequest(requestBody)
+			})
+
+			It("returns an error", func() {
+				expectUnauthorizedError()
 			})
 		})
 	})

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -67,6 +67,9 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 				k8sClient.Create(context.Background(), namespace),
 			).To(Succeed())
 
+			role := createSpaceDeveloperClusterRole(ctx)
+			createRoleBinding(ctx, userName, role.Name, namespaceGUID)
+
 			DeferCleanup(func() {
 				_ = k8sClient.Delete(context.Background(), namespace)
 			})

--- a/api/apis/integration/create_app_test.go
+++ b/api/apis/integration/create_app_test.go
@@ -70,6 +70,9 @@ var _ = Describe("POST /v3/apps endpoint", func() {
 				k8sClient.Create(context.Background(), namespace),
 			).To(Succeed())
 
+			role := createSpaceDeveloperClusterRole(ctx)
+			createRoleBinding(ctx, userName, role.Name, namespaceGUID)
+
 			testEnvironmentVariables = map[string]string{"foo": "foo", "bar": "bar"}
 			envJSON, _ := json.Marshal(&testEnvironmentVariables)
 			requestBody := fmt.Sprintf(`{

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -457,7 +457,6 @@ var _ = Describe("PackageHandler", func() {
 						Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
 					})
 				})
-
 			})
 			When("no packages exist", func() {
 				BeforeEach(func() {

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -177,8 +177,13 @@ func (f *AppRepo) GetAppByNameAndSpace(ctx context.Context, authInfo authorizati
 }
 
 func (f *AppRepo) CreateApp(ctx context.Context, authInfo authorization.Info, appCreateMessage CreateAppMessage) (AppRecord, error) {
+	userClient, err := f.userClientFactory.BuildClient(authInfo)
+	if err != nil {
+		return AppRecord{}, fmt.Errorf("failed to build user client: %w", err)
+	}
+
 	cfApp := appCreateMessage.toCFApp()
-	err := f.privilegedClient.Create(ctx, &cfApp)
+	err = userClient.Create(ctx, &cfApp)
 	if err != nil {
 		return AppRecord{}, err
 	}

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -28,12 +28,13 @@ const (
 
 var _ = Describe("AppRepository", func() {
 	var (
-		testCtx                context.Context
-		appRepo                *AppRepo
-		clientFactory          repositories.UserK8sClientFactory
-		org                    *v1alpha2.SubnamespaceAnchor
-		space1, space2, space3 *v1alpha2.SubnamespaceAnchor
-		cfApp1, cfApp2, cfApp3 *workloadsv1alpha1.CFApp
+		testCtx                   context.Context
+		appRepo                   *AppRepo
+		clientFactory             repositories.UserK8sClientFactory
+		org                       *v1alpha2.SubnamespaceAnchor
+		space1, space2, space3    *v1alpha2.SubnamespaceAnchor
+		cfApp1, cfApp2, cfApp3    *workloadsv1alpha1.CFApp
+		spaceDeveloperClusterRole *rbacv1.ClusterRole
 	)
 
 	BeforeEach(func() {
@@ -145,9 +146,8 @@ var _ = Describe("AppRepository", func() {
 
 	Describe("ListApps", Serial, func() {
 		var (
-			message                   ListAppsMessage
-			spaceDeveloperClusterRole *rbacv1.ClusterRole
-			nonCFNamespace            string
+			message        ListAppsMessage
+			nonCFNamespace string
 		)
 
 		BeforeEach(func() {
@@ -374,6 +374,9 @@ var _ = Describe("AppRepository", func() {
 			Expect(k8sClient.Create(testCtx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: spaceGUID},
 			})).To(Succeed())
+
+			spaceDeveloperClusterRole = createSpaceDeveloperClusterRole(testCtx)
+			createRoleBinding(testCtx, userName, spaceDeveloperClusterRole.Name, spaceGUID)
 
 			appCreateMessage = initializeAppCreateMessage(testAppName, spaceGUID)
 		})
@@ -851,9 +854,8 @@ var _ = Describe("AppRepository", func() {
 
 	Describe("DeleteApp", func() {
 		var (
-			appGUID                   string
-			appCR                     *workloadsv1alpha1.CFApp
-			spaceDeveloperClusterRole *rbacv1.ClusterRole
+			appGUID string
+			appCR   *workloadsv1alpha1.CFApp
 		)
 
 		BeforeEach(func() {

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -124,7 +124,6 @@ func (r *PackageRepo) ListPackages(ctx context.Context, authInfo authorization.I
 	packageRecords := convertToPackageRecords(orderedPackages)
 
 	return applyPackageFilter(packageRecords, message), nil
-
 }
 
 func orderPackages(packages []workloadsv1alpha1.CFPackage, message ListPackagesMessage) []workloadsv1alpha1.CFPackage {

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -545,7 +545,6 @@ var _ = Describe("PackageRepository", func() {
 						Expect(packageList[2].GUID).To(Equal(package1GUID))
 					})
 				})
-
 			})
 
 			When("State filter is provided", func() {
@@ -598,7 +597,6 @@ var _ = Describe("PackageRepository", func() {
 						))
 					})
 				})
-
 			})
 		})
 

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -157,7 +157,7 @@ func createSpaceDeveloperClusterRole(ctx context.Context) *rbacv1.ClusterRole {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				Verbs:     []string{"list", "delete"},
+				Verbs:     []string{"list", "create", "delete"},
 				APIGroups: []string{"workloads.cloudfoundry.org"},
 				Resources: []string{"cfapps"},
 			},

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -22,9 +22,9 @@ var _ = Describe("Apps", func() {
 	)
 
 	BeforeEach(func() {
-		org = createOrg(generateGUID("org"), tokenAuthHeader)
-		createOrgRole("organization_user", rbacv1.UserKind, certUserName, org.GUID, tokenAuthHeader)
-		space1 = createSpace(generateGUID("space1"), org.GUID, tokenAuthHeader)
+		org = createOrg(generateGUID("org"), adminAuthHeader)
+		createOrgRole("organization_user", rbacv1.UserKind, certUserName, org.GUID, adminAuthHeader)
+		space1 = createSpace(generateGUID("space1"), org.GUID, adminAuthHeader)
 	})
 
 	AfterEach(func() {
@@ -39,18 +39,18 @@ var _ = Describe("Apps", func() {
 		)
 
 		BeforeEach(func() {
-			space2 = createSpace(generateGUID("space2"), org.GUID, tokenAuthHeader)
-			space3 = createSpace(generateGUID("space3"), org.GUID, tokenAuthHeader)
+			space2 = createSpace(generateGUID("space2"), org.GUID, adminAuthHeader)
+			space3 = createSpace(generateGUID("space3"), org.GUID, adminAuthHeader)
 
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, tokenAuthHeader)
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, adminAuthHeader)
 
-			app1 = createApp(space1.GUID, generateGUID("app1"), tokenAuthHeader)
-			app2 = createApp(space1.GUID, generateGUID("app2"), tokenAuthHeader)
-			app3 = createApp(space2.GUID, generateGUID("app3"), tokenAuthHeader)
-			app4 = createApp(space2.GUID, generateGUID("app4"), tokenAuthHeader)
-			app5 = createApp(space3.GUID, generateGUID("app5"), tokenAuthHeader)
-			app6 = createApp(space3.GUID, generateGUID("app6"), tokenAuthHeader)
+			app1 = createApp(space1.GUID, generateGUID("app1"), adminAuthHeader)
+			app2 = createApp(space1.GUID, generateGUID("app2"), adminAuthHeader)
+			app3 = createApp(space2.GUID, generateGUID("app3"), adminAuthHeader)
+			app4 = createApp(space2.GUID, generateGUID("app4"), adminAuthHeader)
+			app5 = createApp(space3.GUID, generateGUID("app5"), adminAuthHeader)
+			app6 = createApp(space3.GUID, generateGUID("app6"), adminAuthHeader)
 
 			_, _ = app3, app4
 		})
@@ -97,7 +97,7 @@ var _ = Describe("Apps", func() {
 
 		When("the user has space developer role in the space", func() {
 			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
 			})
 
 			It("succeeds", func() {

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -10,61 +10,102 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-var _ = Describe("Listing Apps", func() {
+var _ = Describe("Apps", func() {
 	var (
-		org                                presenter.OrgResponse
-		space1, space2, space3             presenter.SpaceResponse
-		app1, app2, app3, app4, app5, app6 presenter.AppResponse
+		org    presenter.OrgResponse
+		space1 presenter.SpaceResponse
 	)
 
 	BeforeEach(func() {
-		org = createOrg(uuid.NewString(), tokenAuthHeader)
+		org = createOrg(generateGUID("org"), tokenAuthHeader)
 		createOrgRole("organization_user", rbacv1.UserKind, certUserName, org.GUID, tokenAuthHeader)
-
-		space1 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
-		space2 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
-		space3 = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
-
-		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
-		createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, tokenAuthHeader)
-
-		app1 = createApp(space1.GUID, uuid.NewString(), tokenAuthHeader)
-		app2 = createApp(space1.GUID, uuid.NewString(), tokenAuthHeader)
-		app3 = createApp(space2.GUID, uuid.NewString(), tokenAuthHeader)
-		app4 = createApp(space2.GUID, uuid.NewString(), tokenAuthHeader)
-		app5 = createApp(space3.GUID, uuid.NewString(), tokenAuthHeader)
-		app6 = createApp(space3.GUID, uuid.NewString(), tokenAuthHeader)
-
-		_, _ = app3, app4
+		space1 = createSpace(generateGUID("space1"), org.GUID, tokenAuthHeader)
 	})
 
 	AfterEach(func() {
 		deleteSubnamespace(org.GUID, space1.GUID)
-		deleteSubnamespace(org.GUID, space2.GUID)
-		deleteSubnamespace(org.GUID, space3.GUID)
 		deleteSubnamespace(rootNamespace, org.GUID)
 	})
 
-	It("returns apps only in authorized spaces", func() {
-		Eventually(getAppsFn(certAuthHeader)).Should(SatisfyAll(
-			HaveKeyWithValue("pagination", HaveKeyWithValue("total_results", BeNumerically(">=", 4))),
-			HaveKeyWithValue("resources", ContainElements(
-				HaveKeyWithValue("name", app1.Name),
-				HaveKeyWithValue("name", app2.Name),
-				HaveKeyWithValue("name", app5.Name),
-				HaveKeyWithValue("name", app6.Name),
-			))))
-		Consistently(getAppsFn(certAuthHeader), "5s").ShouldNot(
-			HaveKeyWithValue("resources", ContainElements(
-				HaveKeyWithValue("name", app3.Name),
-				HaveKeyWithValue("name", app4.Name),
-			)))
+	Describe("List", func() {
+		var (
+			space2, space3                     presenter.SpaceResponse
+			app1, app2, app3, app4, app5, app6 presenter.AppResponse
+		)
+
+		BeforeEach(func() {
+			space2 = createSpace(generateGUID("space2"), org.GUID, tokenAuthHeader)
+			space3 = createSpace(generateGUID("space3"), org.GUID, tokenAuthHeader)
+
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, tokenAuthHeader)
+
+			app1 = createApp(space1.GUID, generateGUID("app1"), tokenAuthHeader)
+			app2 = createApp(space1.GUID, generateGUID("app2"), tokenAuthHeader)
+			app3 = createApp(space2.GUID, generateGUID("app3"), tokenAuthHeader)
+			app4 = createApp(space2.GUID, generateGUID("app4"), tokenAuthHeader)
+			app5 = createApp(space3.GUID, generateGUID("app5"), tokenAuthHeader)
+			app6 = createApp(space3.GUID, generateGUID("app6"), tokenAuthHeader)
+
+			_, _ = app3, app4
+		})
+
+		AfterEach(func() {
+			deleteSubnamespace(org.GUID, space2.GUID)
+			deleteSubnamespace(org.GUID, space3.GUID)
+		})
+
+		It("returns apps only in authorized spaces", func() {
+			Eventually(getAppsFn(certAuthHeader)).Should(SatisfyAll(
+				HaveKeyWithValue("pagination", HaveKeyWithValue("total_results", BeNumerically(">=", 4))),
+				HaveKeyWithValue("resources", ContainElements(
+					HaveKeyWithValue("name", app1.Name),
+					HaveKeyWithValue("name", app2.Name),
+					HaveKeyWithValue("name", app5.Name),
+					HaveKeyWithValue("name", app6.Name),
+				))))
+			Consistently(getAppsFn(certAuthHeader), "5s").ShouldNot(
+				HaveKeyWithValue("resources", ContainElements(
+					HaveKeyWithValue("name", app3.Name),
+					HaveKeyWithValue("name", app4.Name),
+				)))
+		})
+	})
+
+	Describe("Create", func() {
+		var (
+			createResponse *http.Response
+			createErr      error
+		)
+
+		JustBeforeEach(func() {
+			appGUID := generateGUID("app")
+			createResponse, createErr = createAppRaw(space1.GUID, appGUID, certAuthHeader)
+		})
+
+		It("fails", func() {
+			Expect(createErr).NotTo(HaveOccurred())
+			defer createResponse.Body.Close()
+			Expect(createResponse).To(HaveHTTPStatus(http.StatusForbidden))
+			Expect(createResponse).To(HaveHTTPBody(ContainSubstring("CF-NotAuthorized")))
+		})
+
+		When("the user has space developer role in the space", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, tokenAuthHeader)
+			})
+
+			It("succeeds", func() {
+				Expect(createErr).NotTo(HaveOccurred())
+				defer createResponse.Body.Close()
+				Expect(createResponse).To(HaveHTTPStatus(http.StatusCreated))
+			})
+		})
 	})
 })
 

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -119,7 +119,7 @@ func ensureServerIsUp() {
 func generateGUID(prefix string) string {
 	guid := uuid.NewString()
 
-	return fmt.Sprintf("%s-%s", prefix, guid[:6])
+	return fmt.Sprintf("%s-%s", prefix, guid[:13])
 }
 
 func waitForNamespaceDeletion(parent, ns string) {
@@ -401,7 +401,7 @@ func httpReq(method, url, authHeader string, jsonBody interface{}) (*http.Respon
 	return resp, nil
 }
 
-func createApp(spaceGUID, name, authHeader string) presenter.AppResponse {
+func createAppRaw(spaceGUID, name, authHeader string) (*http.Response, error) {
 	appsURL := apiServerRoot + apis.AppCreateEndpoint
 
 	payload := payloads.AppCreate{
@@ -415,7 +415,11 @@ func createApp(spaceGUID, name, authHeader string) presenter.AppResponse {
 		},
 	}
 
-	resp, err := httpReq(http.MethodPost, appsURL, authHeader, payload)
+	return httpReq(http.MethodPost, appsURL, authHeader, payload)
+}
+
+func createApp(spaceGUID, name, authHeader string) presenter.AppResponse {
+	resp, err := createAppRaw(spaceGUID, name, authHeader)
 	Expect(err).NotTo(HaveOccurred())
 	defer resp.Body.Close()
 

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -51,6 +51,7 @@ var (
 	certUserName        string
 	certSigningReq      *certsv1.CertificateSigningRequest
 	certAuthHeader      string
+	adminAuthHeader     string
 )
 
 func TestE2E(t *testing.T) {
@@ -68,6 +69,11 @@ var _ = BeforeSuite(func() {
 
 	config, err := controllerruntime.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
+
+	// fine for Kind cluster; might need work for other cluster types
+	cert := config.CertData
+	cert = append(cert, config.KeyData...)
+	adminAuthHeader = "ClientCert " + base64.StdEncoding.EncodeToString(cert)
 
 	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -68,10 +68,10 @@ var _ = Describe("Orgs", func() {
 		var org1, org2, org3, org4 presenter.OrgResponse
 
 		BeforeEach(func() {
-			org1 = createOrg(generateGUID("org1"), tokenAuthHeader)
-			org2 = createOrg(generateGUID("org2"), tokenAuthHeader)
-			org3 = createOrg(generateGUID("org3"), tokenAuthHeader)
-			org4 = createOrg(generateGUID("org4"), tokenAuthHeader)
+			org1 = createOrg(generateGUID("org1"), adminAuthHeader)
+			org2 = createOrg(generateGUID("org2"), adminAuthHeader)
+			org3 = createOrg(generateGUID("org3"), adminAuthHeader)
+			org4 = createOrg(generateGUID("org4"), adminAuthHeader)
 		})
 
 		AfterEach(func() {
@@ -83,9 +83,9 @@ var _ = Describe("Orgs", func() {
 
 		Context("with a bearer token auth header", func() {
 			BeforeEach(func() {
-				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org1.GUID, tokenAuthHeader)
-				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org2.GUID, tokenAuthHeader)
-				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org3.GUID, tokenAuthHeader)
+				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org1.GUID, adminAuthHeader)
+				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org2.GUID, adminAuthHeader)
+				createOrgRole("organization_manager", rbacv1.ServiceAccountKind, serviceAccountName, org3.GUID, adminAuthHeader)
 			})
 
 			It("returns all 3 orgs that the service account has a role in", func() {
@@ -123,9 +123,9 @@ var _ = Describe("Orgs", func() {
 
 		Context("with a client certificate auth header", func() {
 			BeforeEach(func() {
-				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org1.GUID, certAuthHeader)
-				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org2.GUID, certAuthHeader)
-				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org3.GUID, certAuthHeader)
+				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org1.GUID, adminAuthHeader)
+				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org2.GUID, adminAuthHeader)
+				createOrgRole("organization_manager", rbacv1.UserKind, certUserName, org3.GUID, adminAuthHeader)
 			})
 
 			It("returns all 3 orgs that the service account has a role in", func() {

--- a/api/tests/e2e/roles_test.go
+++ b/api/tests/e2e/roles_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,29 +17,6 @@ var _ = Describe("Roles", func() {
 		ctx      context.Context
 		userName string
 	)
-
-	createBinding := func(namespace, userName, roleName string) *rbacv1.RoleBinding {
-		binding := &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      uuid.NewString(),
-				Namespace: namespace,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: rbacv1.UserKind,
-					Name: userName,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: roleName,
-			},
-		}
-
-		Expect(k8sClient.Create(ctx, binding)).To(Succeed())
-
-		return binding
-	}
 
 	BeforeEach(func() {
 		ctx = context.Background()
@@ -51,7 +27,7 @@ var _ = Describe("Roles", func() {
 		var org presenter.OrgResponse
 
 		BeforeEach(func() {
-			org = createOrg(uuid.NewString(), tokenAuthHeader)
+			org = createOrg(uuid.NewString(), adminAuthHeader)
 		})
 
 		AfterEach(func() {
@@ -90,9 +66,9 @@ var _ = Describe("Roles", func() {
 		)
 
 		BeforeEach(func() {
-			org = createOrg(uuid.NewString(), tokenAuthHeader)
-			space = createSpace(uuid.NewString(), org.GUID, tokenAuthHeader)
-			createBinding(org.GUID, userName, "basic-user")
+			org = createOrg(uuid.NewString(), adminAuthHeader)
+			createOrgRole("organization_user", rbacv1.UserKind, userName, org.GUID, adminAuthHeader)
+			space = createSpace(uuid.NewString(), org.GUID, adminAuthHeader)
 		})
 
 		AfterEach(func() {

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -30,8 +30,8 @@ var _ = Describe("Spaces", func() {
 
 		BeforeEach(func() {
 			spaceName = generateGUID("space")
-			org = createOrg(generateGUID("org"), tokenAuthHeader)
-			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org.GUID, tokenAuthHeader)
+			org = createOrg(generateGUID("org"), adminAuthHeader)
+			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org.GUID, adminAuthHeader)
 		})
 
 		AfterEach(func() {
@@ -106,31 +106,31 @@ var _ = Describe("Spaces", func() {
 		)
 
 		BeforeEach(func() {
-			org1 = createOrg(generateGUID("org1"), tokenAuthHeader)
-			org2 = createOrg(generateGUID("org2"), tokenAuthHeader)
-			org3 = createOrg(generateGUID("org3"), tokenAuthHeader)
+			org1 = createOrg(generateGUID("org1"), adminAuthHeader)
+			org2 = createOrg(generateGUID("org2"), adminAuthHeader)
+			org3 = createOrg(generateGUID("org3"), adminAuthHeader)
 
-			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org1.GUID, tokenAuthHeader)
-			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org2.GUID, tokenAuthHeader)
-			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org3.GUID, tokenAuthHeader)
+			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org1.GUID, adminAuthHeader)
+			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org2.GUID, adminAuthHeader)
+			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org3.GUID, adminAuthHeader)
 
-			space11 = createSpace(generateGUID("space1"), org1.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space11.GUID, tokenAuthHeader)
-			space12 = createSpace(generateGUID("space2"), org1.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space12.GUID, tokenAuthHeader)
-			space13 = createSpace(generateGUID("space3"), org1.GUID, tokenAuthHeader)
+			space11 = createSpace(generateGUID("space1"), org1.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space11.GUID, adminAuthHeader)
+			space12 = createSpace(generateGUID("space2"), org1.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space12.GUID, adminAuthHeader)
+			space13 = createSpace(generateGUID("space3"), org1.GUID, adminAuthHeader)
 
-			space21 = createSpace(generateGUID("space1"), org2.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space21.GUID, tokenAuthHeader)
-			space22 = createSpace(generateGUID("space2"), org2.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space22.GUID, tokenAuthHeader)
-			space23 = createSpace(generateGUID("space3"), org2.GUID, tokenAuthHeader)
+			space21 = createSpace(generateGUID("space1"), org2.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space21.GUID, adminAuthHeader)
+			space22 = createSpace(generateGUID("space2"), org2.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space22.GUID, adminAuthHeader)
+			space23 = createSpace(generateGUID("space3"), org2.GUID, adminAuthHeader)
 
-			space31 = createSpace(generateGUID("space1"), org3.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space31.GUID, tokenAuthHeader)
-			space32 = createSpace(generateGUID("space2"), org3.GUID, tokenAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space32.GUID, tokenAuthHeader)
-			space33 = createSpace(generateGUID("space3"), org3.GUID, tokenAuthHeader)
+			space31 = createSpace(generateGUID("space1"), org3.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space31.GUID, adminAuthHeader)
+			space32 = createSpace(generateGUID("space2"), org3.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space32.GUID, adminAuthHeader)
+			space33 = createSpace(generateGUID("space3"), org3.GUID, adminAuthHeader)
 		})
 
 		AfterEach(func() {

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -9,5 +9,6 @@ rules:
   resources:
   - cfapps
   verbs:
+  - create
   - delete
   - list

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1549,6 +1549,7 @@ rules:
   resources:
   - cfapps
   verbs:
+  - create
   - delete
   - list
 ---


### PR DESCRIPTION
## Is there a related GitHub Issue?
#173 

## What is this change about?
We should use the user client in the app repository for create apps. Then the 'create' permission is required on cfapp for the CreateApp call. Add this permission to the space-developer role.

## Does this PR introduce a breaking change?
Users without the space-developer role can no longer create apps.

## Acceptance Steps
1. Deploy cf on a k8s cluster
2. Create and target an org and a space
3. Create a non-privileged user
4. Assign that user a role such as space-manager on the space
5. `cf create-app bob` logged in as that user. See the request fail
6. Assign the space-developer role to that user. Repeat the request and see it pass.

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
