### PR TITLE
Set Owner References on CFPackage, CFBuild and CFProcess

### DIFF
--- a/api/presenter/process_stats.go
+++ b/api/presenter/process_stats.go
@@ -51,7 +51,6 @@ func statRecordToResource(record repositories.PodStatsRecord) ProcessStatsResour
 	var processInstancePorts *[]ProcessInstancePort
 	if record.State != "DOWN" {
 		processInstancePorts = &[]ProcessInstancePort{}
-
 	}
 	return ProcessStatsResource{
 		Type:          record.Type,

--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -1,0 +1,152 @@
+package workloads_test
+
+import (
+	"context"
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
+	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/workloads"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/workloads/fake"
+	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/workloads/testutils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	buildv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("CFPackageReconciler", func() {
+	var (
+		fakeClient *fake.Client
+
+		cfAppGUID     string
+		cfPackageGUID string
+
+		cfApp                *workloadsv1alpha1.CFApp
+		cfAppError           error
+		cfPackage            *workloadsv1alpha1.CFPackage
+		cfPackageError       error
+		cfPackageUpdateError error
+
+		cfPackageReconciler *CFPackageReconciler
+		req                 ctrl.Request
+		ctx                 context.Context
+
+		reconcileResult ctrl.Result
+		reconcileErr    error
+	)
+
+	BeforeEach(func() {
+		fakeClient = new(fake.Client)
+
+		cfAppGUID = "cf-app-guid"
+		cfPackageGUID = "cf-package-guid"
+
+		cfApp = BuildCFAppCRObject(cfAppGUID, defaultNamespace)
+		cfAppError = nil
+		cfPackage = BuildCFPackageCRObject(cfPackageGUID, defaultNamespace, cfAppGUID)
+		cfPackageError = nil
+
+		fakeClient.GetStub = func(_ context.Context, _ types.NamespacedName, obj client.Object) error {
+			switch obj := obj.(type) {
+			case *workloadsv1alpha1.CFApp:
+				cfApp.DeepCopyInto(obj)
+				return cfAppError
+			case *workloadsv1alpha1.CFPackage:
+				cfPackage.DeepCopyInto(obj)
+				return cfPackageError
+
+			default:
+				panic("test Client Get provided a weird obj")
+			}
+		}
+
+		fakeClient.PatchStub = func(ctx context.Context, object client.Object, patch client.Patch, option ...client.PatchOption) error {
+			return cfPackageUpdateError
+		}
+
+		Expect(workloadsv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+		Expect(buildv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
+		cfPackageReconciler = &CFPackageReconciler{
+			Client: fakeClient,
+			Scheme: scheme.Scheme,
+			Log:    zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)),
+		}
+		req = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: defaultNamespace,
+				Name:      cfPackageGUID,
+			},
+		}
+		ctx = context.Background()
+	})
+
+	When("CFPackage is created and the CFPackageReconciler reconciles", func() {
+		When("on the happy path", func() {
+			BeforeEach(func() {
+				reconcileResult, reconcileErr = cfPackageReconciler.Reconcile(ctx, req)
+			})
+
+			It("does not return an error", func() {
+				Expect(reconcileErr).NotTo(HaveOccurred())
+			})
+
+			It("returns an empty result", func() {
+				Expect(reconcileResult).To(Equal(ctrl.Result{}))
+			})
+		})
+
+		When("on the unhappy path", func() {
+			When("fetch CFPackage returns an error", func() {
+				BeforeEach(func() {
+					cfPackageError = errors.New("failing on purpose")
+					reconcileResult, reconcileErr = cfPackageReconciler.Reconcile(ctx, req)
+				})
+
+				It("should return an error", func() {
+					Expect(reconcileErr).To(HaveOccurred())
+				})
+			})
+
+			When("fetch CFPackage returns a NotFoundError", func() {
+				BeforeEach(func() {
+					cfPackageError = apierrors.NewNotFound(schema.GroupResource{}, cfPackage.Name)
+					reconcileResult, reconcileErr = cfPackageReconciler.Reconcile(ctx, req)
+				})
+
+				It("should NOT return any error", func() {
+					Expect(reconcileErr).NotTo(HaveOccurred())
+				})
+			})
+
+			When("fetch CFApp returns an error", func() {
+				BeforeEach(func() {
+					cfAppError = errors.New("failing on purpose")
+					reconcileResult, reconcileErr = cfPackageReconciler.Reconcile(ctx, req)
+				})
+
+				It("should return an error", func() {
+					Expect(reconcileErr).To(HaveOccurred())
+				})
+			})
+
+			When("patch CFPackage returns an error", func() {
+				BeforeEach(func() {
+					cfPackageUpdateError = errors.New("failing on purpose")
+					reconcileResult, reconcileErr = cfPackageReconciler.Reconcile(ctx, req)
+				})
+
+				It("should return an error", func() {
+					Expect(reconcileErr).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/controllers/controllers/workloads/integration/cfpackage_controller_integration_test.go
+++ b/controllers/controllers/workloads/integration/cfpackage_controller_integration_test.go
@@ -1,0 +1,62 @@
+package integration_test
+
+import (
+	"context"
+	"time"
+
+	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
+	. "code.cloudfoundry.org/cf-k8s-controllers/controllers/controllers/workloads/testutils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("CFPackageReconciler", func() {
+	var (
+		namespaceGUID string
+		ns            *corev1.Namespace
+		cfApp         *workloadsv1alpha1.CFApp
+		cfAppGUID     string
+		cfPackage     *workloadsv1alpha1.CFPackage
+		cfPackageGUID string
+	)
+
+	BeforeEach(func() {
+		namespaceGUID = GenerateGUID()
+		cfAppGUID = GenerateGUID()
+		cfPackageGUID = GenerateGUID()
+		ns = createNamespace(context.Background(), k8sClient, namespaceGUID)
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns)
+		})
+
+		cfApp = BuildCFAppCRObject(cfAppGUID, namespaceGUID)
+		Expect(k8sClient.Create(context.Background(), cfApp)).To(Succeed())
+	})
+
+	When("a new CFPackage resource is created", func() {
+		BeforeEach(func() {
+			cfPackage = BuildCFPackageCRObject(cfPackageGUID, namespaceGUID, cfAppGUID)
+			Expect(k8sClient.Create(context.Background(), cfPackage)).To(Succeed())
+		})
+
+		It("eventually reconciles to set the owner reference on the CFPackage", func() {
+			Eventually(func() []metav1.OwnerReference {
+				var createdCFPackage workloadsv1alpha1.CFPackage
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: cfPackageGUID, Namespace: namespaceGUID}, &createdCFPackage)
+				if err != nil {
+					return nil
+				}
+				return createdCFPackage.GetOwnerReferences()
+			}, 5*time.Second).Should(ConsistOf(metav1.OwnerReference{
+				APIVersion: workloadsv1alpha1.GroupVersion.Identifier(),
+				Kind:       "CFApp",
+				Name:       cfApp.Name,
+				UID:        cfApp.UID,
+			}))
+		})
+	})
+})

--- a/controllers/controllers/workloads/integration/suite_integration_test.go
+++ b/controllers/controllers/workloads/integration/suite_integration_test.go
@@ -126,6 +126,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&CFPackageReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CFPackage"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	// Add new reconcilers here
 
 	// Setup index for manager

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -152,6 +152,7 @@ func main() {
 	if err = (&workloadscontrollers.CFPackageReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CFPackage"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CFPackage")
 		os.Exit(1)


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#471 
#472 
#477 

## What is this change about?
<!-- _Please describe the change here._ -->
Sets CFApp as owner on CFPackage, CFBuild and CFProcess. This results in them being deleted when CFApp is deleted.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Follow AC on the issues

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@matt-royal 