### PR TITLE
Fix query param filtering to allow empty strings

### DIFF
--- a/api/payloads/app.go
+++ b/api/payloads/app.go
@@ -55,10 +55,10 @@ type AppSetCurrentDroplet struct {
 }
 
 type AppList struct {
-	Names      string `schema:"names"`
-	GUIDs      string `schema:"guids"`
-	SpaceGuids string `schema:"space_guids"`
-	OrderBy    string `schema:"order_by"`
+	Names      *string `schema:"names"`
+	GUIDs      *string `schema:"guids"`
+	SpaceGuids *string `schema:"space_guids"`
+	OrderBy    string  `schema:"order_by"`
 }
 
 func (a *AppList) ToMessage() repositories.ListAppsMessage {

--- a/api/payloads/app_test.go
+++ b/api/payloads/app_test.go
@@ -10,7 +10,8 @@ var _ = Describe("AppList", func() {
 		Describe("names", func() {
 			When("a single name is specified", func() {
 				It("properly splits them in the message", func() {
-					payload := AppList{Names: "example.com"}
+					names := "example.com"
+					payload := AppList{Names: &names}
 
 					Expect(payload.ToMessage().Names).To(Equal([]string{"example.com"}))
 				})
@@ -18,7 +19,8 @@ var _ = Describe("AppList", func() {
 
 			When("multiple names are specified", func() {
 				It("properly splits them in the message and truncates whitespace", func() {
-					payload := AppList{Names: " example.com, example.org ,cloudfoundry.org "}
+					names := " example.com, example.org ,cloudfoundry.org "
+					payload := AppList{Names: &names}
 
 					Expect(payload.ToMessage().Names).To(Equal([]string{"example.com", "example.org", "cloudfoundry.org"}))
 				})
@@ -37,7 +39,8 @@ var _ = Describe("AppList", func() {
 		Describe("space_guids", func() {
 			When("a single space guid is specified", func() {
 				It("properly splits them in the message", func() {
-					payload := AppList{SpaceGuids: "f6dea88f-0781-4461-b8d9-09fd6f5a0f40"}
+					spaceGuids := "f6dea88f-0781-4461-b8d9-09fd6f5a0f40"
+					payload := AppList{SpaceGuids: &spaceGuids}
 
 					Expect(payload.ToMessage().SpaceGuids).To(Equal([]string{"f6dea88f-0781-4461-b8d9-09fd6f5a0f40"}))
 				})
@@ -45,7 +48,8 @@ var _ = Describe("AppList", func() {
 
 			When("multiple space guids are specified", func() {
 				It("properly splits them in the message and truncates whitespace", func() {
-					payload := AppList{SpaceGuids: " f6dea88f-0781-4461-b8d9-09fd6f5a0f40, ad0836b5-09f4-48c0-adb2-2c61e515562f ,6030b015-f003-4c9f-8bb4-1ed7ae3d3659 "}
+					spaceGuids := " f6dea88f-0781-4461-b8d9-09fd6f5a0f40, ad0836b5-09f4-48c0-adb2-2c61e515562f ,6030b015-f003-4c9f-8bb4-1ed7ae3d3659 "
+					payload := AppList{SpaceGuids: &spaceGuids}
 
 					Expect(payload.ToMessage().SpaceGuids).To(Equal([]string{"f6dea88f-0781-4461-b8d9-09fd6f5a0f40", "ad0836b5-09f4-48c0-adb2-2c61e515562f", "6030b015-f003-4c9f-8bb4-1ed7ae3d3659"}))
 				})

--- a/api/payloads/domain.go
+++ b/api/payloads/domain.go
@@ -5,7 +5,7 @@ import (
 )
 
 type DomainList struct {
-	Names string `schema:"names"`
+	Names *string `schema:"names"`
 }
 
 func (d *DomainList) ToMessage() repositories.ListDomainsMessage {

--- a/api/payloads/domain_test.go
+++ b/api/payloads/domain_test.go
@@ -9,7 +9,8 @@ var _ = Describe("DomainList", func() {
 	Describe("ToMessage", func() {
 		When("a single name is specified", func() {
 			It("properly splits them in the message", func() {
-				payload := DomainList{Names: "example.com"}
+				names := "example.com"
+				payload := DomainList{Names: &names}
 
 				Expect(payload.ToMessage().Names).To(Equal([]string{"example.com"}))
 			})
@@ -17,7 +18,8 @@ var _ = Describe("DomainList", func() {
 
 		When("multiple names are specified", func() {
 			It("properly splits them in the message and truncates whitespace", func() {
-				payload := DomainList{Names: " example.com, example.org ,cloudfoundry.org "}
+				names := " example.com, example.org ,cloudfoundry.org "
+				payload := DomainList{Names: &names}
 
 				Expect(payload.ToMessage().Names).To(Equal([]string{"example.com", "example.org", "cloudfoundry.org"}))
 			})

--- a/api/payloads/package.go
+++ b/api/payloads/package.go
@@ -32,9 +32,9 @@ func (m PackageCreate) ToMessage(record repositories.AppRecord) repositories.Cre
 }
 
 type PackageListQueryParameters struct {
-	AppGUIDs string `schema:"app_guids"`
-	OrderBy  string `schema:"order_by"`
-	States   string `schema:"states"`
+	AppGUIDs *string `schema:"app_guids"`
+	States   *string `schema:"states"`
+	OrderBy  string  `schema:"order_by"`
 
 	// Below parameters are ignored, but must be included to ignore as query parameters
 	PerPage string `schema:"per_page"`
@@ -49,9 +49,9 @@ func (p *PackageListQueryParameters) ToMessage() repositories.ListPackagesMessag
 
 	return repositories.ListPackagesMessage{
 		AppGUIDs:        parseArrayParam(p.AppGUIDs),
+		States:          parseArrayParam(p.States),
 		SortBy:          strings.TrimPrefix(p.OrderBy, "-"),
 		DescendingOrder: descendingOrder,
-		States:          parseArrayParam(p.States),
 	}
 }
 

--- a/api/payloads/process.go
+++ b/api/payloads/process.go
@@ -17,7 +17,7 @@ func (p ProcessScale) ToRecord() repositories.ProcessScaleValues {
 }
 
 type ProcessList struct {
-	AppGUIDs string `schema:"app_guids"`
+	AppGUIDs *string `schema:"app_guids"`
 }
 
 func (p *ProcessList) ToMessage() repositories.ListProcessesMessage {

--- a/api/payloads/route.go
+++ b/api/payloads/route.go
@@ -28,11 +28,11 @@ func (p RouteCreate) ToMessage() repositories.CreateRouteMessage {
 }
 
 type RouteList struct {
-	AppGUIDs    string `schema:"app_guids"`
-	SpaceGUIDs  string `schema:"space_guids"`
-	DomainGUIDs string `schema:"domain_guids"`
-	Hosts       string `schema:"hosts"`
-	Paths       string `schema:"paths"`
+	AppGUIDs    *string `schema:"app_guids"`
+	SpaceGUIDs  *string `schema:"space_guids"`
+	DomainGUIDs *string `schema:"domain_guids"`
+	Hosts       *string `schema:"hosts"`
+	Paths       *string `schema:"paths"`
 }
 
 func (p *RouteList) ToMessage() repositories.ListRoutesMessage {

--- a/api/payloads/shared.go
+++ b/api/payloads/shared.go
@@ -25,14 +25,15 @@ type Metadata struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-func parseArrayParam(arrayParam string) []string {
-	if arrayParam == "" {
+func parseArrayParam(arrayParam *string) []string {
+	if arrayParam == nil {
 		return []string{}
 	}
 
-	elements := strings.Split(arrayParam, ",")
+	elements := strings.Split(*arrayParam, ",")
 	for i, e := range elements {
 		elements[i] = strings.TrimSpace(e)
 	}
+
 	return elements
 }

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -371,6 +371,17 @@ var _ = Describe("RouteRepository", func() {
 					})
 					It("eventually returns a list of routeRecords for one of the CFRoute CRs", func() {
 						Expect(routeRecords).To(HaveLen(1))
+						Expect(routeRecords[0].Path).To(Equal("/some/path"))
+					})
+				})
+
+				When("an empty path filter is provided", func() {
+					BeforeEach(func() {
+						message = ListRoutesMessage{Paths: []string{""}}
+					})
+					It("eventually returns a list of routeRecords for one of the CFRoute CRs", func() {
+						Expect(routeRecords).To(HaveLen(1))
+						Expect(routeRecords[0].Path).To(Equal(""))
 					})
 				})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#567

## What is this change about?
Fixes query param filtering for list endpoints.

## Acceptance Steps
* Setup cf-k8s-controllers
* Create Route with empty string path
* Create Route with populated path
* List Routes with param `cf curl /v3/routes?paths=`
* See that only empty string path Route is returned.

## Tag your pair, your PM, and/or team
@davewalter @akrishna90 @gnovv 