### PR TITLE
Use client.MatchingFields to find resources by name

### DIFF
--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -129,15 +129,12 @@ func (m CreateRouteMessage) toCFRoute() networkingv1alpha1.CFRoute {
 func (f *RouteRepo) GetRoute(ctx context.Context, authInfo authorization.Info, routeGUID string) (RouteRecord, error) {
 	// TODO: Could look up namespace from guid => namespace cache to do Get
 	cfRouteList := &networkingv1alpha1.CFRouteList{}
-	err := f.privilegedClient.List(ctx, cfRouteList)
+	err := f.privilegedClient.List(ctx, cfRouteList, client.MatchingFields{"metadata.name": routeGUID})
 	if err != nil {
 		return RouteRecord{}, err
 	}
 
-	routeList := cfRouteList.Items
-	filteredRouteList := filterByRouteName(routeList, routeGUID)
-
-	toReturn, err := returnRoute(filteredRouteList)
+	toReturn, err := returnRoute(cfRouteList.Items)
 	return toReturn, err
 }
 
@@ -250,18 +247,6 @@ func (r RouteRecord) UpdateDomainRef(d DomainRecord) RouteRecord {
 	r.Domain = d
 
 	return r
-}
-
-func filterByRouteName(routeList []networkingv1alpha1.CFRoute, name string) []networkingv1alpha1.CFRoute {
-	var filtered []networkingv1alpha1.CFRoute
-
-	for i, route := range routeList {
-		if route.Name == name {
-			filtered = append(filtered, routeList[i])
-		}
-	}
-
-	return filtered
 }
 
 func filterByAppDestination(routeList []networkingv1alpha1.CFRoute, appGUID string) []networkingv1alpha1.CFRoute {

--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -35,7 +35,7 @@ kubectl certificate approve "${csr_name}"
 kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}' | base64 --decode >"${cert_file}"
 kubectl config set-credentials "${username}" --client-certificate="${cert_file}" --client-key="${priv_key_file}" --embed-certs
 
-cat<<EOF
+cat <<EOF
 
 Use "cf set-space-role ${username} ORG SPACE SpaceDeveloper" to grant this user permissions in a space.
 EOF


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Use client.MatchingFields to find resource by name instead of doing it manually as it is also probably more efficient and we can eventually take advantage of controller-runtime cache.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@kieron-dev 
