### PR TITLE
Run dependabot checks daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,19 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "daily"
+
 - package-ecosystem: "docker"
   directory: "/api"
   schedule:
-    interval: "weekly"
+    interval: "daily"
+
 - package-ecosystem: "docker"
   directory: "/controllers"
   schedule:
-    interval: "weekly"
+    interval: "daily"
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "daily"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR updates the Dependabot configuration to run the checks daily instead of weekly.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Dependabot PRs are opened on any day of the week, not just Monday.
