### PR TITLE
Do not run ginkgo recursively when invoked from vim

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -32,4 +32,8 @@ if [[ -n "$GINKGO_NODES" ]]; then
   extra_args+=("--procs=${GINKGO_NODES}")
 fi
 
-ginkgo --race -r -p --randomize-all --randomize-suites "${extra_args[@]}" $@
+if [[ -z "$NON_RECURSIVE_TEST" ]]; then
+  extra_args+=("-r")
+fi
+
+ginkgo --race -p --randomize-all --randomize-suites "${extra_args[@]}" $@

--- a/scripts/test
+++ b/scripts/test
@@ -1,1 +1,5 @@
-./run-tests.sh
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+NON_RECURSIVE_TEST=true $SCRIPT_DIR/run-tests.sh $@


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
The vim test integration executes `scripts/test` if it exists. We want this to run on the current suite, not any suites in sub-directories.

To enable this, we add another env option `NON_RECUSIVE_TEST` to run-tests.sh, and set this in `script/test` before invoking `run-tests.sh`. When not set, ginkgo is executed with the `-r` flag, otherwise without it.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
In vim, with the eirini team's configuration, press `<space>ts` from a test in `api/apis`, and see only the apis suite runs, not the apis/integration suite too.

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
