### PR TITLE
Use single payload validator in all handles

### DIFF
--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -48,6 +48,8 @@ var _ = Describe("AppHandler", func() {
 		domainRepo = new(fake.CFDomainRepository)
 		podRepo = new(fake.PodRepository)
 		scaleAppProcessFunc = new(fake.ScaleAppProcess)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		apiHandler := NewAppHandler(
 			logf.Log.WithName(testAppHandlerLoggerName),
@@ -59,6 +61,7 @@ var _ = Describe("AppHandler", func() {
 			domainRepo,
 			podRepo,
 			scaleAppProcessFunc.Spy,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 	})

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -27,10 +27,11 @@ type CFBuildRepository interface {
 }
 
 type BuildHandler struct {
-	serverURL   url.URL
-	buildRepo   CFBuildRepository
-	packageRepo CFPackageRepository
-	logger      logr.Logger
+	serverURL        url.URL
+	buildRepo        CFBuildRepository
+	packageRepo      CFPackageRepository
+	logger           logr.Logger
+	decoderValidator *DecoderValidator
 }
 
 func NewBuildHandler(
@@ -38,12 +39,14 @@ func NewBuildHandler(
 	serverURL url.URL,
 	buildRepo CFBuildRepository,
 	packageRepo CFPackageRepository,
+	decoderValidator *DecoderValidator,
 ) *BuildHandler {
 	return &BuildHandler{
-		logger:      logger,
-		serverURL:   serverURL,
-		buildRepo:   buildRepo,
-		packageRepo: packageRepo,
+		logger:           logger,
+		serverURL:        serverURL,
+		buildRepo:        buildRepo,
+		packageRepo:      packageRepo,
+		decoderValidator: decoderValidator,
 	}
 }
 
@@ -71,7 +74,7 @@ func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, w http.Re
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.BuildCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -67,11 +67,15 @@ var _ = Describe("BuildHandler", func() {
 			req, err = http.NewRequestWithContext(ctx, "GET", "/v3/builds/"+buildGUID, nil)
 			Expect(err).NotTo(HaveOccurred())
 
+			decoderValidator, err := NewDefaultDecoderValidator()
+			Expect(err).NotTo(HaveOccurred())
+
 			buildHandler := NewBuildHandler(
 				logf.Log.WithName(testBuildHandlerLoggerName),
 				*serverURL,
 				buildRepo,
 				new(fake.CFPackageRepository),
+				decoderValidator,
 			)
 			buildHandler.RegisterRoutes(router)
 		})
@@ -403,11 +407,15 @@ var _ = Describe("BuildHandler", func() {
 				AppGUID:     appGUID,
 			}, nil)
 
+			decoderValidator, err := NewDefaultDecoderValidator()
+			Expect(err).NotTo(HaveOccurred())
+
 			buildHandler := NewBuildHandler(
 				logf.Log.WithName(testBuildHandlerLoggerName),
 				*serverURL,
 				buildRepo,
 				packageRepo,
+				decoderValidator,
 			)
 			buildHandler.RegisterRoutes(router)
 		})

--- a/api/apis/integration/app_test.go
+++ b/api/apis/integration/app_test.go
@@ -45,6 +45,8 @@ var _ = Describe("App Handler", func() {
 		podRepo := repositories.NewPodRepo(k8sClient)
 		scaleProcess := actions.NewScaleProcess(processRepo).Invoke
 		scaleAppProcess := actions.NewScaleAppProcess(appRepo, processRepo, scaleProcess).Invoke
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		apiHandler = NewAppHandler(
 			logf.Log.WithName("integration tests"),
@@ -56,6 +58,7 @@ var _ = Describe("App Handler", func() {
 			domainRepo,
 			podRepo,
 			scaleAppProcess,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -36,11 +36,15 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 		processRepo := repositories.NewProcessRepo(k8sClient)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+
 		apiHandler := NewSpaceManifestHandler(
 			logf.Log.WithName("integration tests"),
 			*serverURL,
 			actions.NewApplyManifest(appRepo, domainRepo, processRepo, routeRepo).Invoke,
 			repositories.NewOrgRepo("cf", k8sClient, clientFactory, namespacePermissions, 1*time.Minute, true),
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 	})

--- a/api/apis/integration/build_test.go
+++ b/api/apis/integration/build_test.go
@@ -23,12 +23,15 @@ var _ = Describe("Build", func() {
 		userClientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
 		buildRepo := repositories.NewBuildRepo(k8sClient, userClientFactory)
 		packageRepo := repositories.NewPackageRepo(k8sClient)
+		decoderValidator, err := apis.NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		buildHandler = apis.NewBuildHandler(
 			logf.Log.WithName("integration tests"),
 			*serverURL,
 			buildRepo,
 			packageRepo,
+			decoderValidator,
 		)
 		buildHandler.RegisterRoutes(router)
 

--- a/api/apis/integration/get_app_env_test.go
+++ b/api/apis/integration/get_app_env_test.go
@@ -36,6 +36,8 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 		podRepo := repositories.NewPodRepo(k8sClient)
 		scaleProcess := actions.NewScaleProcess(processRepo).Invoke
 		scaleAppProcess := actions.NewScaleAppProcess(appRepo, processRepo, scaleProcess).Invoke
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		apiHandler := NewAppHandler(
 			logf.Log.WithName("integration tests"),
@@ -47,6 +49,7 @@ var _ = Describe("GET /v3/apps/:guid/env", func() {
 			domainRepo,
 			podRepo,
 			scaleAppProcess,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 

--- a/api/apis/integration/route_test.go
+++ b/api/apis/integration/route_test.go
@@ -35,6 +35,8 @@ var _ = Describe("Route Handler", func() {
 		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		apiHandler = NewRouteHandler(
 			logf.Log.WithName("TestRouteHandler"),
@@ -42,6 +44,7 @@ var _ = Describe("Route Handler", func() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -31,16 +31,18 @@ type CFOrgRepository interface {
 }
 
 type OrgHandler struct {
-	logger     logr.Logger
-	apiBaseURL url.URL
-	orgRepo    CFOrgRepository
+	logger           logr.Logger
+	apiBaseURL       url.URL
+	orgRepo          CFOrgRepository
+	decoderValidator *DecoderValidator
 }
 
-func NewOrgHandler(apiBaseURL url.URL, orgRepo CFOrgRepository) *OrgHandler {
+func NewOrgHandler(apiBaseURL url.URL, orgRepo CFOrgRepository, decoderValidator *DecoderValidator) *OrgHandler {
 	return &OrgHandler{
-		logger:     controllerruntime.Log.WithName("Org Handler"),
-		apiBaseURL: apiBaseURL,
-		orgRepo:    orgRepo,
+		logger:           controllerruntime.Log.WithName("Org Handler"),
+		apiBaseURL:       apiBaseURL,
+		orgRepo:          orgRepo,
+		decoderValidator: decoderValidator,
 	}
 }
 
@@ -48,7 +50,7 @@ func (h *OrgHandler) orgCreateHandler(info authorization.Info, w http.ResponseWr
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.OrgCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -38,8 +38,10 @@ var _ = Describe("OrgHandler", func() {
 		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
 
 		orgRepo = new(fake.OrgRepository)
+		decoderValidator, err := apis.NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
-		orgHandler = apis.NewOrgHandler(*serverURL, orgRepo)
+		orgHandler = apis.NewOrgHandler(*serverURL, orgRepo, decoderValidator)
 		orgHandler.RegisterRoutes(router)
 	})
 

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -52,6 +52,7 @@ type PackageHandler struct {
 	dropletRepo        CFDropletRepository
 	uploadSourceImage  SourceImageUploader
 	buildRegistryAuth  RegistryAuthBuilder
+	decoderValidator   *DecoderValidator
 	registryBase       string
 	registrySecretName string
 }
@@ -64,6 +65,7 @@ func NewPackageHandler(
 	dropletRepo CFDropletRepository,
 	uploadSourceImage SourceImageUploader,
 	buildRegistryAuth RegistryAuthBuilder,
+	decoderValidator *DecoderValidator,
 	registryBase string,
 	registrySecretName string) *PackageHandler {
 	return &PackageHandler{
@@ -76,6 +78,7 @@ func NewPackageHandler(
 		buildRegistryAuth:  buildRegistryAuth,
 		registryBase:       registryBase,
 		registrySecretName: registrySecretName,
+		decoderValidator:   decoderValidator,
 	}
 }
 
@@ -154,7 +157,7 @@ func (h PackageHandler) packageCreateHandler(authInfo authorization.Info, w http
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.PackageCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -48,6 +48,9 @@ var _ = Describe("PackageHandler", func() {
 	})
 
 	JustBeforeEach(func() {
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+
 		apiHandler := NewPackageHandler(
 			logf.Log.WithName(testPackageHandlerLoggerName),
 			*serverURL,
@@ -56,6 +59,7 @@ var _ = Describe("PackageHandler", func() {
 			dropletRepo,
 			uploadImageSource.Spy,
 			buildRegistryAuth.Spy,
+			decoderValidator,
 			packageRegistryBase,
 			packageImagePullSecretName,
 		)

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -48,6 +48,7 @@ type ProcessHandler struct {
 	processRepo       CFProcessRepository
 	fetchProcessStats FetchProcessStats
 	scaleProcess      ScaleProcess
+	decoderValidator  *DecoderValidator
 }
 
 func NewProcessHandler(
@@ -56,6 +57,7 @@ func NewProcessHandler(
 	processRepo CFProcessRepository,
 	fetchProcessStats FetchProcessStats,
 	scaleProcessFunc ScaleProcess,
+	decoderValidator *DecoderValidator,
 ) *ProcessHandler {
 	return &ProcessHandler{
 		logger:            logger,
@@ -63,6 +65,7 @@ func NewProcessHandler(
 		processRepo:       processRepo,
 		fetchProcessStats: fetchProcessStats,
 		scaleProcess:      scaleProcessFunc,
+		decoderValidator:  decoderValidator,
 	}
 }
 
@@ -124,7 +127,7 @@ func (h *ProcessHandler) processScaleHandler(authInfo authorization.Info, w http
 	processGUID := vars["guid"]
 
 	var payload payloads.ProcessScale
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -33,6 +33,8 @@ var _ = Describe("ProcessHandler", func() {
 		processRepo = new(fake.CFProcessRepository)
 		fetchProcessStats = new(fake.FetchProcessStats)
 		scaleProcessFunc = new(fake.ScaleProcess)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		apiHandler := NewProcessHandler(
 			logf.Log.WithName(testAppHandlerLoggerName),
@@ -40,6 +42,7 @@ var _ = Describe("ProcessHandler", func() {
 			processRepo,
 			fetchProcessStats.Spy,
 			scaleProcessFunc.Spy,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 	})

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -44,16 +44,18 @@ type CFRoleRepository interface {
 }
 
 type RoleHandler struct {
-	logger     logr.Logger
-	apiBaseURL url.URL
-	roleRepo   CFRoleRepository
+	logger           logr.Logger
+	apiBaseURL       url.URL
+	roleRepo         CFRoleRepository
+	decoderValidator *DecoderValidator
 }
 
-func NewRoleHandler(apiBaseURL url.URL, roleRepo CFRoleRepository) *RoleHandler {
+func NewRoleHandler(apiBaseURL url.URL, roleRepo CFRoleRepository, decoderValidator *DecoderValidator) *RoleHandler {
 	return &RoleHandler{
-		logger:     controllerruntime.Log.WithName("Role Handler"),
-		apiBaseURL: apiBaseURL,
-		roleRepo:   roleRepo,
+		logger:           controllerruntime.Log.WithName("Role Handler"),
+		apiBaseURL:       apiBaseURL,
+		roleRepo:         roleRepo,
+		decoderValidator: decoderValidator,
 	}
 }
 
@@ -61,7 +63,7 @@ func (h *RoleHandler) roleCreateHandler(authInfo authorization.Info, w http.Resp
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.RoleCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		h.logger.Error(rme, "Failed to parse body")
 		writeRequestMalformedErrorResponse(w, rme)

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -32,8 +32,10 @@ var _ = Describe("RoleHandler", func() {
 		now = time.Unix(1631892190, 0) // 2021-09-17T15:23:10Z
 
 		roleRepo = new(fake.CFRoleRepository)
+		decoderValidator, err := apis.NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
-		roleHandler = apis.NewRoleHandler(*serverURL, roleRepo)
+		roleHandler = apis.NewRoleHandler(*serverURL, roleRepo, decoderValidator)
 		roleHandler.RegisterRoutes(router)
 	})
 

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -38,11 +38,12 @@ type CFRouteRepository interface {
 }
 
 type RouteHandler struct {
-	logger     logr.Logger
-	serverURL  url.URL
-	routeRepo  CFRouteRepository
-	domainRepo CFDomainRepository
-	appRepo    CFAppRepository
+	logger           logr.Logger
+	serverURL        url.URL
+	routeRepo        CFRouteRepository
+	domainRepo       CFDomainRepository
+	appRepo          CFAppRepository
+	decoderValidator *DecoderValidator
 }
 
 func NewRouteHandler(
@@ -51,13 +52,15 @@ func NewRouteHandler(
 	routeRepo CFRouteRepository,
 	domainRepo CFDomainRepository,
 	appRepo CFAppRepository,
+	decoderValidator *DecoderValidator,
 ) *RouteHandler {
 	return &RouteHandler{
-		logger:     logger,
-		serverURL:  serverURL,
-		routeRepo:  routeRepo,
-		domainRepo: domainRepo,
-		appRepo:    appRepo,
+		logger:           logger,
+		serverURL:        serverURL,
+		routeRepo:        routeRepo,
+		domainRepo:       domainRepo,
+		appRepo:          appRepo,
+		decoderValidator: decoderValidator,
 	}
 }
 
@@ -198,7 +201,7 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, w http.Re
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.RouteCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return
@@ -268,7 +271,7 @@ func (h *RouteHandler) routeAddDestinationsHandler(authInfo authorization.Info, 
 	w.Header().Set("Content-Type", "application/json")
 
 	var destinationCreatePayload payloads.DestinationListCreate
-	rme := decodeAndValidateJSONPayload(r, &destinationCreatePayload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &destinationCreatePayload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -44,6 +44,8 @@ var _ = Describe("RouteHandler", func() {
 		routeRepo = new(fake.CFRouteRepository)
 		domainRepo = new(fake.CFDomainRepository)
 		appRepo = new(fake.CFAppRepository)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
 
 		routeHandler := NewRouteHandler(
 			logf.Log.WithName("TestRouteHandler"),
@@ -51,6 +53,7 @@ var _ = Describe("RouteHandler", func() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			decoderValidator,
 		)
 		routeHandler.RegisterRoutes(router)
 	})

--- a/api/apis/service_instance_handler.go
+++ b/api/apis/service_instance_handler.go
@@ -36,6 +36,7 @@ type ServiceInstanceHandler struct {
 	serverURL           url.URL
 	serviceInstanceRepo CFServiceInstanceRepository
 	appRepo             CFAppRepository
+	decoderValidator    *DecoderValidator
 }
 
 func NewServiceInstanceHandler(
@@ -43,12 +44,14 @@ func NewServiceInstanceHandler(
 	serverURL url.URL,
 	serviceInstanceRepo CFServiceInstanceRepository,
 	appRepo CFAppRepository,
+	decoderValidator *DecoderValidator,
 ) *ServiceInstanceHandler {
 	return &ServiceInstanceHandler{
 		logger:              logger,
 		serverURL:           serverURL,
 		serviceInstanceRepo: serviceInstanceRepo,
 		appRepo:             appRepo,
+		decoderValidator:    decoderValidator,
 	}
 }
 
@@ -57,7 +60,7 @@ func (h *ServiceInstanceHandler) serviceInstanceCreateHandler(authInfo authoriza
 	w.Header().Set("Content-Type", "application/json")
 
 	var payload payloads.ServiceInstanceCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		writeRequestMalformedErrorResponse(w, rme)
 		return

--- a/api/apis/service_instance_handler_test.go
+++ b/api/apis/service_instance_handler_test.go
@@ -38,11 +38,15 @@ var _ = Describe("ServiceInstanceHandler", func() {
 	BeforeEach(func() {
 		serviceInstanceRepo = new(fake.CFServiceInstanceRepository)
 		appRepo = new(fake.CFAppRepository)
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+
 		serviceInstanceHandler := NewServiceInstanceHandler(
 			logf.Log.WithName(testServiceInstanceHandlerLoggerName),
 			*serverURL,
 			serviceInstanceRepo,
 			appRepo,
+			decoderValidator,
 		)
 		serviceInstanceHandler.RegisterRoutes(router)
 	})

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -40,14 +40,16 @@ type SpaceHandler struct {
 	logger                  logr.Logger
 	apiBaseURL              url.URL
 	imageRegistrySecretName string
+	decoderValidator        *DecoderValidator
 }
 
-func NewSpaceHandler(apiBaseURL url.URL, imageRegistrySecretName string, spaceRepo SpaceRepository) *SpaceHandler {
+func NewSpaceHandler(apiBaseURL url.URL, imageRegistrySecretName string, spaceRepo SpaceRepository, decoderValidator *DecoderValidator) *SpaceHandler {
 	return &SpaceHandler{
 		apiBaseURL:              apiBaseURL,
 		imageRegistrySecretName: imageRegistrySecretName,
 		spaceRepo:               spaceRepo,
 		logger:                  controllerruntime.Log.WithName("Space Handler"),
+		decoderValidator:        decoderValidator,
 	}
 }
 
@@ -55,7 +57,7 @@ func (h *SpaceHandler) SpaceCreateHandler(info authorization.Info, w http.Respon
 	ctx := r.Context()
 	w.Header().Set("Content-Type", "application/json")
 	var payload payloads.SpaceCreate
-	rme := decodeAndValidateJSONPayload(r, &payload)
+	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
 	if rme != nil {
 		h.logger.Error(rme, "Failed to decode and validate payload")
 		writeRequestMalformedErrorResponse(w, rme)

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -37,7 +37,15 @@ var _ = Describe("Spaces", func() {
 		requestBody = ""
 		requestPath = spacesBase
 		spaceRepo = new(fake.SpaceRepository)
-		spaceHandler = apis.NewSpaceHandler(*serverURL, registryCredentialsSecretName, spaceRepo)
+		decoderValidator, err := apis.NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+
+		spaceHandler = apis.NewSpaceHandler(
+			*serverURL,
+			registryCredentialsSecretName,
+			spaceRepo,
+			decoderValidator,
+		)
 		spaceHandler.RegisterRoutes(router)
 	})
 

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -46,11 +46,15 @@ var _ = Describe("SpaceManifestHandler", func() {
 			},
 		}, nil)
 
+		decoderValidator, err := NewDefaultDecoderValidator()
+		Expect(err).NotTo(HaveOccurred())
+
 		apiHandler := NewSpaceManifestHandler(
 			logf.Log.WithName("testSpaceManifestHandler"),
 			*serverURL,
 			applyManifestAction.Spy,
 			spaceRepo,
+			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)
 	})

--- a/api/main.go
+++ b/api/main.go
@@ -127,6 +127,11 @@ func main() {
 		routeRepo,
 	).Invoke
 
+	decoderValidator, err := apis.NewDefaultDecoderValidator()
+	if err != nil {
+		panic(fmt.Sprintf("could not wire validator: %v", err))
+	}
+
 	handlers := []APIHandler{
 		apis.NewRootV3Handler(config.ServerURL),
 		apis.NewRootHandler(
@@ -144,6 +149,7 @@ func main() {
 			domainRepo,
 			podRepo,
 			scaleAppProcessAction.Invoke,
+			decoderValidator,
 		),
 		apis.NewRouteHandler(
 			ctrl.Log.WithName("RouteHandler"),
@@ -151,6 +157,7 @@ func main() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			decoderValidator,
 		),
 		apis.NewServiceRouteBindingHandler(
 			ctrl.Log.WithName("ServiceRouteBinding"),
@@ -164,6 +171,7 @@ func main() {
 			dropletRepo,
 			repositories.UploadSourceImage,
 			newRegistryAuthBuilder(privilegedK8sClient, config),
+			decoderValidator,
 			config.PackageRegistryBase,
 			config.PackageRegistrySecretName,
 		),
@@ -172,6 +180,7 @@ func main() {
 			*serverURL,
 			buildRepo,
 			packageRepo,
+			decoderValidator,
 		),
 		apis.NewDropletHandler(
 			ctrl.Log.WithName("DropletHandler"),
@@ -184,6 +193,7 @@ func main() {
 			processRepo,
 			fetchProcessStatsAction.Invoke,
 			scaleProcessAction.Invoke,
+			decoderValidator,
 		),
 		apis.NewDomainHandler(
 			ctrl.Log.WithName("DomainHandler"),
@@ -196,20 +206,22 @@ func main() {
 		),
 		apis.NewLogCacheHandler(),
 
-		apis.NewOrgHandler(*serverURL, orgRepo),
+		apis.NewOrgHandler(*serverURL, orgRepo, decoderValidator),
 
-		apis.NewSpaceHandler(*serverURL, config.PackageRegistrySecretName, orgRepo),
+		apis.NewSpaceHandler(*serverURL, config.PackageRegistrySecretName, orgRepo, decoderValidator),
 
 		apis.NewSpaceManifestHandler(
 			ctrl.Log.WithName("SpaceManifestHandler"),
 			*serverURL,
 			applyManifestAction,
 			orgRepo,
+			decoderValidator,
 		),
 
 		apis.NewRoleHandler(
 			*serverURL,
 			roleRepo,
+			decoderValidator,
 		),
 
 		apis.NewWhoAmI(cachingIdentityProvider, *serverURL),
@@ -226,6 +238,7 @@ func main() {
 			*serverURL,
 			serviceInstanceRepo,
 			appRepo,
+			decoderValidator,
 		),
 	}
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/289

## What is this change about?
Use a singleton instance of payload validator instead of creating a new one on every HTTP request thus making use of the singleton validator cache.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@mnitchev 
