### PR TITLE
Add an admin user on kind deployment

### DIFF
--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -73,10 +73,7 @@ var _ = BeforeSuite(func() {
 	config, err := controllerruntime.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
 
-	// fine for Kind cluster; might need work for other cluster types
-	cert := config.CertData
-	cert = append(cert, config.KeyData...)
-	adminAuthHeader = "ClientCert " + base64.StdEncoding.EncodeToString(cert)
+	adminAuthHeader = "ClientCert " + obtainAdminUserCert()
 
 	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -386,6 +383,15 @@ func obtainClientCert(name string) (*certsv1.CertificateSigningRequest, string) 
 	})).To(Succeed())
 
 	return k8sCSR, base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func obtainAdminUserCert() string {
+	crtBytes, err := base64.StdEncoding.DecodeString(mustHaveEnv("CF_ADMIN_CERT"))
+	Expect(err).NotTo(HaveOccurred())
+	keyBytes, err := base64.StdEncoding.DecodeString(mustHaveEnv("CF_ADMIN_KEY"))
+	Expect(err).NotTo(HaveOccurred())
+
+	return base64.StdEncoding.EncodeToString(append(crtBytes, keyBytes...))
 }
 
 func deleteCSR(csr *certsv1.CertificateSigningRequest) {

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -1,0 +1,14 @@
+# The CF Admin Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: admin
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - create
+  - delete
+  - list

--- a/controllers/config/cf_roles/kustomization.yaml
+++ b/controllers/config/cf_roles/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- cf_admin.yaml
 - cf_space_developer.yaml
 - cf_space_manager.yaml
 - cf_org_manager.yaml

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1233,6 +1233,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: cf-k8s-controllers-admin
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - create
+  - delete
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   creationTimestamp: null
   name: cf-k8s-controllers-manager-role
 rules:

--- a/dependencies/cf-setup.yaml
+++ b/dependencies/cf-setup.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cf
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-admin-binding
+  namespace: cf
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cf-k8s-controllers-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: admin

--- a/dependencies/namespace.yaml
+++ b/dependencies/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cf

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -121,6 +121,8 @@ EOF
       kubectl config use-context "$current_cluster"
     fi
   fi
+
+  "$SCRIPT_DIR"/create-new-user.sh admin
   kind export kubeconfig --name "$cluster" --kubeconfig "$HOME/.kube/$cluster.yml"
 }
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -39,11 +39,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "*************************"
-echo "Creating CF Namespace"
-echo "*************************"
+echo "*********************************************"
+echo "Creating CF Namespace and admin RoleBinding"
+echo "*********************************************"
 
-kubectl apply -f "${DEP_DIR}/namespace.yaml"
+kubectl apply -f "${DEP_DIR}/cf-setup.yaml"
+
+echo "***********************"
+echo "Creating user 'admin'"
+echo "***********************"
+
+"$SCRIPT_DIR/create-new-user.sh" admin
 
 echo "*************************"
 echo "Installing Cert Manager"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -22,6 +22,8 @@ else
   export KUBECONFIG="${HOME}/.kube/e2e.yml"
   export API_SERVER_ROOT=http://localhost
   export ROOT_NAMESPACE=cf
+  export CF_ADMIN_CERT=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-certificate-data}')
+  export CF_ADMIN_KEY=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-key-data}')
 
   extra_args+=("--slow-spec-threshold=30s")
 fi


### PR DESCRIPTION
Use the new scripts/create-new-user.sh script to create a
user with name admin and bind this user to the cf-k8s-controllers-admin
role. This role is a clone of the cf-k8s-controllers-space-developer
to begin with and should be incrementally granted more permissions as we
add new endpoints to the api. The goal is to eventually have and admin
role that is just as powerful as needed, but not as powerful as the k8s
admin user.

## Is there a related GitHub Issue?
#466 

## What is this change about?
Use the new scripts/create-new-user.sh script to create a
user with name admin and bind this user to the cf-k8s-controllers-admin
role. This role is a clone of the cf-k8s-controllers-space-developer
to begin with and should be incrementally granted more permissions as we
add new endpoints to the api. The goal is to eventually have and admin
role that is just as powerful as needed, but not as powerful as the k8s
admin user.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
- `make test-e2e` is green 
- `cf api http://localhost`
- `cf login`, chose the `admin` option
- `cf create-org myorg` 
- `cf orgs` displays the created org 

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 

## Things to remember
