### PR TITLE
Generic cf api helper for the api e2e tests

### DIFF
--- a/api/tests/e2e/helpers/cf_api.go
+++ b/api/tests/e2e/helpers/cf_api.go
@@ -1,0 +1,105 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	. "github.com/onsi/gomega"
+)
+
+type QueryParams map[string]string
+
+type APIRequest struct {
+	ServerURL   string
+	Method      string
+	Endpoint    string
+	AuthHeader  string
+	Body        interface{}
+	QueryParams QueryParams
+	Response    *http.Response
+	Error       error
+}
+
+func NewCFAPI(serverURL string) APIRequest {
+	return APIRequest{
+		ServerURL: serverURL,
+	}
+}
+
+func (r APIRequest) Request(method, endpoint string) APIRequest {
+	return APIRequest{
+		ServerURL: r.ServerURL,
+		Method:    method,
+		Endpoint:  endpoint,
+	}
+}
+
+func (r APIRequest) WithBody(body interface{}) APIRequest {
+	r.Body = body
+	return r
+}
+
+func (r APIRequest) WithQueryParams(params QueryParams) APIRequest {
+	r.QueryParams = params
+	return r
+}
+
+func (r APIRequest) DoWithAuth(authHeader string) APIRequest {
+	r.AuthHeader = authHeader
+	return r.do()
+}
+
+func (r APIRequest) Do() APIRequest {
+	return r.do()
+}
+
+func (r APIRequest) do() APIRequest {
+	var bodyReader io.Reader
+	if r.Body != nil {
+		bodyBytes, err := json.Marshal(r.Body)
+		if err != nil {
+			r.Error = err
+			return r
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	query := url.Values{}
+	for key, val := range r.QueryParams {
+		query.Set(key, val)
+	}
+
+	req, err := http.NewRequest(r.Method, r.ServerURL+r.Endpoint+"?"+query.Encode(), bodyReader)
+	if err != nil {
+		r.Error = err
+		return r
+	}
+
+	req.Header.Add("Authorization", r.AuthHeader)
+
+	r.Response, r.Error = http.DefaultClient.Do(req)
+
+	return r
+}
+
+func (r APIRequest) ValidateStatus(expectedStatus int) APIRequest {
+	ExpectWithOffset(2, r.Raw().StatusCode).To(Equal(expectedStatus))
+	return r
+}
+
+func (r APIRequest) Raw() *http.Response {
+	ExpectWithOffset(2, r.Error).NotTo(HaveOccurred())
+	return r.Response
+}
+
+func (r APIRequest) Status() int {
+	return r.Raw().StatusCode
+}
+
+func (r APIRequest) DecodeResponseBody(receiver interface{}) {
+	defer r.Response.Body.Close()
+	ExpectWithOffset(2, json.NewDecoder(r.Response.Body).Decode(receiver)).To(Succeed())
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.10.0
+	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.8.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,8 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -2136,6 +2138,7 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211111160137-58aab5ef257a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211203184738-4852103109b8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
This is an attempt to. create a generic test helper that will make it easy and readable to make any api call in our e2e tests.
The idea is to keep it concise and flexible , while still being obvious what it does. This is a draft PR so please leave comments on whether you like it better than the old style, what works and what doesn't. I have covered the orgs and roles tests which should be enough to hit all current needs.