### PR TITLE
Implement authz for restart app endpoint

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
-	Describe("Droplets", func() {
+	Describe("built apps", func() {
 		var (
 			app      presenter.AppResponse
 			pkg      presenter.PackageResponse
@@ -177,6 +177,8 @@ var _ = Describe("Apps", func() {
 				_, err := get("/v3/droplets/"+build.GUID, adminAuthHeader)
 				return err
 			}).Should(Succeed())
+
+			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
 		})
 
 		Describe("get current droplet", func() {
@@ -186,10 +188,6 @@ var _ = Describe("Apps", func() {
 
 			JustBeforeEach(func() {
 				response, httpErr = get("/v3/apps/"+app.GUID+"/droplets/current", certAuthHeader)
-			})
-
-			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
 			})
 
 			It("succeeds", func() {
@@ -209,13 +207,24 @@ var _ = Describe("Apps", func() {
 				})
 			})
 
-			BeforeEach(func() {
-				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
-			})
-
 			It("returns 200", func() {
 				Expect(httpErr).NotTo(HaveOccurred())
 				Expect(response).To(HaveKeyWithValue("data", HaveKeyWithValue("guid", build.GUID)))
+			})
+		})
+
+		Describe("app restart", func() {
+			BeforeEach(func() {
+				setCurrentDroplet(app.GUID, build.GUID, adminAuthHeader)
+			})
+
+			JustBeforeEach(func() {
+				response, httpErr = post("/v3/apps/"+app.GUID+"/actions/restart", certAuthHeader, nil)
+			})
+
+			It("succeeds", func() {
+				Expect(httpErr).NotTo(HaveOccurred())
+				Expect(response).To(HaveKeyWithValue("state", "STARTED"))
 			})
 		})
 	})

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -644,6 +644,14 @@ func getWithQuery(endpoint string, authHeaderValue string, query map[string]stri
 }
 
 func patch(endpoint string, authHeaderValue string, payload interface{}) (map[string]interface{}, error) {
+	return doUpdate(http.MethodPatch, endpoint, authHeaderValue, payload)
+}
+
+func post(endpoint string, authHeaderValue string, payload interface{}) (map[string]interface{}, error) {
+	return doUpdate(http.MethodPost, endpoint, authHeaderValue, payload)
+}
+
+func doUpdate(httpMethod, endpoint string, authHeaderValue string, payload interface{}) (map[string]interface{}, error) {
 	serverUrl, err := url.Parse(apiServerRoot)
 	if err != nil {
 		return nil, err
@@ -651,7 +659,7 @@ func patch(endpoint string, authHeaderValue string, payload interface{}) (map[st
 
 	serverUrl.Path = endpoint
 
-	resp, err := httpReq(http.MethodPatch, serverUrl.String(), authHeaderValue, payload)
+	resp, err := httpReq(httpMethod, serverUrl.String(), authHeaderValue, payload)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#449 

## What is this change about?
Use the user client factory to obtain a user authenticated client for the `SetAppDesiredState()` call.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #449

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
