### PR TITLE
Return 404 if not authorized to list app processes

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -434,8 +434,8 @@ func (h *AppHandler) getProcessesForAppHandler(authInfo authorization.Info, w ht
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
 		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
+		case repositories.PermissionDeniedOrNotFoundError:
+			h.logger.Info("Permission denied or app not found", "AppGUID", appGUID, "err", err)
 			writeNotFoundErrorResponse(w, "App")
 			return
 		default:

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -1601,10 +1601,11 @@ var _ = Describe("AppHandler", func() {
 				})
 			})
 		})
+
 		When("On the sad path and", func() {
-			When("the app cannot be found", func() {
+			When("the app cannot be found or user is not authorized to see it", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
 				})
 
 				It("returns an error", func() {

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -129,6 +129,21 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
+	Describe("list processes for an app", func() {
+		var app presenter.AppResponse
+
+		BeforeEach(func() {
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
+			app = createApp(space1.GUID, generateGUID("app"), adminAuthHeader)
+		})
+
+		It("successfully lists the empty set of processes", func() {
+			resp, err := get("/v3/apps/"+app.GUID+"/processes", certAuthHeader)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(HaveKeyWithValue("resources", BeEmpty()))
+		})
+	})
+
 	Describe("Droplets", func() {
 		var (
 			app      presenter.AppResponse


### PR DESCRIPTION
## Is there a related GitHub Issue?
#447 

## What is this change about?
Return 404 error if user is not authorized to list app processes. This currently equates to permissions to get the app, so no change has been made to the process repo code to not use the privileged k8s client.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See story

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
