### PR TITLE
Cache identities in new  CachingIdentityProvider

### DIFF
--- a/api/apis/buildpack_handler.go
+++ b/api/apis/buildpack_handler.go
@@ -24,9 +24,9 @@ type BuildpackRepository interface {
 }
 
 type BuildpackHandler struct {
-	logger        logr.Logger
-	serverURL     url.URL
-	buildpackRepo BuildpackRepository
+	logger             logr.Logger
+	serverURL          url.URL
+	buildpackRepo      BuildpackRepository
 	clusterBuilderName string
 }
 
@@ -37,9 +37,9 @@ func NewBuildpackHandler(
 	clusterBuilderName string,
 ) *BuildpackHandler {
 	return &BuildpackHandler{
-		logger:        logger,
-		serverURL:     serverURL,
-		buildpackRepo: buildpackRepo,
+		logger:             logger,
+		serverURL:          serverURL,
+		buildpackRepo:      buildpackRepo,
 		clusterBuilderName: clusterBuilderName,
 	}
 }

--- a/api/authorization/caching_identity_provider.go
+++ b/api/authorization/caching_identity_provider.go
@@ -1,0 +1,43 @@
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+const (
+	cacheTTL = 120 * time.Second
+)
+
+type CachingIdentityProvider struct {
+	identityProvider IdentityProvider
+	identityCache    *cache.Expiring
+}
+
+func NewCachingIdentityProvider(identityProvider IdentityProvider, identityCache *cache.Expiring) *CachingIdentityProvider {
+	return &CachingIdentityProvider{
+		identityProvider: identityProvider,
+		identityCache:    identityCache,
+	}
+}
+
+func (p *CachingIdentityProvider) GetIdentity(ctx context.Context, info Info) (Identity, error) {
+	idInterface, ok := p.identityCache.Get(info.Hash())
+	if ok {
+		id, castOK := idInterface.(Identity)
+		if castOK {
+			return id, nil
+		}
+		return Identity{}, fmt.Errorf("identity-provider cache: expected authorization.Identity{}, got %T", idInterface)
+	}
+
+	identity, err := p.identityProvider.GetIdentity(ctx, info)
+	if err == nil {
+		p.identityCache.Set(info.Hash(), identity, cacheTTL)
+	}
+
+	return identity, err
+}

