### PR TITLE
Use Stack ID from Builder's Status when listing Buildpacks

### DIFF
--- a/api/repositories/buildpack_repository.go
+++ b/api/repositories/buildpack_repository.go
@@ -61,7 +61,7 @@ func clusterBuilderToBuildpackRecords(builder *buildv1alpha2.ClusterBuilder) []B
 		currentRecord := BuildpackRecord{
 			Name:      orderEntry.Group[0].Id,
 			Position:  i + 1,
-			Stack:     builder.Spec.Stack.Name,
+			Stack:     builder.Status.Stack.ID,
 			Version:   orderEntry.Group[0].Version,
 			CreatedAt: builder.CreationTimestamp.UTC().Format(TimestampFormat),
 			UpdatedAt: updatedAtTime,

--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -99,6 +99,12 @@ var _ = Describe("BuildpackRepository", func() {
 			}
 			clusterBuilder.Status.Order = clusterBuilderOrderStatus
 
+			clusterBuilderStackStatus := buildv1alpha1.BuildStack{
+				ID:       "io.buildpacks.stacks.bionic",
+				RunImage: "index.docker.io/paketobuildpacks/run@sha256:79185c8427ebfed9b7df3e0fa12e101ec8b24aa899bbc541648d5923fb494084",
+			}
+			clusterBuilder.Status.Stack = clusterBuilderStackStatus
+
 			Expect(k8sClient.Status().Update(beforeCtx, clusterBuilder)).To(Succeed())
 			DeferCleanup(func() {
 				_ = k8sClient.Delete(context.Background(), clusterBuilder)
@@ -117,19 +123,19 @@ var _ = Describe("BuildpackRepository", func() {
 					MatchFields(IgnoreExtras, Fields{
 						"Name":     Equal("paketo-buildpacks/buildpack-1-1"),
 						"Position": Equal(1),
-						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Stack":    Equal("io.buildpacks.stacks.bionic"),
 						"Version":  Equal("1.1"),
 					}),
 					MatchFields(IgnoreExtras, Fields{
 						"Name":     Equal("paketo-buildpacks/buildpack-2-1"),
 						"Position": Equal(2),
-						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Stack":    Equal("io.buildpacks.stacks.bionic"),
 						"Version":  Equal("2.1"),
 					}),
 					MatchFields(IgnoreExtras, Fields{
 						"Name":     Equal("paketo-buildpacks/buildpack-3-1"),
 						"Position": Equal(3),
-						"Stack":    Equal(clusterBuilder.Spec.Stack.Name),
+						"Stack":    Equal("io.buildpacks.stacks.bionic"),
 						"Version":  Equal("3.1"),
 					}),
 				))


### PR DESCRIPTION
## Is there a related GitHub Issue?
Issue: https://github.com/cloudfoundry/cf-k8s-controllers/issues/575

## What is this change about?
The Stack/ClusterStack name in a Builder's Spec is often something generic like "default" or "base". This change uses the Stack ID from the Builder's Status which typically includes more meaningful information for developers (typically something like `io.buildpacks.stacks.bionic`) that conveys details about the base OS.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
1. Deploy and run `cf buildpacks`. Should see something like this:

```
11:52 $ cf buildpacks
Getting buildpacks as tdowney...

position   name                         stack                         enabled   locked   filename
1          paketo-buildpacks/java       io.buildpacks.stacks.bionic   true      false    paketo-buildpacks/java@6.7.1
2          paketo-buildpacks/go         io.buildpacks.stacks.bionic   true      false    paketo-buildpacks/go@0.13.2
3          paketo-buildpacks/nodejs     io.buildpacks.stacks.bionic   true      false    paketo-buildpacks/nodejs@0.12.0
4          paketo-buildpacks/ruby       io.buildpacks.stacks.bionic   true      false    paketo-buildpacks/ruby@0.10.0
5          paketo-buildpacks/procfile   io.buildpacks.stacks.bionic   true      false    paketo-buildpacks/procfile@5.0.2
```

## Tag your pair, your PM, and/or team
@gnovv 

