### PR TITLE
Make org and space creation async in e2e tests

### DIFF
--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -174,6 +174,15 @@ func createOrg(orgName, authHeader string) presenter.OrgResponse {
 	return org
 }
 
+func asyncCreateOrg(orgName, authHeader string, createdOrg *presenter.OrgResponse, wg *sync.WaitGroup) {
+	go func() {
+		defer GinkgoRecover()
+		defer wg.Done()
+
+		*createdOrg = createOrg(orgName, authHeader)
+	}()
+}
+
 func createSpaceRaw(spaceName, orgGUID, authHeader string) (*http.Response, error) {
 	spacesURL := apiServerRoot + apis.SpaceCreateEndpoint
 	payload := payloads.SpaceCreate{
@@ -204,6 +213,15 @@ func createSpace(spaceName, orgGUID, authHeader string) presenter.SpaceResponse 
 	Expect(err).NotTo(HaveOccurred())
 
 	return space
+}
+
+func asyncCreateSpace(spaceName, orgGUID, authHeader string, createdSpace *presenter.SpaceResponse, wg *sync.WaitGroup) {
+	go func() {
+		defer GinkgoRecover()
+		defer wg.Done()
+
+		*createdSpace = createSpace(spaceName, orgGUID, authHeader)
+	}()
 }
 
 // createRole creates an org or space role

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -67,10 +67,14 @@ var _ = Describe("Orgs", func() {
 		var org1, org2, org3, org4 presenter.OrgResponse
 
 		BeforeEach(func() {
-			org1 = createOrg(generateGUID("org1"), adminAuthHeader)
-			org2 = createOrg(generateGUID("org2"), adminAuthHeader)
-			org3 = createOrg(generateGUID("org3"), adminAuthHeader)
-			org4 = createOrg(generateGUID("org4"), adminAuthHeader)
+			var wg sync.WaitGroup
+
+			wg.Add(4)
+			asyncCreateOrg(generateGUID("org1"), adminAuthHeader, &org1, &wg)
+			asyncCreateOrg(generateGUID("org2"), adminAuthHeader, &org2, &wg)
+			asyncCreateOrg(generateGUID("org3"), adminAuthHeader, &org3, &wg)
+			asyncCreateOrg(generateGUID("org4"), adminAuthHeader, &org4, &wg)
+			wg.Wait()
 		})
 
 		AfterEach(func() {

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -111,31 +111,40 @@ var _ = Describe("Spaces", func() {
 		)
 
 		BeforeEach(func() {
-			org1 = createOrg(generateGUID("org1"), adminAuthHeader)
-			org2 = createOrg(generateGUID("org2"), adminAuthHeader)
-			org3 = createOrg(generateGUID("org3"), adminAuthHeader)
+			var orgWG sync.WaitGroup
+
+			orgWG.Add(3)
+			asyncCreateOrg(generateGUID("org1"), adminAuthHeader, &org1, &orgWG)
+			asyncCreateOrg(generateGUID("org2"), adminAuthHeader, &org2, &orgWG)
+			asyncCreateOrg(generateGUID("org3"), adminAuthHeader, &org3, &orgWG)
+			orgWG.Wait()
+
+			var spaceWG sync.WaitGroup
+
+			spaceWG.Add(9)
+			asyncCreateSpace(generateGUID("space1"), org1.GUID, adminAuthHeader, &space11, &spaceWG)
+			asyncCreateSpace(generateGUID("space2"), org1.GUID, adminAuthHeader, &space12, &spaceWG)
+			asyncCreateSpace(generateGUID("space3"), org1.GUID, adminAuthHeader, &space13, &spaceWG)
+
+			asyncCreateSpace(generateGUID("space1"), org2.GUID, adminAuthHeader, &space21, &spaceWG)
+			asyncCreateSpace(generateGUID("space2"), org2.GUID, adminAuthHeader, &space22, &spaceWG)
+			asyncCreateSpace(generateGUID("space3"), org2.GUID, adminAuthHeader, &space23, &spaceWG)
+
+			asyncCreateSpace(generateGUID("space1"), org3.GUID, adminAuthHeader, &space31, &spaceWG)
+			asyncCreateSpace(generateGUID("space2"), org3.GUID, adminAuthHeader, &space32, &spaceWG)
+			asyncCreateSpace(generateGUID("space3"), org3.GUID, adminAuthHeader, &space33, &spaceWG)
+			spaceWG.Wait()
 
 			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org1.GUID, adminAuthHeader)
 			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org2.GUID, adminAuthHeader)
 			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, org3.GUID, adminAuthHeader)
 
-			space11 = createSpace(generateGUID("space1"), org1.GUID, adminAuthHeader)
-			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space11.GUID, adminAuthHeader)
-			space12 = createSpace(generateGUID("space2"), org1.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space12.GUID, adminAuthHeader)
-			space13 = createSpace(generateGUID("space3"), org1.GUID, adminAuthHeader)
-
-			space21 = createSpace(generateGUID("space1"), org2.GUID, adminAuthHeader)
+			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space11.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space21.GUID, adminAuthHeader)
-			space22 = createSpace(generateGUID("space2"), org2.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space22.GUID, adminAuthHeader)
-			space23 = createSpace(generateGUID("space3"), org2.GUID, adminAuthHeader)
-
-			space31 = createSpace(generateGUID("space1"), org3.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space31.GUID, adminAuthHeader)
-			space32 = createSpace(generateGUID("space2"), org3.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.ServiceAccountKind, serviceAccountName, space32.GUID, adminAuthHeader)
-			space33 = createSpace(generateGUID("space3"), org3.GUID, adminAuthHeader)
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This changes multiple org and space creations to be done in parallel, using a wait group to synchronise.

It shaves around 30 seconds off the running time of the tests from 3 mins to 2 mins 30 on my machine.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2e tests remain green and run a bit faster

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
