### PR TITLE
Add authz to the create package endpoint

### DIFF
--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -645,16 +645,17 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
 			})
 
 			JustBeforeEach(func() {
 				makePostRequest(validBody)
 			})
 
-			It("returns an error", func() {
-				expectUnprocessableEntityError("App is invalid. Ensure it exists and you have access to it.")
+			It("returns a not found error", func() {
+				expectNotFoundError("App not found")
 			})
+
 			itDoesntCreateAPackage()
 		})
 
@@ -777,6 +778,20 @@ var _ = Describe("PackageHandler", func() {
 
 			It("returns an unknown error", func() {
 				expectUnknownError()
+			})
+		})
+
+		When("the user is not allowed to create packages", func() {
+			BeforeEach(func() {
+				packageRepo.CreatePackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(errors.New("no")))
+			})
+
+			JustBeforeEach(func() {
+				makePostRequest(validBody)
+			})
+
+			It("returns an unauthorized error", func() {
+				expectNotAuthorizedError()
 			})
 		})
 	})

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	hnsv1alpha2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var _ = Describe("PackageRepository", func() {
@@ -26,26 +27,33 @@ var _ = Describe("PackageRepository", func() {
 		packageRepo               *repositories.PackageRepo
 		ctx                       context.Context
 		spaceDeveloperClusterRole *rbacv1.ClusterRole
+		org                       *hnsv1alpha2.SubnamespaceAnchor
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		packageRepo = repositories.NewPackageRepo(k8sClient, userClientFactory)
 		spaceDeveloperClusterRole = createClusterRole(ctx, repositories.SpaceDeveloperClusterRoleRules)
+
+		rootNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rootNamespace}}
+		Expect(k8sClient.Create(ctx, rootNs)).To(Succeed())
+		org = createOrgAnchorAndNamespace(ctx, rootNamespace, prefixedGUID("org"))
 	})
 
 	Describe("CreatePackage", func() {
-		var packageCreate repositories.CreatePackageMessage
-
-		const (
-			spaceGUID = "the-space-guid"
+		var (
+			packageCreate  repositories.CreatePackageMessage
+			createdPackage repositories.PackageRecord
+			createErr      error
+			space          *hnsv1alpha2.SubnamespaceAnchor
 		)
 
 		BeforeEach(func() {
+			space = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space"))
 			packageCreate = repositories.CreatePackageMessage{
 				Type:      "bits",
 				AppGUID:   appGUID,
-				SpaceGUID: spaceGUID,
+				SpaceGUID: space.Name,
 				OwnerRef: metav1.OwnerReference{
 					APIVersion: "workloads.cloudfoundry.org/v1alpha1",
 					Kind:       "CFApp",
@@ -53,78 +61,81 @@ var _ = Describe("PackageRepository", func() {
 					UID:        appUID,
 				},
 			}
-
-			Expect(
-				k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}),
-			).To(Succeed())
 		})
 
-		AfterEach(func() {
-			Expect(
-				k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}),
-			).To(Succeed())
+		JustBeforeEach(func() {
+			createdPackage, createErr = packageRepo.CreatePackage(ctx, authInfo, packageCreate)
 		})
 
-		It("creates a Package record", func() {
-			returnedPackageRecord, err := packageRepo.CreatePackage(ctx, authInfo, packageCreate)
-			Expect(err).NotTo(HaveOccurred())
+		It("fails because the user is not a space developer", func() {
+			Expect(createErr).To(BeAssignableToTypeOf(repositories.ForbiddenError{}))
+		})
 
-			packageGUID := returnedPackageRecord.GUID
-			Expect(packageGUID).NotTo(BeEmpty())
-			Expect(returnedPackageRecord.Type).To(Equal("bits"))
-			Expect(returnedPackageRecord.AppGUID).To(Equal(appGUID))
-			Expect(returnedPackageRecord.State).To(Equal("AWAITING_UPLOAD"))
+		When("the user is a SpaceDeveloper", func() {
+			BeforeEach(func() {
+				createRoleBinding(ctx, userName, spaceDeveloperClusterRole.Name, space.Name)
+			})
 
-			createdAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+			AfterEach(func() {
+				cleanupPackage(ctx, k8sClient, createdPackage.GUID, createdPackage.SpaceGUID)
+			})
 
-			updatedAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+			It("creates a Package record", func() {
+				Expect(createErr).NotTo(HaveOccurred())
 
-			packageNSName := types.NamespacedName{Name: packageGUID, Namespace: spaceGUID}
-			createdCFPackage := new(workloadsv1alpha1.CFPackage)
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, packageNSName, createdCFPackage)
-				return err == nil
-			}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				packageGUID := createdPackage.GUID
+				Expect(packageGUID).NotTo(BeEmpty())
+				Expect(createdPackage.Type).To(Equal("bits"))
+				Expect(createdPackage.AppGUID).To(Equal(appGUID))
+				Expect(createdPackage.State).To(Equal("AWAITING_UPLOAD"))
 
-			Expect(createdCFPackage.Name).To(Equal(packageGUID))
-			Expect(createdCFPackage.Namespace).To(Equal(spaceGUID))
-			Expect(createdCFPackage.Spec.Type).To(Equal(workloadsv1alpha1.PackageType("bits")))
-			Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(appGUID))
-			Expect(createdCFPackage.ObjectMeta.OwnerReferences).To(Equal(
-				[]metav1.OwnerReference{
-					{
-						APIVersion: "workloads.cloudfoundry.org/v1alpha1",
-						Kind:       "CFApp",
-						Name:       appGUID,
-						UID:        appUID,
-					},
-				}))
+				createdAt, err := time.Parse(time.RFC3339, createdPackage.CreatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(createdAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
 
-			Expect(cleanupPackage(ctx, k8sClient, packageGUID, spaceGUID)).To(Succeed())
+				updatedAt, err := time.Parse(time.RFC3339, createdPackage.CreatedAt)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedAt).To(BeTemporally("~", time.Now(), timeCheckThreshold*time.Second))
+
+				packageNSName := types.NamespacedName{Name: packageGUID, Namespace: space.Name}
+				createdCFPackage := new(workloadsv1alpha1.CFPackage)
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, packageNSName, createdCFPackage)
+					return err == nil
+				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+
+				Expect(createdCFPackage.Name).To(Equal(packageGUID))
+				Expect(createdCFPackage.Namespace).To(Equal(space.Name))
+				Expect(createdCFPackage.Spec.Type).To(Equal(workloadsv1alpha1.PackageType("bits")))
+				Expect(createdCFPackage.Spec.AppRef.Name).To(Equal(appGUID))
+				Expect(createdCFPackage.ObjectMeta.OwnerReferences).To(Equal(
+					[]metav1.OwnerReference{
+						{
+							APIVersion: "workloads.cloudfoundry.org/v1alpha1",
+							Kind:       "CFApp",
+							Name:       appGUID,
+							UID:        appUID,
+						},
+					}))
+			})
 		})
 	})
 
 	Describe("GetPackage", func() {
 		var (
-			namespace   *corev1.Namespace
 			packageGUID string
 			cfPackage   *workloadsv1alpha1.CFPackage
+			space       *hnsv1alpha2.SubnamespaceAnchor
 		)
 
 		BeforeEach(func() {
-			namespaceName := generateGUID()
-			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
-			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+			space = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space1"))
 
 			packageGUID = generateGUID()
 			cfPackage = &workloadsv1alpha1.CFPackage{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      packageGUID,
-					Namespace: namespace.Name,
+					Namespace: space.Name,
 				},
 				Spec: workloadsv1alpha1.CFPackageSpec{
 					Type: "bits",
@@ -138,12 +149,11 @@ var _ = Describe("PackageRepository", func() {
 
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, cfPackage)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 		})
 
 		When("the user is authorized in the namespace", func() {
 			BeforeEach(func() {
-				createRoleBinding(ctx, userName, spaceDeveloperClusterRole.Name, namespace.Name)
+				createRoleBinding(ctx, userName, spaceDeveloperClusterRole.Name, space.Name)
 			})
 
 			It("can fetch the PackageRecord we're looking for", func() {
@@ -164,14 +174,19 @@ var _ = Describe("PackageRepository", func() {
 			})
 
 			When("table-testing the State field", func() {
-				var cfPackage *workloadsv1alpha1.CFPackage
+				var cfPackageTable *workloadsv1alpha1.CFPackage
+
+				type testCase struct {
+					description   string
+					expectedState string
+					setupFunc     func(cfPackage2 *workloadsv1alpha1.CFPackage)
+				}
 
 				BeforeEach(func() {
-					packageGUID = generateGUID()
-					cfPackage = &workloadsv1alpha1.CFPackage{
+					cfPackageTable = &workloadsv1alpha1.CFPackage{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      packageGUID,
-							Namespace: namespace.Name,
+							Name:      generateGUID(),
+							Namespace: space.Name,
 						},
 						Spec: workloadsv1alpha1.CFPackageSpec{
 							Type: "bits",
@@ -181,12 +196,6 @@ var _ = Describe("PackageRepository", func() {
 						},
 					}
 				})
-
-				type testCase struct {
-					description   string
-					expectedState string
-					setupFunc     func(cfPackage2 *workloadsv1alpha1.CFPackage)
-				}
 
 				cases := []testCase{
 					{
@@ -204,11 +213,11 @@ var _ = Describe("PackageRepository", func() {
 				for _, tc := range cases {
 					When(tc.description, func() {
 						It("has state "+tc.expectedState, func() {
-							tc.setupFunc(cfPackage)
-							Expect(k8sClient.Create(ctx, cfPackage)).To(Succeed())
-							defer func() { Expect(k8sClient.Delete(ctx, cfPackage)).To(Succeed()) }()
+							tc.setupFunc(cfPackageTable)
+							Expect(k8sClient.Create(ctx, cfPackageTable)).To(Succeed())
+							defer func() { Expect(k8sClient.Delete(ctx, cfPackageTable)).To(Succeed()) }()
 
-							record, err := packageRepo.GetPackage(ctx, authInfo, cfPackage.Name)
+							record, err := packageRepo.GetPackage(ctx, authInfo, cfPackageTable.Name)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(record.State).To(Equal(tc.expectedState))
 						})
@@ -227,17 +236,16 @@ var _ = Describe("PackageRepository", func() {
 		When("duplicate Packages exist across namespaces with the same GUID", func() {
 			var (
 				duplicatePackage *workloadsv1alpha1.CFPackage
-				anotherNamespace *corev1.Namespace
+				anotherSpace     *hnsv1alpha2.SubnamespaceAnchor
 			)
 
 			BeforeEach(func() {
-				anotherNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: generateGUID()}}
-				Expect(k8sClient.Create(ctx, anotherNamespace)).To(Succeed())
+				anotherSpace = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space"))
 
 				duplicatePackage = &workloadsv1alpha1.CFPackage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      packageGUID,
-						Namespace: anotherNamespace.Name,
+						Namespace: anotherSpace.Name,
 					},
 					Spec: workloadsv1alpha1.CFPackageSpec{
 						Type: "bits",
@@ -276,22 +284,13 @@ var _ = Describe("PackageRepository", func() {
 		)
 
 		var (
-			namespace  *corev1.Namespace
-			namespace2 *corev1.Namespace
+			space1 *hnsv1alpha2.SubnamespaceAnchor
+			space2 *hnsv1alpha2.SubnamespaceAnchor
 		)
 
 		BeforeEach(func() {
-			namespace1Name := generateGUID()
-			namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace1Name}}
-			Expect(k8sClient.Create(context.Background(), namespace)).To(Succeed())
-			namespace2Name := generateGUID()
-			namespace2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace2Name}}
-			Expect(k8sClient.Create(context.Background(), namespace2)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			Expect(k8sClient.Delete(context.Background(), namespace)).To(Succeed())
-			Expect(k8sClient.Delete(context.Background(), namespace2)).To(Succeed())
+			space1 = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space1"))
+			space2 = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space2"))
 		})
 
 		When("multiple packages exist in different namespaces", func() {
@@ -308,7 +307,7 @@ var _ = Describe("PackageRepository", func() {
 				package1 = &workloadsv1alpha1.CFPackage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      package1GUID,
-						Namespace: namespace.Name,
+						Namespace: space1.Name,
 					},
 					Spec: workloadsv1alpha1.CFPackageSpec{
 						Type: "bits",
@@ -325,7 +324,7 @@ var _ = Describe("PackageRepository", func() {
 				package2 = &workloadsv1alpha1.CFPackage{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      package2GUID,
-						Namespace: namespace2.Name,
+						Namespace: space2.Name,
 					},
 					Spec: workloadsv1alpha1.CFPackageSpec{
 						Type: "bits",
@@ -375,7 +374,7 @@ var _ = Describe("PackageRepository", func() {
 						package3 = &workloadsv1alpha1.CFPackage{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      package3GUID,
-								Namespace: namespace.Name,
+								Namespace: space1.Name,
 							},
 							Spec: workloadsv1alpha1.CFPackageSpec{
 								Type: "bits",
@@ -443,7 +442,7 @@ var _ = Describe("PackageRepository", func() {
 					package3 = &workloadsv1alpha1.CFPackage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      package3GUID,
-							Namespace: namespace2.Name,
+							Namespace: space2.Name,
 						},
 						Spec: workloadsv1alpha1.CFPackageSpec{
 							Type: "bits",
@@ -580,8 +579,8 @@ var _ = Describe("PackageRepository", func() {
 	Describe("UpdatePackageSource", func() {
 		var (
 			existingCFPackage workloadsv1alpha1.CFPackage
-			spaceGUID         string
 			updateMessage     repositories.UpdatePackageSourceMessage
+			space             *hnsv1alpha2.SubnamespaceAnchor
 		)
 
 		const (
@@ -591,7 +590,7 @@ var _ = Describe("PackageRepository", func() {
 		)
 
 		BeforeEach(func() {
-			spaceGUID = generateGUID()
+			space = createSpaceAnchorAndNamespace(ctx, org.Name, prefixedGUID("space"))
 
 			existingCFPackage = workloadsv1alpha1.CFPackage{
 				TypeMeta: metav1.TypeMeta{
@@ -600,7 +599,7 @@ var _ = Describe("PackageRepository", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      packageGUID,
-					Namespace: spaceGUID,
+					Namespace: space.Name,
 				},
 				Spec: workloadsv1alpha1.CFPackageSpec{
 					Type:   "bits",
@@ -610,14 +609,10 @@ var _ = Describe("PackageRepository", func() {
 
 			updateMessage = repositories.UpdatePackageSourceMessage{
 				GUID:               packageGUID,
-				SpaceGUID:          spaceGUID,
+				SpaceGUID:          space.Name,
 				ImageRef:           packageSourceImageRef,
 				RegistrySecretName: packageRegistrySecretName,
 			}
-
-			Expect(
-				k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}),
-			).To(Succeed())
 
 			Expect(
 				k8sClient.Create(ctx, &existingCFPackage),
@@ -628,20 +623,16 @@ var _ = Describe("PackageRepository", func() {
 			Expect(
 				k8sClient.Delete(ctx, &existingCFPackage),
 			).To(Succeed())
-
-			Expect(
-				k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spaceGUID}}),
-			).To(Succeed())
 		})
 
 		It("returns an updated record", func() {
 			returnedPackageRecord, err := packageRepo.UpdatePackageSource(ctx, authInfo, updateMessage)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(returnedPackageRecord.GUID).To(Equal(existingCFPackage.ObjectMeta.Name))
+			Expect(returnedPackageRecord.GUID).To(Equal(existingCFPackage.Name))
 			Expect(returnedPackageRecord.Type).To(Equal(string(existingCFPackage.Spec.Type)))
 			Expect(returnedPackageRecord.AppGUID).To(Equal(existingCFPackage.Spec.AppRef.Name))
-			Expect(returnedPackageRecord.SpaceGUID).To(Equal(existingCFPackage.ObjectMeta.Namespace))
+			Expect(returnedPackageRecord.SpaceGUID).To(Equal(existingCFPackage.Namespace))
 			Expect(returnedPackageRecord.State).To(Equal("READY"))
 
 			createdAt, err := time.Parse(time.RFC3339, returnedPackageRecord.CreatedAt)
@@ -657,15 +648,15 @@ var _ = Describe("PackageRepository", func() {
 			_, err := packageRepo.UpdatePackageSource(ctx, authInfo, updateMessage)
 			Expect(err).NotTo(HaveOccurred())
 
-			packageNSName := types.NamespacedName{Name: packageGUID, Namespace: spaceGUID}
+			packageNSName := types.NamespacedName{Name: packageGUID, Namespace: space.Name}
 			createdCFPackage := new(workloadsv1alpha1.CFPackage)
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, packageNSName, createdCFPackage)
 				return err == nil
 			}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
 
-			Expect(createdCFPackage.Name).To(Equal(existingCFPackage.ObjectMeta.Name))
-			Expect(createdCFPackage.Namespace).To(Equal(existingCFPackage.ObjectMeta.Namespace))
+			Expect(createdCFPackage.Name).To(Equal(existingCFPackage.Name))
+			Expect(createdCFPackage.Namespace).To(Equal(existingCFPackage.Namespace))
 			Expect(createdCFPackage.Spec.Type).To(Equal(existingCFPackage.Spec.Type))
 			Expect(createdCFPackage.Spec.AppRef).To(Equal(existingCFPackage.Spec.AppRef))
 			Expect(createdCFPackage.Spec.Source.Registry).To(Equal(workloadsv1alpha1.Registry{
@@ -676,12 +667,12 @@ var _ = Describe("PackageRepository", func() {
 	})
 })
 
-func cleanupPackage(ctx context.Context, k8sClient client.Client, packageGUID, namespace string) error {
+func cleanupPackage(ctx context.Context, k8sClient client.Client, packageGUID, namespace string) {
 	cfPackage := workloadsv1alpha1.CFPackage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      packageGUID,
 			Namespace: namespace,
 		},
 	}
-	return k8sClient.Delete(ctx, &cfPackage)
+	Expect(k8sClient.Delete(ctx, &cfPackage)).To(Succeed())
 }

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -98,6 +98,11 @@ var (
 			Resources: []string{"cfbuilds"},
 		},
 		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{"workloads.cloudfoundry.org"},
+			Resources: []string{"cfpackages"},
+		},
+		{
 			Verbs:     []string{"get", "list", "create", "delete"},
 			APIGroups: []string{"networking.cloudfoundry.org"},
 			Resources: []string{"cfroutes"},

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -518,7 +518,7 @@ func createApp(spaceGUID, name string) presenter.AppResponse {
 	return app
 }
 
-func createPackage(appGUID, authHeader string) presenter.PackageResponse {
+func createPackageRaw(appGUID, authHeader string) (*http.Response, error) {
 	packagesURL := apiServerRoot + apis.PackageCreateEndpoint
 
 	payload := payloads.PackageCreate{
@@ -532,7 +532,11 @@ func createPackage(appGUID, authHeader string) presenter.PackageResponse {
 		},
 	}
 
-	resp, err := httpReq(http.MethodPost, packagesURL, authHeader, payload)
+	return httpReq(http.MethodPost, packagesURL, authHeader, payload)
+}
+
+func createPackage(appGUID, authHeader string) presenter.PackageResponse {
+	resp, err := createPackageRaw(appGUID, authHeader)
 	Expect(err).NotTo(HaveOccurred())
 	defer resp.Body.Close()
 

--- a/api/tests/e2e/package_test.go
+++ b/api/tests/e2e/package_test.go
@@ -1,0 +1,96 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+var _ = Describe("Package", func() {
+	var (
+		org       presenter.OrgResponse
+		space     presenter.SpaceResponse
+		app       presenter.AppResponse
+		httpResp  *resty.Response
+		httpErr   error
+		result    map[string]interface{}
+		resultErr map[string]interface{}
+	)
+
+	BeforeEach(func() {
+		org = createOrg(generateGUID("org"))
+		createOrgRole("organization_user", rbacv1.UserKind, certUserName, org.GUID, adminAuthHeader)
+
+		space = createSpace(generateGUID("space1"), org.GUID)
+		app = createApp(space.GUID, generateGUID("app"))
+	})
+
+	AfterEach(func() {
+		deleteSubnamespace(rootNamespace, org.GUID)
+	})
+
+	JustBeforeEach(func() {
+		httpResp, httpErr = certClient.R().
+			SetBody(map[string]interface{}{
+				"type": "bits",
+				"relationships": map[string]interface{}{
+					"app": map[string]interface{}{
+						"data": map[string]interface{}{
+							"guid": app.GUID,
+						},
+					},
+				},
+			}).
+			SetError(&resultErr).
+			SetResult(&result).
+			Post("/v3/packages")
+	})
+
+	Describe("Create", func() {
+		It("fails with a resource not found error", func() {
+			Expect(httpErr).NotTo(HaveOccurred())
+			Expect(httpResp.StatusCode()).To(Equal(http.StatusNotFound))
+			Expect(resultErr).To(
+				HaveKeyWithValue("errors", ConsistOf(
+					HaveKeyWithValue("title", Equal("CF-ResourceNotFound")),
+				)))
+		})
+
+		When("the user is a SpaceDeveloper", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space.GUID, adminAuthHeader)
+			})
+
+			It("succeeds", func() {
+				Expect(httpErr).NotTo(HaveOccurred())
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusCreated))
+				Expect(result).To(HaveKeyWithValue("guid", Not(BeEmpty())))
+
+				By("creating the package", func() {
+					actualPackage := map[string]interface{}{}
+					getResp, getErr := certClient.R().SetResult(&actualPackage).Get(fmt.Sprintf("/v3/packages/%s", result["guid"]))
+					Expect(getErr).NotTo(HaveOccurred())
+					Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
+					Expect(actualPackage["guid"]).To(Equal(result["guid"]))
+				})
+			})
+		})
+
+		When("the user is a SpaceManager (i.e. can get apps but cannot create packages)", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, space.GUID, adminAuthHeader)
+			})
+
+			It("fails with a forbidden error", func() {
+				Expect(httpErr).NotTo(HaveOccurred())
+				Expect(httpResp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resultErr).To(HaveKeyWithValue("errors", ConsistOf(HaveKeyWithValue("title", Equal("CF-NotAuthorized")))))
+			})
+		})
+	})
+})

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -30,6 +30,15 @@ rules:
   - cfpackages
   verbs:
   - get
+  - create
+
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfbuilds
+  verbs:
+  - get
+  - create
 
 - apiGroups:
   - workloads.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -30,6 +30,7 @@ rules:
   - cfpackages
   verbs:
   - get
+  - create
 
 - apiGroups:
   - workloads.cloudfoundry.org
@@ -39,6 +40,12 @@ rules:
   - get
   - create
 
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - create
 - apiGroups:
   - services.cloudfoundry.org
   resources:

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1464,6 +1464,14 @@ rules:
   - cfpackages
   verbs:
   - get
+  - create
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfbuilds
+  verbs:
+  - get
+  - create
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:
@@ -1901,12 +1909,19 @@ rules:
   - cfpackages
   verbs:
   - get
+  - create
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:
   - cfbuilds
   verbs:
   - get
+  - create
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
   - create
 - apiGroups:
   - services.cloudfoundry.org


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/544

## What is this change about?
Enable authz for the `create package` endpoint

## Does this PR introduce a breaking change?
`create package` now requires the `space developer role` to be assigned to the user

## Acceptance Steps
See the story

@georgethebeatle 
@mnitchev 
