### PR TITLE
New ADR for resource name prefixes

### DIFF
--- a/api/docs/architecture-decisions/0001-cf-resource-guid-format.md
+++ b/api/docs/architecture-decisions/0001-cf-resource-guid-format.md
@@ -18,6 +18,9 @@ For more details see [our exploration (Issue #2)](https://github.com/cloudfoundr
 
 ## Decision
 We’ve decided to generate globally unique, non-deterministic GUIDs for resources we create. This GUID will be used as a resource’s name on Kubernetes. This aligns more closely with what existing Cloud Foundry clients expect and avoids encoding extra information in the identifier that may be difficult for us to work with long term.
+> **NOTE:** in [ADR 0004](0004-resource-name-prefixes.md) we somewhat modified
+> this decision to include a prefix on generated GUIDs for orgs, spaces and
+> CFProcesses.
 
 We believe we can address some of the performance implications here by using an in-memory cache on the CF API shim that maps known GUIDs to the Kubernetes namespace in which the object lives.
 

--- a/api/docs/architecture-decisions/0004-resource-name-prefixes.md
+++ b/api/docs/architecture-decisions/0004-resource-name-prefixes.md
@@ -1,0 +1,41 @@
+# CF Resource GUID Prefixing
+
+Date: 2022-01-12
+
+## Status
+
+Draft
+
+## Context
+
+We have received feedback from the field that naming standard k8s typed objects (e.g. namespaces, statefulsets) with raw guids makes the system difficult for a k8s operator to use.
+
+For example:
+- it's hard when looking at a list of namespaces to tell which ones are CF-created. That makes it difficult to uninstall the things you installed to a cluster if you're just kicking the tires.
+- it's hard to tell which namespaces are cf spaces versus orgs. When listing other things like secrets or roles, it is hard to tell if they are in a space or an org or are totally unrelated to CF.
+- it's hard to be sure which stateful sets are CF apps, versus possibly other workloads that also have GUID names.
+
+The proposal to address this issue is to prefix the names of these resources with strings (e.g. "cforg-") that clearly identify them as CF resources. The request is to add this prefix to the object name rather than a label or other metadata, in order to make it easily discoverable.
+
+We considered 2 possible approaches to implement this:
+1. At the time of GUID generation for spaces, orgs, and processes, we simply prepend a prefix, and then treat that prefix as an opaque part of the GUID everywhere else. This option is far less costly, but will result in GUIDs returned to the CF API client with non-standard formatting.
+1. At the point(s) where we are converting a GUID stored on a CF-defined resource into a name on a non-CF-defined resource, we add the prefix to the name. When making the opposite transformation, we strip the prefix. This approach would require conversion in numerous places, given that we use namespace names throughout the code, but has the benefit that GUIDs retain GUID formattting.
+
+## Decision
+After some discussion, we decided that the first, easiest solution is the better one. We will make a small change to modfiy GUID generation for orgs, spaces, and CFProcesses. We will try to avoid writing any code that parses the GUIDs or explicitly expects the prefixes to be there. 
+
+## Consequences
+
+### Pros
+* This solution is trivial to implement.
+* This decision is reversible. So long as we don't rely on the existence of the prefix, we can change or remove it at any time.
+* This decision is extensible. We can decide to apply prefixes to other object type GUIDs (e.g. CFRoute, CFApp, etc.) as we see fit.
+* Because we are not introducing a discrepancy between GUID and object name, users can still rely on them to be the same. (I.e. `kubectl get secret -n $(cf space s --guid)` will continue to work)
+
+### Cons
+* Our GUIDs will no longer conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt), and therfore will not be convertible into binary format.
+
+## Open Questions
+
+* Should we extend this decision to other types?
+* Some CF API clients may have fixed length columns in a database, or columns that are guid typed. Our new guids may not fit or may fail to parse. Does any such client exist?

--- a/api/docs/architecture-decisions/0004-resource-name-prefixes.md
+++ b/api/docs/architecture-decisions/0004-resource-name-prefixes.md
@@ -4,7 +4,7 @@ Date: 2022-01-14
 
 ## Status
 
-Draft
+Accepted
 
 ## Context
 

--- a/api/docs/architecture-decisions/0004-resource-name-prefixes.md
+++ b/api/docs/architecture-decisions/0004-resource-name-prefixes.md
@@ -1,6 +1,6 @@
 # CF Resource GUID Prefixing
 
-Date: 2022-01-12
+Date: 2022-01-14
 
 ## Status
 
@@ -15,14 +15,17 @@ For example:
 - it's hard to tell which namespaces are cf spaces versus orgs. When listing other things like secrets or roles, it is hard to tell if they are in a space or an org or are totally unrelated to CF.
 - it's hard to be sure which stateful sets are CF apps, versus possibly other workloads that also have GUID names.
 
-The proposal to address this issue is to prefix the names of these resources with strings (e.g. "cforg-") that clearly identify them as CF resources. The request is to add this prefix to the object name rather than a label or other metadata, in order to make it easily discoverable.
+The proposal to address this issue is to prefix the names of these resources with strings (e.g. "cf-org-") that clearly identify them as CF resources. The request is to add this prefix to the object name rather than a label or other metadata, in order to make it easily discoverable.
 
 We considered 2 possible approaches to implement this:
 1. At the time of GUID generation for spaces, orgs, and processes, we simply prepend a prefix, and then treat that prefix as an opaque part of the GUID everywhere else. This option is far less costly, but will result in GUIDs returned to the CF API client with non-standard formatting.
 1. At the point(s) where we are converting a GUID stored on a CF-defined resource into a name on a non-CF-defined resource, we add the prefix to the name. When making the opposite transformation, we strip the prefix. This approach would require conversion in numerous places, given that we use namespace names throughout the code, but has the benefit that GUIDs retain GUID formattting.
 
 ## Decision
-After some discussion, we decided that the first, easiest solution is the better one. We will make a small change to modfiy GUID generation for orgs, spaces, and CFProcesses. We will try to avoid writing any code that parses the GUIDs or explicitly expects the prefixes to be there. 
+After some discussion, we decided that the first, easiest solution is the better one. We will make a small change to modfiy GUID generation for orgs, spaces, and CFProcesses. We will try to avoid writing any code that parses the GUIDs or explicitly expects the prefixes to be there. We will use the prefixes:
+- "cf-org-"
+- "cf-space-"
+- "cf-proc-"
 
 ## Consequences
 
@@ -33,9 +36,9 @@ After some discussion, we decided that the first, easiest solution is the better
 * Because we are not introducing a discrepancy between GUID and object name, users can still rely on them to be the same. (I.e. `kubectl get secret -n $(cf space s --guid)` will continue to work)
 
 ### Cons
-* Our GUIDs will no longer conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt), and therfore will not be convertible into binary format.
+* Our GUIDs will no longer conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt), and therefore will not be convertible into binary format.
 
 ## Open Questions
 
-* Should we extend this decision to other types?
-* Some CF API clients may have fixed length columns in a database, or columns that are guid typed. Our new guids may not fit or may fail to parse. Does any such client exist?
+* Should we extend this decision to other types, and prefix guids for things like CFRoute, CFPackage, etc?
+* Some CF API clients may have fixed length columns in a database, or columns that are guid typed. Our new guids may not fit or may fail to parse. The affected clients we are aware of would need major modification to work with the API shim anyway, so we don't believe this will create a significant burden.


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No. (we failed to copy it over from Jira) 

## What is this change about?
<!-- _Please describe the change here._ -->

## Does this PR introduce a breaking change?
It records a decision we made in team forum to prefix guids with strings so that the resulting k8s objects would also be decorated.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->

## Tag your pair, your PM, and/or team
@tcdowney PTAL

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
