### PR TITLE
Move authentication tests to the whoami endpoint

### DIFF
--- a/api/tests/helpers/cert_auth_header.go
+++ b/api/tests/helpers/cert_auth_header.go
@@ -1,0 +1,57 @@
+package helpers
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func CreateCertificateAuthHeader() string {
+	certKeyPEM := CreateCertificatePEM()
+
+	return "ClientCert " + base64.StdEncoding.EncodeToString(certKeyPEM)
+}
+
+func CreateCertificatePEM() []byte {
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	Expect(err).NotTo(HaveOccurred())
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"cf-on-k8s"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &certPrivKey.PublicKey, certPrivKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	out := new(bytes.Buffer)
+	err = pem.Encode(out, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = pem.Encode(out, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return out.Bytes()
+}

--- a/api/tests/integration/user_client_factory_test.go
+++ b/api/tests/integration/user_client_factory_test.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	thelpers "code.cloudfoundry.org/cf-k8s-controllers/api/tests/helpers"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/tests/integration/helpers"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -198,9 +199,29 @@ var _ = Describe("Unprivileged User Client Factory", func() {
 			})
 		})
 
-		When("the auth is not valid", func() {
+		When("the token is not valid", func() {
 			BeforeEach(func() {
 				authInfo.Token = "xxx"
+			})
+
+			It("fails", func() {
+				Expect(authorization.IsInvalidAuth(buildClientErr)).To(BeTrue())
+			})
+		})
+
+		When("the cert is not valid", func() {
+			BeforeEach(func() {
+				authInfo.CertData = []byte("not a cert")
+			})
+
+			It("fails", func() {
+				Expect(buildClientErr).To(MatchError(ContainSubstring("failed to decode cert PEM")))
+			})
+		})
+
+		When("the cert is not valid on this cluster", func() {
+			BeforeEach(func() {
+				authInfo.CertData = thelpers.CreateCertificatePEM()
 			})
 
 			It("fails", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
#483 

## What is this change about?

Since we are using a middleware for parsing the authentication header,
we should just test that in one place, instead of on every endpoint.
This should eliminate a lot of duplication.
Additionally add some missing tests to the user client factory.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Look at the tests 👀 

## Tag your pair, your PM, and/or team
@kieron-dev 
