### PR TITLE
Delete namespaces in parallel in e2e tests

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
@@ -56,8 +57,12 @@ var _ = Describe("Apps", func() {
 		})
 
 		AfterEach(func() {
-			deleteSubnamespace(org.GUID, space2.GUID)
-			deleteSubnamespace(org.GUID, space3.GUID)
+			var wg sync.WaitGroup
+			wg.Add(2)
+			for _, id := range []string{space2.GUID, space3.GUID} {
+				asyncDeleteSubnamespace(org.GUID, id, &wg)
+			}
+			wg.Wait()
 		})
 
 		It("returns apps only in authorized spaces", func() {

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
@@ -75,10 +76,12 @@ var _ = Describe("Orgs", func() {
 		})
 
 		AfterEach(func() {
-			deleteSubnamespace(rootNamespace, org1.GUID)
-			deleteSubnamespace(rootNamespace, org2.GUID)
-			deleteSubnamespace(rootNamespace, org3.GUID)
-			deleteSubnamespace(rootNamespace, org4.GUID)
+			var wg sync.WaitGroup
+			wg.Add(4)
+			for _, id := range []string{org1.GUID, org2.GUID, org3.GUID, org4.GUID} {
+				asyncDeleteSubnamespace(rootNamespace, id, &wg)
+			}
+			wg.Wait()
 		})
 
 		Context("with a bearer token auth header", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
It is only necessary to wait for spaces to be deleted before deleting the org, so we can parallelise most deletions to speed up e2e tests

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2e tests are green

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
