### PR TITLE
add RBAC to api and space dev

### DIFF
--- a/api/config/base/rbac/role.yaml
+++ b/api/config/base/rbac/role.yaml
@@ -69,6 +69,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders/status
+  verbs:
+  - get
+- apiGroups:
   - networking.cloudfoundry.org
   resources:
   - cfdomains

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -78,6 +78,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders/status
+  verbs:
+  - get
+- apiGroups:
   - networking.cloudfoundry.org
   resources:
   - cfdomains

--- a/api/repositories/buildpack_repository.go
+++ b/api/repositories/buildpack_repository.go
@@ -11,6 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+//+kubebuilder:rbac:groups=kpack.io,resources=clusterbuilders,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=kpack.io,resources=clusterbuilders/status,verbs=get
+
 type BuildpackRepository struct {
 	privilegedClient  client.Client
 	userClientFactory UserK8sClientFactory

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -19,3 +19,11 @@ rules:
   - create
   - delete
   - list
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1559,6 +1559,14 @@ rules:
   - create
   - delete
   - list
+- apiGroups:
+  - kpack.io
+  resources:
+  - clusterbuilders
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION

## Is there a related GitHub Issue?
fixes missing rbac in #349 

## What is this change about?
`cf buildpacks` fails due to missing kubebuilder rbac annotation

## Does this PR introduce a breaking change?
no

## Acceptance Steps
see issue

## Tag your pair, your PM, and/or team
@Birdrock 

