### PR TITLE
Authenticate package uploading

### DIFF
--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -168,7 +168,7 @@ func (h PackageHandler) packageCreateHandler(authInfo authorization.Info, w http
 		switch err.(type) {
 		case repositories.PermissionDeniedOrNotFoundError:
 			h.logger.Info("App not found", "App GUID", payload.Relationships.App.Data.GUID)
-			writeNotFoundErrorResponse(w, "App")
+			writeUnprocessableEntityError(w, "App is invalid. Ensure it exists and you have access to it.")
 		default:
 			h.logger.Info("Error finding App", "App GUID", payload.Relationships.App.Data.GUID)
 			writeUnknownErrorResponse(w)

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -978,6 +978,22 @@ var _ = Describe("PackageHandler", func() {
 			itDoesntUpdateAnyPackages()
 		})
 
+		When("getting the package is forbidden", func() {
+			BeforeEach(func() {
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.ForbiddenError{})
+			})
+
+			JustBeforeEach(func() {
+				makeUploadRequest(packageGUID, strings.NewReader("the-zip-contents"))
+			})
+
+			It("returns an error", func() {
+				expectNotFoundError("Package not found")
+			})
+			itDoesntBuildAnImageFromSource()
+			itDoesntUpdateAnyPackages()
+		})
+
 		When("fetching the package errors", func() {
 			BeforeEach(func() {
 				packageRepo.GetPackageReturns(repositories.PackageRecord{}, errors.New("boom"))
@@ -1043,6 +1059,20 @@ var _ = Describe("PackageHandler", func() {
 				expectUnknownError()
 			})
 			itDoesntUpdateAnyPackages()
+		})
+
+		When("updating the package is forbidden", func() {
+			BeforeEach(func() {
+				packageRepo.UpdatePackageSourceReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(errors.New("no")))
+			})
+
+			JustBeforeEach(func() {
+				makeUploadRequest(packageGUID, strings.NewReader("the-zip-contents"))
+			})
+
+			It("returns an error", func() {
+				expectNotAuthorizedError()
+			})
 		})
 
 		When("updating the package source registry errors", func() {

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -652,8 +652,8 @@ var _ = Describe("PackageHandler", func() {
 				makePostRequest(validBody)
 			})
 
-			It("returns a not found error", func() {
-				expectNotFoundError("App not found")
+			It("returns an unprocessable entity error", func() {
+				expectUnprocessableEntityError("App is invalid. Ensure it exists and you have access to it.")
 			})
 
 			itDoesntCreateAPackage()

--- a/api/repositories/shared.go
+++ b/api/repositories/shared.go
@@ -88,7 +88,7 @@ var (
 			Resources: []string{"cfapps"},
 		},
 		{
-			Verbs:     []string{"get"},
+			Verbs:     []string{"get", "patch"},
 			APIGroups: []string{"workloads.cloudfoundry.org"},
 			Resources: []string{"cfpackages"},
 		},

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -59,6 +59,8 @@ type resource struct {
 	Name          string        `json:"name,omitempty"`
 	GUID          string        `json:"guid,omitempty"`
 	Relationships relationships `json:"relationships,omitempty"`
+	CreatedAt     string        `json:"created_at,omitempty"`
+	UpdatedAt     string        `json:"updated_at,omitempty"`
 }
 
 type relationships map[string]relationship

--- a/api/tests/e2e/package_test.go
+++ b/api/tests/e2e/package_test.go
@@ -50,9 +50,11 @@ var _ = Describe("Package", func() {
 
 	Describe("Create", func() {
 		It("fails with a resource not found error", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
 			Expect(resultErr.Errors).To(HaveLen(1))
-			Expect(resultErr.Errors[0].Title).To(Equal("CF-ResourceNotFound"))
+			Expect(resultErr.Errors[0].Title).To(Equal("CF-UnprocessableEntity"))
+			Expect(resultErr.Errors[0].Code).To(Equal(10008))
+			Expect(resultErr.Errors[0].Detail).To(Equal("App is invalid. Ensure it exists and you have access to it."))
 		})
 
 		When("the user is a SpaceDeveloper", func() {
@@ -86,6 +88,8 @@ var _ = Describe("Package", func() {
 				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
 				Expect(resultErr.Errors).To(HaveLen(1))
 				Expect(resultErr.Errors[0].Title).To(Equal("CF-NotAuthorized"))
+				Expect(resultErr.Errors[0].Code).To(Equal(10003))
+				Expect(resultErr.Errors[0].Detail).To(Equal("You are not authorized to perform the requested action"))
 			})
 		})
 	})

--- a/api/tests/e2e/package_test.go
+++ b/api/tests/e2e/package_test.go
@@ -31,24 +31,24 @@ var _ = Describe("Package", func() {
 		deleteOrg(orgGUID)
 	})
 
-	JustBeforeEach(func() {
-		var err error
-		resp, err = certClient.R().
-			SetBody(packageResource{
-				Type: "bits",
-				resource: resource{
-					Relationships: relationships{
-						"app": relationship{Data: resource{GUID: appGUID}},
-					},
-				},
-			}).
-			SetError(&resultErr).
-			SetResult(&result).
-			Post("/v3/packages")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	Describe("Create", func() {
+		JustBeforeEach(func() {
+			var err error
+			resp, err = certClient.R().
+				SetBody(packageResource{
+					Type: "bits",
+					resource: resource{
+						Relationships: relationships{
+							"app": relationship{Data: resource{GUID: appGUID}},
+						},
+					},
+				}).
+				SetError(&resultErr).
+				SetResult(&result).
+				Post("/v3/packages")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("fails with a resource not found error", func() {
 			Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
 			Expect(resultErr.Errors).To(HaveLen(1))
@@ -63,19 +63,9 @@ var _ = Describe("Package", func() {
 			})
 
 			It("succeeds", func() {
+				Expect(resultErr.Errors).To(HaveLen(0))
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 				Expect(result.GUID).ToNot(BeEmpty())
-
-				By("creating the package", func() {
-					var actualPackage packageResource
-					getResp, getErr := certClient.R().
-						SetResult(&actualPackage).
-						Get("/v3/packages/" + result.GUID)
-
-					Expect(getErr).NotTo(HaveOccurred())
-					Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
-					Expect(actualPackage.GUID).To(Equal(result.GUID))
-				})
 			})
 		})
 
@@ -90,6 +80,48 @@ var _ = Describe("Package", func() {
 				Expect(resultErr.Errors[0].Title).To(Equal("CF-NotAuthorized"))
 				Expect(resultErr.Errors[0].Code).To(Equal(10003))
 				Expect(resultErr.Errors[0].Detail).To(Equal("You are not authorized to perform the requested action"))
+			})
+		})
+	})
+
+	Describe("Upload", func() {
+		var pkgGUID string
+
+		BeforeEach(func() {
+			pkgGUID = createPackage(appGUID)
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			resp, err = certClient.R().
+				SetFile("bits", "assets/node.zip").
+				SetError(&resultErr).
+				SetResult(&result).
+				Post("/v3/packages/" + pkgGUID + "/upload")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("the user is a SpaceManager (i.e. can get apps but cannot update packages)", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("fails with a forbidden error", func() {
+				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resultErr.Errors).To(HaveLen(1))
+				Expect(resultErr.Errors[0].Title).To(Equal("CF-NotAuthorized"))
+				Expect(resultErr.Errors[0].Code).To(Equal(10003))
+				Expect(resultErr.Errors[0].Detail).To(Equal("You are not authorized to perform the requested action"))
+			})
+		})
+
+		When("the user is a SpaceDeveloper", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("succeeds", func() {
+				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 			})
 		})
 	})

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -31,6 +31,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 
 - apiGroups:
   - workloads.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -31,6 +31,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 
 - apiGroups:
   - workloads.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_manager.yaml
+++ b/controllers/config/cf_roles/cf_space_manager.yaml
@@ -10,3 +10,10 @@ rules:
   - cfapps
   verbs:
   - get
+
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages
+  verbs:
+  - get

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1465,6 +1465,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:
@@ -1910,6 +1911,7 @@ rules:
   verbs:
   - get
   - create
+  - patch
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:
@@ -1957,6 +1959,12 @@ rules:
   - workloads.cloudfoundry.org
   resources:
   - cfapps
+  verbs:
+  - get
+- apiGroups:
+  - workloads.cloudfoundry.org
+  resources:
+  - cfpackages
   verbs:
   - get
 ---


### PR DESCRIPTION
## Is there a related GitHub Issue?

#545 

## What is this change about?

This introduces authentication to the package upload endpoint. Some notes:

* This actually leverages RBAC on package updates, and it does not actually prevent unauthorised users to upload packages. The endpoint will return an error _after_ the upload and leave the package unchanged. We have opened bug #613 to figure out how to address this issue, as access to the container registry is not subject to Kubernetes RBAC.
* This also fixes the error returned when trying to create a package for an app the user doesn't have access to: the correct error is `422 Unprocessable Entity` and not `404 Not Found`.