### PR TITLE
Allow cf-admins only to create spaces

### DIFF
--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -88,6 +88,13 @@ func (h *SpaceHandler) SpaceCreateHandler(info authorization.Info, w http.Respon
 			return
 		}
 
+		if repositories.IsForbiddenError(err) {
+			h.logger.Error(err, "not allowed to create spaces")
+			writeNotAuthorizedErrorResponse(w)
+
+			return
+		}
+
 		h.logger.Error(err, "Failed to create space", "Space Name", space.Name)
 		writeUnknownErrorResponse(w)
 		return

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -138,6 +138,16 @@ var _ = Describe("Spaces", func() {
 			})
 		})
 
+		When("user is not allowed to create a space", func() {
+			BeforeEach(func() {
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewForbiddenError(errors.New("nope")))
+			})
+
+			It("returns an unauthorised error", func() {
+				expectUnauthorizedError()
+			})
+		})
+
 		When("providing the space repository fails", func() {
 			BeforeEach(func() {
 				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, errors.New("space-repo-provisioning-failed"))

--- a/api/repositories/errors.go
+++ b/api/repositories/errors.go
@@ -1,5 +1,7 @@
 package repositories
 
+import "errors"
+
 type NotFoundError struct {
 	Err          error
 	ResourceType string
@@ -58,4 +60,8 @@ func (e ForbiddenError) Error() string {
 
 func (e ForbiddenError) Unwrap() error {
 	return e.err
+}
+
+func IsForbiddenError(err error) bool {
+	return errors.As(err, &ForbiddenError{})
 }

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -39,14 +39,15 @@ func TestRepositories(t *testing.T) {
 }
 
 var (
-	testEnv       *envtest.Environment
-	k8sClient     client.WithWatch
-	k8sConfig     *rest.Config
-	userName      string
-	authInfo      authorization.Info
-	rootNamespace string
-	idProvider    authorization.IdentityProvider
-	nsPerms       *authorization.NamespacePermissions
+	testEnv          *envtest.Environment
+	k8sClient        client.WithWatch
+	k8sConfig        *rest.Config
+	userName         string
+	authInfo         authorization.Info
+	rootNamespace    string
+	idProvider       authorization.IdentityProvider
+	nsPerms          *authorization.NamespacePermissions
+	adminClusterRole *rbacv1.ClusterRole
 )
 
 var _ = BeforeSuite(func() {
@@ -82,6 +83,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.NewWithWatch(k8sConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	adminClusterRole = createAdminClusterRole(context.Background())
 })
 
 var _ = AfterSuite(func() {
@@ -225,6 +228,11 @@ var (
 			Verbs:     []string{"create", "delete"},
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"rolebindings"},
+		},
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"hnc.x-k8s.io"},
+			Resources: []string{"subnamespaceanchors"},
 		},
 	}
 

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -13,7 +13,6 @@ rules:
   - create
   - delete
   - list
-
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -37,3 +36,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - hnc.x-k8s.io
+  resources:
+  - subnamespaceanchors
+  verbs:
+  - create

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1265,6 +1265,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - hnc.x-k8s.io
+  resources:
+  - subnamespaceanchors
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/235

## What is this change about?
Allow space creation to users that have the `cf-admin` role assigned.

The implementation would use the user k8s client (instead the privileged one) in the space repository to create the space subnamespace anchor. This means that the user has to be assigned to the `cf-admin` role which is the only one allowing subnamespace anchor creation.

## Does this PR introduce a breaking change?
No (or sort of - from now on regular users would not be able to create spaces :) )

## Acceptance Steps

0. Deploy on kind and `cf api` the cluster 

### Admin user
1. login as `admin`
2. `cf create-org o`
3. `cf create-space -o o s`
4. Make sure the commands above caused no errors

### Non-admin users
1. `./scripts/create-new-user.sh nonadmin`
2. Assign the `organization-user` role to `nonadmin`
```
cat <<EOF | kubectl apply -f -
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: nonadmin-binding
  namespace: cf
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cf-k8s-controllers-organization-user
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: nonadmin
EOF

```
2. Login as `nonadmin`
3. `cf create-space -o o s2` should fail with `You are not authorized to perform the requested action`

## Tag your pair, your PM, and/or team
@kieron-dev 
@mnitchev 

