### PR TITLE
Set default memory limit to 1024

### DIFF
--- a/controllers/config/base/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/base/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,7 +1,7 @@
 kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
 clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
-  memoryMB: 500
-  diskQuotaMB: 512
+  memoryMB: 1024
+  diskQuotaMB: 1024
 cfk8s_controller_namespace: cf-k8s-controllers-system
 workloads_tls_secret_name: cf-k8s-workloads-ingress-cert

--- a/controllers/config/overlays/kind-local-registry/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind-local-registry/controllersconfig/cf_k8s_controllers_config.yaml
@@ -2,7 +2,7 @@ kpackImageTag: localregistry-docker-registry.default.svc.cluster.local:30050/cf-
 
 clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
-  memoryMB: 500
-  diskQuotaMB: 512
+  memoryMB: 1024
+  diskQuotaMB: 1024
 cfk8s_controller_namespace: cf-k8s-controllers-system
 workloads_tls_secret_name: ""

--- a/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/kind/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,7 +1,7 @@
 kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
 clusterBuilderName: cf-kpack-cluster-builder
 cfProcessDefaults:
-  memoryMB: 500
-  diskQuotaMB: 512
+  memoryMB: 1024
+  diskQuotaMB: 1024
 cfk8s_controller_namespace: cf-k8s-controllers-system
 workloads_tls_secret_name: ""

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1657,8 +1657,8 @@ data:
     kpackImageTag: gcr.io/cf-relint-greengrass/cf-k8s-controllers/kpack/beta
     clusterBuilderName: cf-kpack-cluster-builder
     cfProcessDefaults:
-      memoryMB: 500
-      diskQuotaMB: 512
+      memoryMB: 1024
+      diskQuotaMB: 1024
     cfk8s_controller_namespace: cf-k8s-controllers-system
     workloads_tls_secret_name: cf-k8s-workloads-ingress-cert
 kind: ConfigMap


### PR DESCRIPTION
Co-authored-by: Akira Wong <wakira@vmware.com>

## Is there a related GitHub Issue?
#492 

## What is this change about?
Update the default memory and disk limits for apps

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Deploy the api/controllers with default configuration, then push and app without any scaling configuration. View the app info and see that the memory and disk requests are now 1024MB.

## Tag your pair, your PM, and/or team
paired w/ @gnovv 
