### PR TITLE
Use userClientFactory correctly in repo code

### DIFF
--- a/api/apis/integration/app_test.go
+++ b/api/apis/integration/app_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,17 +29,15 @@ import (
 
 var _ = Describe("App Handler", func() {
 	var (
-		apiHandler         *AppHandler
-		namespace          *corev1.Namespace
-		spaceDeveloperRole *rbacv1.ClusterRole
-		spaceManagerRole   *rbacv1.ClusterRole
+		apiHandler *AppHandler
+		namespace  *corev1.Namespace
 	)
 
 	BeforeEach(func() {
 		clientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
 		identityProvider := new(fake.IdentityProvider)
 		nsPermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
-		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions, true)
+		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions)
 		dropletRepo := repositories.NewDropletRepo(k8sClient)
 		processRepo := repositories.NewProcessRepo(k8sClient)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
@@ -67,9 +64,6 @@ var _ = Describe("App Handler", func() {
 		Expect(
 			k8sClient.Create(ctx, namespace),
 		).To(Succeed())
-
-		spaceDeveloperRole = createClusterRole(ctx, repositories.SpaceDeveloperClusterRoleRules)
-		spaceManagerRole = createClusterRole(ctx, repositories.SpaceManagerClusterRoleRules)
 	})
 
 	AfterEach(func() {

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -32,7 +32,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 		identityProvider := new(fake.IdentityProvider)
 		namespacePermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
 
-		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, namespacePermissions, false)
+		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, namespacePermissions)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 		processRepo := repositories.NewProcessRepo(k8sClient)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)

--- a/api/apis/integration/get_app_env_test.go
+++ b/api/apis/integration/get_app_env_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 		identityProvider := new(fake.IdentityProvider)
 		namespacePermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
 
-		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, namespacePermissions, false)
+		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, namespacePermissions)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 		processRepo := repositories.NewProcessRepo(k8sClient)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
@@ -59,6 +59,8 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 		DeferCleanup(func() {
 			_ = k8sClient.Delete(context.Background(), namespace)
 		})
