### PR TITLE
Implement authz on set current droplet endpoint

### DIFF
--- a/api/apis/apis_suite_test.go
+++ b/api/apis/apis_suite_test.go
@@ -137,3 +137,15 @@ func expectNotAuthenticatedError() {
         ]
     }`)
 }
+
+func expectInvalidAuthError() {
+	expectJSONResponse(http.StatusUnauthorized, `{
+      "errors": [
+          {
+            "detail": "Invalid Auth Token",
+            "title": "CF-InvalidAuthToken",
+            "code": 1000
+          }
+        ]
+    }`)
+}

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -244,7 +244,7 @@ var (
 			Resources: []string{"secrets"},
 		},
 		{
-			Verbs:     []string{"get", "list", "create", "delete"},
+			Verbs:     []string{"get", "list", "create", "patch", "delete"},
 			APIGroups: []string{"workloads.cloudfoundry.org"},
 			Resources: []string{"cfapps"},
 		},

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -627,6 +627,39 @@ func getWithQuery(endpoint string, authHeaderValue string, query map[string]stri
 	return response, nil
 }
 
+func patch(endpoint string, authHeaderValue string, payload interface{}) (map[string]interface{}, error) {
+	serverUrl, err := url.Parse(apiServerRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	serverUrl.Path = endpoint
+
+	resp, err := httpReq(http.MethodPatch, serverUrl.String(), authHeaderValue, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	response := map[string]interface{}{}
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func uploadNodeApp(pkgGUID, authHeader string) {
 	var b bytes.Buffer
 	writer := multipart.NewWriter(&b)

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -11,6 +11,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
   - delete
   - list
 - apiGroups:

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -18,6 +18,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
   - delete
   - list
 - apiGroups:

--- a/controllers/config/cf_roles/cf_space_manager.yaml
+++ b/controllers/config/cf_roles/cf_space_manager.yaml
@@ -3,4 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: space-manager
-rules: []
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get

--- a/controllers/controllers/services/integration/suite_test.go
+++ b/controllers/controllers/services/integration/suite_test.go
@@ -36,10 +36,12 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var _ = cfg // make the linter happy
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	cfg       *rest.Config
+	_         = cfg // make the linter happy
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -68,7 +70,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1448,6 +1448,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
   - delete
   - list
 - apiGroups:
@@ -1858,6 +1859,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
   - delete
   - list
 - apiGroups:
@@ -1873,7 +1875,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cf-k8s-controllers-space-manager
-rules: []
+rules:
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfapps
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Is there a related GitHub Issue?
#446 

## What is this change about?
This adds cfapp patch permissions to space-developer and admin roles and uses the 'user client' to perform the patch.

We also added get permission to space-manager as a readonly user helped in the e2e test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See you can set current droplet on an app as admin or spacedeveloper, but not as any other role.

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 