### PR TITLE
Stop leaking subnamespace anchors in e2e tests

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -184,8 +184,9 @@ var _ = Describe("Apps", func() {
 			buildGUID = createBuild(pkgGUID)
 
 			Eventually(func() (int, error) {
-				getResp, err := adminClient.R().Get("/v3/droplets/" + buildGUID)
-				return getResp.StatusCode(), err
+				var err error
+				resp, err = adminClient.R().Get("/v3/droplets/" + buildGUID)
+				return resp.StatusCode(), err
 			}).Should(Equal(http.StatusOK))
 
 			createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Orgs", func() {
 	var resp *resty.Response
 
-	Describe("creating orgs", func() {
+	Describe("create", func() {
 		var (
 			result    resource
 			client    *resty.Client
@@ -49,8 +49,14 @@ var _ = Describe("Orgs", func() {
 		})
 
 		When("the org name already exists", func() {
+			var duplOrgGUID string
+
 			BeforeEach(func() {
-				createOrg(orgName)
+				duplOrgGUID = createOrg(orgName)
+			})
+
+			AfterEach(func() {
+				deleteOrg(duplOrgGUID)
 			})
 
 			It("returns an unprocessable entity error", func() {
@@ -73,7 +79,7 @@ var _ = Describe("Orgs", func() {
 		})
 	})
 
-	Describe("listing orgs", func() {
+	Describe("list", func() {
 		var (
 			org1Name, org2Name, org3Name, org4Name string
 			org1GUID, org2GUID, org3GUID, org4GUID string

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -15,18 +15,20 @@ import (
 var _ = Describe("Spaces", func() {
 	var resp *resty.Response
 
-	Describe("Creating spaces", func() {
+	Describe("create", func() {
 		var (
-			result    resource
-			client    *resty.Client
-			orgGUID   string
-			spaceName string
-			resultErr cfErrs
+			result     resource
+			client     *resty.Client
+			orgGUID    string
+			parentGUID string
+			spaceName  string
+			resultErr  cfErrs
 		)
 
 		BeforeEach(func() {
 			spaceName = generateGUID("space")
 			orgGUID = createOrg(generateGUID("org"))
+			parentGUID = orgGUID
 			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, orgGUID)
 		})
 
@@ -40,7 +42,7 @@ var _ = Describe("Spaces", func() {
 				SetBody(resource{
 					Name: spaceName,
 					Relationships: relationships{
-						"organization": {Data: resource{GUID: orgGUID}},
+						"organization": {Data: resource{GUID: parentGUID}},
 					},
 				}).
 				SetError(&resultErr).
@@ -77,7 +79,7 @@ var _ = Describe("Spaces", func() {
 			When("the organization relationship references a space guid", func() {
 				BeforeEach(func() {
 					otherSpaceGUID := createSpace(generateGUID("some-other-space"), orgGUID)
-					orgGUID = otherSpaceGUID
+					parentGUID = otherSpaceGUID
 				})
 
 				It("denies the request", func() {
@@ -101,7 +103,7 @@ var _ = Describe("Spaces", func() {
 		})
 	})
 
-	Describe("listing spaces", func() {
+	Describe("list", func() {
 		var (
 			org1GUID, org2GUID, org3GUID          string
 			space11GUID, space12GUID, space13GUID string


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Fix a couple of cases where orgs are leaked in the e2e tests. And fix a couple of describe names

## Does this PR introduce a breaking change?
No

## Acceptance Steps
E2es green

## Tag your pair, your PM, and/or team
@danail-branekov 