### PR TITLE
Clean up the apps end-to-end tests

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -2,20 +2,24 @@ package e2e_test
 
 import (
 	"net/http"
-	"sync"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
+	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Apps", func() {
 	var (
-		org    presenter.OrgResponse
-		space1 presenter.SpaceResponse
+		org      presenter.OrgResponse
+		space1   presenter.SpaceResponse
+		app      presenter.AppResponse
+		result   map[string]interface{}
+		httpResp *resty.Response
+		httpErr  error
 	)
 
 	BeforeEach(func() {
@@ -28,7 +32,7 @@ var _ = Describe("Apps", func() {
 		deleteSubnamespace(rootNamespace, org.GUID)
 	})
 
-	Describe("List", func() {
+	Describe("List apps", func() {
 		var (
 			space2, space3                     presenter.SpaceResponse
 			app1, app2, app3, app4, app5, app6 presenter.AppResponse
@@ -41,38 +45,33 @@ var _ = Describe("Apps", func() {
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space3.GUID, adminAuthHeader)
 
-			app1 = createApp(space1.GUID, generateGUID("app1"), adminAuthHeader)
-			app2 = createApp(space1.GUID, generateGUID("app2"), adminAuthHeader)
-			app3 = createApp(space2.GUID, generateGUID("app3"), adminAuthHeader)
-			app4 = createApp(space2.GUID, generateGUID("app4"), adminAuthHeader)
-			app5 = createApp(space3.GUID, generateGUID("app5"), adminAuthHeader)
-			app6 = createApp(space3.GUID, generateGUID("app6"), adminAuthHeader)
-
-			_, _ = app3, app4
+			app1 = createApp(space1.GUID, generateGUID("app1"))
+			app2 = createApp(space1.GUID, generateGUID("app2"))
+			app3 = createApp(space2.GUID, generateGUID("app3"))
+			app4 = createApp(space2.GUID, generateGUID("app4"))
+			app5 = createApp(space3.GUID, generateGUID("app5"))
+			app6 = createApp(space3.GUID, generateGUID("app6"))
 		})
 
-		AfterEach(func() {
-			var wg sync.WaitGroup
-			wg.Add(2)
-			for _, id := range []string{space2.GUID, space3.GUID} {
-				asyncDeleteSubnamespace(org.GUID, id, &wg)
-			}
-			wg.Wait()
+		JustBeforeEach(func() {
+			httpResp, httpErr = certClient.R().SetResult(&result).Get("/v3/apps")
 		})
 
 		It("returns apps only in authorized spaces", func() {
-			apps, err := get("/v3/apps", certAuthHeader)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(SatisfyAll(
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+
+			Expect(result).To(
 				HaveKeyWithValue("pagination", HaveKeyWithValue("total_results", BeNumerically(">=", 4))),
 				HaveKeyWithValue("resources", ContainElements(
 					HaveKeyWithValue("name", app1.Name),
 					HaveKeyWithValue("name", app2.Name),
 					HaveKeyWithValue("name", app5.Name),
 					HaveKeyWithValue("name", app6.Name),
-				))))
+				)),
+			)
 
-			Expect(apps).ToNot(
+			Expect(result).ToNot(
 				HaveKeyWithValue("resources", ContainElements(
 					HaveKeyWithValue("name", app3.Name),
 					HaveKeyWithValue("name", app4.Name),
@@ -80,22 +79,24 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
-	Describe("Create", func() {
-		var (
-			createResponse *http.Response
-			createErr      error
-		)
-
+	Describe("Create an app", func() {
 		JustBeforeEach(func() {
-			appGUID := generateGUID("app")
-			createResponse, createErr = createAppRaw(space1.GUID, appGUID, certAuthHeader)
+			httpResp, httpErr = certClient.R().SetBody(map[string]interface{}{
+				"name": generateGUID("app"),
+				"relationships": map[string]interface{}{
+					"space": map[string]interface{}{
+						"data": map[string]interface{}{
+							"guid": space1.GUID,
+						},
+					},
+				},
+			}).Post("/v3/apps")
 		})
 
 		It("fails", func() {
-			Expect(createErr).NotTo(HaveOccurred())
-			defer createResponse.Body.Close()
-			Expect(createResponse).To(HaveHTTPStatus(http.StatusForbidden))
-			Expect(createResponse).To(HaveHTTPBody(ContainSubstring("CF-NotAuthorized")))
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusForbidden))
+			Expect(httpResp.Body()).To(ContainSubstring("CF-NotAuthorized"))
 		})
 
 		When("the user has space developer role in the space", func() {
@@ -104,127 +105,134 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("succeeds", func() {
-				Expect(createErr).NotTo(HaveOccurred())
-				defer createResponse.Body.Close()
-				Expect(createResponse).To(HaveHTTPStatus(http.StatusCreated))
+				Expect(httpErr).NotTo(HaveOccurred())
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusCreated))
 			})
 		})
 	})
 
-	Describe("Fetch App", func() {
-		var app presenter.AppResponse
-
+	Describe("Fetch an app", func() {
 		BeforeEach(func() {
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
-			app = createApp(space1.GUID, generateGUID("app1"), adminAuthHeader)
+			app = createApp(space1.GUID, generateGUID("app1"))
+		})
+
+		JustBeforeEach(func() {
+			httpResp, httpErr = certClient.R().SetResult(&result).Get("/v3/apps/" + app.GUID)
 		})
 
 		It("can fetch the app", func() {
-			appResponse, err := get("/v3/apps/"+app.GUID, certAuthHeader)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(appResponse).To(SatisfyAll(
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(result).To(SatisfyAll(
 				HaveKeyWithValue("name", app.Name),
 				HaveKeyWithValue("guid", app.GUID),
 			))
 		})
 	})
 
-	Describe("list processes for an app", func() {
-		var app presenter.AppResponse
-
+	Describe("List app processes", func() {
 		BeforeEach(func() {
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
-			app = createApp(space1.GUID, generateGUID("app"), adminAuthHeader)
+			app = createApp(space1.GUID, generateGUID("app"))
+		})
+
+		JustBeforeEach(func() {
+			httpResp, httpErr = certClient.R().SetResult(&result).Get("/v3/apps/" + app.GUID + "/processes")
 		})
 
 		It("successfully lists the empty set of processes", func() {
-			resp, err := get("/v3/apps/"+app.GUID+"/processes", certAuthHeader)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(HaveKeyWithValue("resources", BeEmpty()))
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(result).To(HaveKeyWithValue("resources", BeEmpty()))
 		})
 	})
 
-	Describe("list routes for an app", func() {
-		var app presenter.AppResponse
-
+	Describe("List app routes", func() {
 		BeforeEach(func() {
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
-			app = createApp(space1.GUID, generateGUID("app"), adminAuthHeader)
+			app = createApp(space1.GUID, generateGUID("app"))
+		})
+
+		JustBeforeEach(func() {
+			httpResp, httpErr = certClient.R().SetResult(&result).Get("/v3/apps/" + app.GUID + "/routes")
 		})
 
 		It("successfully lists the empty set of processes", func() {
-			resp, err := get("/v3/apps/"+app.GUID+"/routes", certAuthHeader)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(HaveKeyWithValue("resources", BeEmpty()))
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(result).To(HaveKeyWithValue("resources", BeEmpty()))
 		})
 	})
 
-	Describe("built apps", func() {
+	Describe("Built apps", func() {
 		var (
-			app      presenter.AppResponse
-			pkg      presenter.PackageResponse
-			build    presenter.BuildResponse
-			response map[string]interface{}
-			httpErr  error
+			pkg   presenter.PackageResponse
+			build presenter.BuildResponse
 		)
 
 		BeforeEach(func() {
-			app = createApp(space1.GUID, generateGUID("app"), adminAuthHeader)
+			app = createApp(space1.GUID, generateGUID("app"))
 			pkg = createPackage(app.GUID, adminAuthHeader)
 			uploadNodeApp(pkg.GUID, adminAuthHeader)
 			build = createBuild(pkg.GUID, adminAuthHeader)
-			Eventually(func() error {
-				_, err := get("/v3/droplets/"+build.GUID, adminAuthHeader)
-				return err
-			}).Should(Succeed())
+
+			Eventually(func() (int, error) {
+				resp, err := adminClient.R().Get("/v3/droplets/" + build.GUID)
+				return resp.StatusCode(), err
+			}).Should(Equal(http.StatusOK))
 
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1.GUID, adminAuthHeader)
 		})
 
-		Describe("get current droplet", func() {
+		Describe("Get app current droplet", func() {
 			BeforeEach(func() {
 				setCurrentDroplet(app.GUID, build.GUID, adminAuthHeader)
 			})
 
 			JustBeforeEach(func() {
-				response, httpErr = get("/v3/apps/"+app.GUID+"/droplets/current", certAuthHeader)
+				httpResp, httpErr = certClient.R().SetResult(&result).Get("/v3/apps/" + app.GUID + "/droplets/current")
 			})
 
 			It("succeeds", func() {
 				Expect(httpErr).NotTo(HaveOccurred())
-				Expect(response).To(HaveKeyWithValue("state", "STAGED"))
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(result).To(HaveKeyWithValue("state", "STAGED"))
 			})
 		})
 
-		Describe("set current droplet", func() {
+		Describe("Set app current droplet", func() {
 			JustBeforeEach(func() {
-				response, httpErr = patch("/v3/apps/"+app.GUID+"/relationships/current_droplet", certAuthHeader, payloads.AppSetCurrentDroplet{
-					Relationship: payloads.Relationship{
-						Data: &payloads.RelationshipData{
-							GUID: build.GUID,
+				httpResp, httpErr = certClient.R().
+					SetBody(map[string]interface{}{
+						"data": map[string]interface{}{
+							"guid": build.GUID,
 						},
-					},
-				})
+					}).
+					SetResult(&result).
+					Patch("/v3/apps/" + app.GUID + "/relationships/current_droplet")
 			})
 
 			It("returns 200", func() {
 				Expect(httpErr).NotTo(HaveOccurred())
-				Expect(response).To(HaveKeyWithValue("data", HaveKeyWithValue("guid", build.GUID)))
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(result).To(HaveKeyWithValue("data", HaveKeyWithValue("guid", build.GUID)))
 			})
 		})
 
-		Describe("app restart", func() {
+		Describe("Restart an app", func() {
 			BeforeEach(func() {
 				setCurrentDroplet(app.GUID, build.GUID, adminAuthHeader)
 			})
 
 			JustBeforeEach(func() {
-				response, httpErr = post("/v3/apps/"+app.GUID+"/actions/restart", certAuthHeader, nil)
+				httpResp, httpErr = certClient.R().SetResult(&result).Post("/v3/apps/" + app.GUID + "/actions/restart")
 			})
 
 			It("succeeds", func() {
 				Expect(httpErr).NotTo(HaveOccurred())
-				Expect(response).To(HaveKeyWithValue("state", "STARTED"))
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(result).To(HaveKeyWithValue("state", "STARTED"))
 			})
 		})
 	})

--- a/api/tests/e2e/builds_test.go
+++ b/api/tests/e2e/builds_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Builds", func() {
 		)
 
 		BeforeEach(func() {
-			app = createApp(space.GUID, generateGUID("app"), adminAuthHeader)
+			app = createApp(space.GUID, generateGUID("app"))
 			pkg = createPackage(app.GUID, adminAuthHeader)
 			uploadNodeApp(pkg.GUID, adminAuthHeader)
 			build = createBuild(pkg.GUID, adminAuthHeader)

--- a/api/tests/e2e/droplets_test.go
+++ b/api/tests/e2e/droplets_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Droplets", func() {
 		)
 
 		BeforeEach(func() {
-			app = createApp(space.GUID, generateGUID("app"), adminAuthHeader)
+			app = createApp(space.GUID, generateGUID("app"))
 			pkg = createPackage(app.GUID, adminAuthHeader)
 			uploadNodeApp(pkg.GUID, adminAuthHeader)
 			build = createBuild(pkg.GUID, adminAuthHeader)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.10.0
+	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-containerregistry v0.8.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -818,6 +818,8 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -2140,6 +2142,7 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211111160137-58aab5ef257a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211203184738-4852103109b8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/484

## What is this change about?
Tidying up the e2e tests by using a rest client library. This makes the tests more explicit and more readable.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests
## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 
