### PR TITLE
Authorize GET /v3/apps/{guid}

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -105,7 +105,7 @@ func (h *AppHandler) appGetHandler(authInfo authorization.Info, w http.ResponseW
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
 		switch err.(type) {
-		case repositories.NotFoundError:
+		case repositories.PermissionDeniedOrNotFoundError:
 			h.logger.Info("App not found", "AppGUID", appGUID)
 			writeNotFoundErrorResponse(w, "App")
 			return
@@ -643,7 +643,6 @@ func (h *AppHandler) appPatchEnvVarsHandler(authInfo authorization.Info, w http.
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-
 		switch err.(type) {
 		case repositories.NotFoundError:
 			h.logger.Info("App not found", "AppGUID", appGUID)

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -172,9 +172,10 @@ var _ = Describe("AppHandler", func() {
                 }`, defaultServerURL, appGUID, spaceGUID)), "Response body matches response:")
 			})
 		})
-		When("the app cannot be found", func() {
+
+		When("the app cannot be found or the client is not authorized to get it", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -2755,7 +2756,6 @@ var _ = Describe("AppHandler", func() {
 					expectUnknownError()
 				})
 			})
-
 		})
 	})
 })

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -173,7 +173,7 @@ func createSpaceDeveloperClusterRole(ctx context.Context) *rbacv1.ClusterRole {
 				Resources: []string{"secrets"},
 			},
 			{
-				Verbs:     []string{"list", "create", "delete"},
+				Verbs:     []string{"get", "list", "create", "delete"},
 				APIGroups: []string{"workloads.cloudfoundry.org"},
 				Resources: []string{"cfapps"},
 			},

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -16,6 +16,7 @@ rules:
   resources:
   - cfapps
   verbs:
+  - get
   - create
   - delete
   - list

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1556,6 +1556,7 @@ rules:
   resources:
   - cfapps
   verbs:
+  - get
   - create
   - delete
   - list


### PR DESCRIPTION
## Is there a related GitHub Issue?
#234 

## What is this change about?
Use the user authenticated client to perform the Get of the cfapp resource from kubernetes.

At the moment we still retrieve the app by guid in an inefficient way, going through the entire list of apps retrieved by a privileged client looking for the matching guid. Then we use the user client to perform a `Get` once we know the namespace and name.

This need to be fixed in a generic way using some kind of cache.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Create org and space
2. Target org and space
2. `cf create-app bob`
3. `cf app bob --guid` and copy the guid
4. Create new user
5. Login as new user
6. `cf curl /v3/apps/{guid}`
7. Expect Not Found response

## Tag your pair, your PM, and/or team
@gcapizzi 