+
+		createRoleBinding(ctx, userName, spaceDeveloperRole.Name, namespaceGUID)
 	})
 
 	When("the app has environment variables", func() {

--- a/api/apis/integration/route_test.go
+++ b/api/apis/integration/route_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Route Handler", func() {
 		clientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
 		identityProvider := new(fake.IdentityProvider)
 		nsPermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
-		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions, true)
+		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 

--- a/api/main.go
+++ b/api/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 	scaleProcessAction := actions.NewScaleProcess(repositories.NewProcessRepo(privilegedCRClient))
 	scaleAppProcessAction := actions.NewScaleAppProcess(
-		repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+		repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 		repositories.NewProcessRepo(privilegedCRClient),
 		scaleProcessAction.Invoke,
 	)
@@ -104,7 +104,7 @@ func main() {
 	fetchProcessStatsAction := actions.NewFetchProcessStats(
 		repositories.NewProcessRepo(privilegedCRClient),
 		repositories.NewPodRepo(privilegedCRClient),
-		repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+		repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 	)
 
 	orgRepo := repositories.NewOrgRepo(config.RootNamespace, privilegedCRClient, buildUserClient, nsPermissions, createTimeout, config.AuthEnabled)
@@ -118,7 +118,7 @@ func main() {
 		apis.NewAppHandler(
 			ctrl.Log.WithName("AppHandler"),
 			*serverURL,
-			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 			repositories.NewDropletRepo(privilegedCRClient),
 			repositories.NewProcessRepo(privilegedCRClient),
 			repositories.NewRouteRepo(privilegedCRClient, buildUserClient),
@@ -131,7 +131,7 @@ func main() {
 			*serverURL,
 			repositories.NewRouteRepo(privilegedCRClient, buildUserClient),
 			repositories.NewDomainRepo(privilegedCRClient),
-			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 		),
 		apis.NewServiceRouteBindingHandler(
 			ctrl.Log.WithName("ServiceRouteBinding"),
@@ -141,7 +141,7 @@ func main() {
 			ctrl.Log.WithName("PackageHandler"),
 			*serverURL,
 			repositories.NewPackageRepo(privilegedCRClient),
-			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 			repositories.NewDropletRepo(privilegedCRClient),
 			repositories.UploadSourceImage,
 			newRegistryAuthBuilder(privilegedK8sClient, config),
@@ -185,7 +185,7 @@ func main() {
 			ctrl.Log.WithName("SpaceManifestHandler"),
 			*serverURL,
 			actions.NewApplyManifest(
-				repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+				repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 				repositories.NewDomainRepo(privilegedCRClient),
 				repositories.NewProcessRepo(privilegedCRClient),
 				repositories.NewRouteRepo(privilegedCRClient, buildUserClient),
@@ -212,7 +212,7 @@ func main() {
 		apis.NewBuildpackHandler(
 			ctrl.Log.WithName("BuildpackHandler"),
 			*serverURL,
-			repositories.NewBuildpackRepository(privilegedCRClient, buildUserClient, config.AuthEnabled),
+			repositories.NewBuildpackRepository(buildUserClient),
 			config.ClusterBuilderName,
 		),
 
@@ -220,7 +220,7 @@ func main() {
 			ctrl.Log.WithName("ServiceInstanceHandler"),
 			*serverURL,
 			repositories.NewServiceInstanceRepo(buildUserClient),
-			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions, config.AuthEnabled),
+			repositories.NewAppRepo(privilegedCRClient, buildUserClient, nsPermissions),
 		),
 	}
 

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -43,7 +43,7 @@ var _ = Describe("AppRepository", func() {
 		testCtx = context.Background()
 
 		clientFactory = repositories.NewUnprivilegedClientFactory(k8sConfig)
-		appRepo = NewAppRepo(k8sClient, clientFactory, nsPerms, true)
+		appRepo = NewAppRepo(k8sClient, clientFactory, nsPerms)
 
 		rootNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rootNamespace}}
 		Expect(k8sClient.Create(testCtx, rootNs)).To(Succeed())
@@ -1063,7 +1063,7 @@ var _ = Describe("AppRepository", func() {
 					k8sClient.Create(context.Background(), secret),
 				).To(Succeed())
 
-				appRepo = NewAppRepo(k8sClient, clientFactory, nsPerms, true)
+				appRepo = NewAppRepo(k8sClient, clientFactory, nsPerms)
 			})
 
 			When("the user can read secrets in the space", func() {

--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -106,71 +106,40 @@ var _ = Describe("BuildpackRepository", func() {
 		})
 
 		Describe("List", func() {
-			When("auth is enabled", func() {
-				It("returns records matching the buildpacks of the ClusterBuilder and no error", func() {
-					buildpackRepo = NewBuildpackRepository(k8sClient, clientFactory, true)
-					spaceDeveloperClusterRole = createClusterRole(beforeCtx, repositories.SpaceDeveloperClusterRoleRules)
-					createClusterRoleBinding(beforeCtx, userName, spaceDeveloperClusterRole.Name)
+			It("returns records matching the buildpacks of the ClusterBuilder and no error", func() {
+				buildpackRepo = NewBuildpackRepository(clientFactory)
+				spaceDeveloperClusterRole = createClusterRole(beforeCtx, repositories.SpaceDeveloperClusterRoleRules)
+				createClusterRoleBinding(beforeCtx, userName, spaceDeveloperClusterRole.Name)
 
-					buildpackRecords, err := buildpackRepo.GetBuildpacksForBuilder(context.Background(), authInfo, clusterBuilder.Name)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(buildpackRecords).To(ConsistOf(
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-1-1"),
-							"Position": Equal(1),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("1.1"),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-2-1"),
-							"Position": Equal(2),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("2.1"),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-3-1"),
-							"Position": Equal(3),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("3.1"),
-						}),
-					))
-				})
+				buildpackRecords, err := buildpackRepo.GetBuildpacksForBuilder(context.Background(), authInfo, clusterBuilder.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(buildpackRecords).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Name":     Equal("paketo-buildpacks/buildpack-1-1"),
+						"Position": Equal(1),
+						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Version":  Equal("1.1"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name":     Equal("paketo-buildpacks/buildpack-2-1"),
+						"Position": Equal(2),
+						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Version":  Equal("2.1"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name":     Equal("paketo-buildpacks/buildpack-3-1"),
+						"Position": Equal(3),
+						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Version":  Equal("3.1"),
+					}),
+				))
 			})
 
-			When("auth is enabled, but insufficient perm", func() {
+			When("insufficient perm", func() {
 				It("fails to retrieve buildpack records", func() {
-					buildpackRepo = NewBuildpackRepository(k8sClient, clientFactory, true)
+					buildpackRepo = NewBuildpackRepository(clientFactory)
 					_, err := buildpackRepo.GetBuildpacksForBuilder(context.Background(), authInfo, clusterBuilder.Name)
 					Expect(err).To(HaveOccurred())
-				})
-			})
-
-			When("auth is disabled", func() {
-				It("returns records matching the buildpacks of the ClusterBuilder and no error", func() {
-					authDisabledBuildpackRepo := NewBuildpackRepository(k8sClient, clientFactory, false)
-					buildpackRecords, err := authDisabledBuildpackRepo.GetBuildpacksForBuilder(context.Background(), authInfo, clusterBuilder.Name)
-
-					Expect(err).NotTo(HaveOccurred())
-					Expect(buildpackRecords).To(ConsistOf(
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-1-1"),
-							"Position": Equal(1),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("1.1"),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-2-1"),
-							"Position": Equal(2),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("2.1"),
-						}),
-						MatchFields(IgnoreExtras, Fields{
-							"Name":     Equal("paketo-buildpacks/buildpack-3-1"),
-							"Position": Equal(3),
-							"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
-							"Version":  Equal("3.1"),
-						}),
-					))
 				})
 			})
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Correct the usage of userClientFactory in the app and buildpack repos

We shouldn't pass the authEnabled flag in, and we should trust that main has injected the correct client factory.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green CI

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
