### PR TITLE
Reset error to nil to stop test interference

### DIFF
--- a/controllers/controllers/workloads/cfpackage_controller_test.go
+++ b/controllers/controllers/workloads/cfpackage_controller_test.go
@@ -68,6 +68,7 @@ var _ = Describe("CFPackageReconciler", func() {
 			}
 		}
 
+		cfPackageUpdateError = nil
 		fakeClient.PatchStub = func(ctx context.Context, object client.Object, patch client.Patch, option ...client.PatchOption) error {
 			return cfPackageUpdateError
 		}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#539 

## What is this change about?
Fix test flake.

The variable `cfPackageUpdateError` is not initialized, so when the test setting it in "patch CFPackage returns an error" has run, subsequent happy path tests will fail.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
`ginkgo --randomize-all --until-it-fails controllers/controllers/workloads` succeeds for as long as you can wait.

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
