### PR TITLE
Add helpful instruction to create-new-user script

### DIFF
--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -15,21 +15,27 @@ username="$1"
 priv_key_file="$(mktemp)"
 csr_file="$(mktemp)"
 cert_file="$(mktemp)"
-csr_name="$(echo $RANDOM | shasum | head -c 40)"
+csr_name="$(echo ${RANDOM} | shasum | head -c 40)"
 
-openssl req -new -newkey rsa:4096 -keyout "$priv_key_file" -nodes -out "$csr_file" -subj "/CN=$username"
+openssl req -new -newkey rsa:4096 -keyout "${priv_key_file}" -nodes -out "${csr_file}" -subj "/CN=${username}"
 
 cat <<EOF | kubectl create -f -
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
-  name: $csr_name
+  name: ${csr_name}
 spec:
   signerName: "kubernetes.io/kube-apiserver-client"
-  request: "$(base64 "$csr_file" | tr -d '\n')"
+  request: "$(base64 "${csr_file}" | tr -d '\n')"
   usages:
   - client auth
 EOF
-kubectl certificate approve "$csr_name"
-kubectl get csr "$csr_name" -o jsonpath='{.status.certificate}' | base64 --decode >"$cert_file"
-kubectl config set-credentials "$username" --client-certificate="$cert_file" --client-key="$priv_key_file" --embed-certs
+
+kubectl certificate approve "${csr_name}"
+kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}' | base64 --decode >"${cert_file}"
+kubectl config set-credentials "${username}" --client-certificate="${cert_file}" --client-key="${priv_key_file}" --embed-certs
+
+cat<<EOF
+
+Use "cf set-space-role ${username} ORG SPACE SpaceDeveloper" to grant this user permissions in a space.
+EOF


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This PR adds output to the `create-new-user` script to tell the user how to grant space developer permissions to the new user.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Create a cluster, run the `create-new-user` script, and see the output with the sample `cf set-space-role` command.