--- a/api/authorization/caching_identity_provider_test.go
+++ b/api/authorization/caching_identity_provider_test.go
@@ -1,0 +1,110 @@
+package authorization_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/utils/clock/testing"
+)
+
+var _ = Describe("IdentityProvider", func() {
+	var (
+		authInfo      authorization.Info
+		fakeProvider  *fake.IdentityProvider
+		idProvider    *authorization.CachingIdentityProvider
+		aliceId, id   authorization.Identity
+		clock         *testing.FakeClock
+		identityCache *cache.Expiring
+		getErr        error
+	)
+
+	BeforeEach(func() {
+		fakeProvider = new(fake.IdentityProvider)
+		clock = testing.NewFakeClock(time.Now())
+		identityCache = cache.NewExpiringWithClock(clock)
+
+		aliceId = authorization.Identity{Kind: rbacv1.UserKind, Name: "alice"}
+		authInfo = authorization.Info{
+			Token: "a-token",
+		}
+		fakeProvider.GetIdentityReturns(aliceId, nil)
+
+		idProvider = authorization.NewCachingIdentityProvider(fakeProvider, identityCache)
+	})
+
+	JustBeforeEach(func() {
+		id, getErr = idProvider.GetIdentity(context.Background(), authInfo)
+	})
+
+	It("succeeds", func() {
+		Expect(getErr).NotTo(HaveOccurred())
+	})
+
+	It("gets the auth info from the real identity provider", func() {
+		Expect(fakeProvider.GetIdentityCallCount()).To(Equal(1))
+		_, actualAuthInfo := fakeProvider.GetIdentityArgsForCall(0)
+		Expect(actualAuthInfo).To(Equal(authInfo))
+	})
+
+	When("the real identity provider fails", func() {
+		BeforeEach(func() {
+			fakeProvider.GetIdentityReturns(authorization.Identity{}, errors.New("boom"))
+		})
+
+		It("returns an error", func() {
+			Expect(getErr).To(MatchError(ContainSubstring("boom")))
+		})
+	})
+
+	When("the token is cached", func() {
+		BeforeEach(func() {
+			_, err := idProvider.GetIdentity(context.Background(), authInfo)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not call the token inspector", func() {
+			Expect(fakeProvider.GetIdentityCallCount()).To(Equal(1))
+		})
+
+		It("returns the correct identity", func() {
+			Expect(id).To(Equal(aliceId))
+		})
+
+		It("uses the hash of the auth info as a key", func() {
+			Expect(identityCache.Len()).To(Equal(1))
+			_, ok := identityCache.Get(authInfo.Hash())
+			Expect(ok).To(BeTrue())
+		})
+
+		When("a different auth info is sent", func() {
+			BeforeEach(func() {
+				newAuthInfo := authorization.Info{
+					Token: "new-token",
+				}
+				_, err := idProvider.GetIdentity(context.Background(), newAuthInfo)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("gets the identity both times", func() {
+				Expect(fakeProvider.GetIdentityCallCount()).To(Equal(2))
+			})
+		})
+
+		When("the cache has a non Identity value for the key", func() {
+			BeforeEach(func() {
+				identityCache.Set(authInfo.Hash(), 42, time.Minute)
+			})
+
+			It("returns an error", func() {
+				Expect(getErr).To(MatchError(ContainSubstring("identity-provider cache: expected authorization.Identity{}, got int")))
+			})
+		})
+	})
+})

--- a/api/authorization/info.go
+++ b/api/authorization/info.go
@@ -1,6 +1,10 @@
 package authorization
 
-import "context"
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+)
 
 type Info struct {
 	Token    string
@@ -34,4 +38,10 @@ func (i Info) Scheme() string {
 	}
 
 	return UnknownScheme
+}
+
+func (i Info) Hash() string {
+	key := append([]byte(i.Token), i.CertData...)
+	hasher := sha256.New()
+	return hex.EncodeToString(hasher.Sum(key))
 }

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,7 +95,8 @@ var _ = BeforeEach(func() {
 	rootNamespace = prefixedGUID("root-ns")
 	tokenInspector := authorization.NewTokenReviewer(k8sClient)
 	certInspector := authorization.NewCertInspector(k8sConfig)
-	idProvider = authorization.NewCertTokenIdentityProvider(tokenInspector, certInspector)
+	baseIDProvider := authorization.NewCertTokenIdentityProvider(tokenInspector, certInspector)
+	idProvider = authorization.NewCachingIdentityProvider(baseIDProvider, cache.NewExpiring())
 	nsPerms = authorization.NewNamespacePermissions(k8sClient, idProvider, rootNamespace)
 })
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	code.cloudfoundry.org/eirini-controller v0.2.0
 	github.com/buildpacks/lifecycle v0.13.2
 	github.com/buildpacks/pack v0.23.0
-	github.com/containerd/containerd v1.5.8
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/go-logr/logr v1.2.2
 	github.com/go-playground/locales v0.14.0
@@ -28,6 +27,7 @@ require (
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	k8s.io/client-go v0.23.1
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/controller-tools v0.8.0
 	sigs.k8s.io/hierarchical-namespaces v0.9.0
@@ -51,7 +51,6 @@ require (
 	github.com/buildpacks/imgutil v0.0.0-20211203200417-76206845baac // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.10.1 // indirect
-	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.12+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -112,8 +111,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
-	google.golang.org/grpc v1.43.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -122,7 +119,6 @@ require (
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/legacy-cloud-providers v0.19.7 // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	knative.dev/pkg v0.0.0-20210902173607-844a6bc45596 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -479,7 +479,6 @@ github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDG
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=
 github.com/containerd/ttrpc v1.0.1/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
-github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=
 github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Evzy5KFQpQ=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd/go.mod h1:GeKYzf2pQcqv7tJ0AoCuuhtnqhva5LNU3U+OyKxxJpk=


### PR DESCRIPTION
## Is there a related GitHub Issue?
#442 

## What is this change about?
Use an expiring cache with TTL of 2 minutes.

The identity provider is used to determine the ID given an auth token or
client certificate. In both cases, the code goes to the cluster to
obtain the identity, and this is a slow operation. It makes sense to
cache the results for a short time.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. use time to record cf operations (for example create-space, create-org and push)
1. redeploy with these changes
1. use time again for the same operations
1. notice that the times are significantly lower

## Tag your pair, your PM, and/or team
@kieron-dev 
