### PR TITLE
Setup KUBECONFIG outside of deploy-on-kind scripts

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -94,7 +94,6 @@ ensure_kind_cluster() {
   if [[ -n "$api_only" ]]; then return 0; fi
 
   if ! kind get clusters | grep -q "$cluster"; then
-    current_cluster="$(kubectl config current-context 2>/dev/null)" || true
     cat <<EOF | kind create cluster --name "$cluster" --wait 5m --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -117,13 +116,9 @@ nodes:
     hostPort: 30050
     protocol: TCP
 EOF
-    if [[ -n "$current_cluster" ]]; then
-      kubectl config use-context "$current_cluster"
-    fi
   fi
 
-  "$SCRIPT_DIR"/create-new-user.sh admin
-  kind export kubeconfig --name "$cluster" --kubeconfig "$HOME/.kube/$cluster.yml"
+  kind export kubeconfig --name "$cluster"
 }
 
 ensure_local_registry() {
@@ -219,7 +214,6 @@ deploy_cf_k8s_api() {
 }
 
 ensure_kind_cluster "$cluster"
-export KUBECONFIG="$HOME/.kube/$cluster.yml"
 ensure_local_registry
 install_dependencies
 deploy_cf_k8s_controllers

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,11 +15,11 @@ if ! egrep -q e2e <(echo "$@"); then
   setup_envtest_env "${ENVTEST_ASSETS_DIR}"
   extra_args+=("--skip-package=e2e" "--coverprofile=cover.out" "--coverpkg=code.cloudfoundry.org/cf-k8s-controllers/...")
 else
+  export KUBECONFIG="${HOME}/.kube/e2e.yml"
   if [ -z "${SKIP_DEPLOY}" ]; then
     "${SCRIPT_DIR}/deploy-on-kind.sh" e2e
   fi
 
-  export KUBECONFIG="${HOME}/.kube/e2e.yml"
   export API_SERVER_ROOT=http://localhost
   export ROOT_NAMESPACE=cf
   export CF_ADMIN_CERT=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-certificate-data}')


### PR DESCRIPTION
This changes `scripts/deploy-on-kind.sh` to always use the current `$KUBECONFIG` instead of exporting its own one. This allows users to create development clusters using their default config, while `scripts/run-tests.sh` can deploy test clusters with a separate config just by exporting a different `$KUBECONFIG` _before_ calling `scripts/deploy-on-kind.sh`.