### PR TITLE
Remove ResourceNotFoundError and PermissionDeniedOrNotFoundError from repositories

### DIFF
--- a/api/actions/fake/cfapp_repository.go
+++ b/api/actions/fake/cfapp_repository.go
@@ -72,21 +72,6 @@ type CFAppRepository struct {
 		result1 repositories.AppRecord
 		result2 error
 	}
-	GetNamespaceStub        func(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)
-	getNamespaceMutex       sync.RWMutex
-	getNamespaceArgsForCall []struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 string
-	}
-	getNamespaceReturns struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}
-	getNamespaceReturnsOnCall map[int]struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -356,72 +341,6 @@ func (fake *CFAppRepository) GetAppByNameAndSpaceReturnsOnCall(i int, result1 re
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) GetNamespace(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.SpaceRecord, error) {
-	fake.getNamespaceMutex.Lock()
-	ret, specificReturn := fake.getNamespaceReturnsOnCall[len(fake.getNamespaceArgsForCall)]
-	fake.getNamespaceArgsForCall = append(fake.getNamespaceArgsForCall, struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 string
-	}{arg1, arg2, arg3})
-	stub := fake.GetNamespaceStub
-	fakeReturns := fake.getNamespaceReturns
-	fake.recordInvocation("GetNamespace", []interface{}{arg1, arg2, arg3})
-	fake.getNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *CFAppRepository) GetNamespaceCallCount() int {
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
-	return len(fake.getNamespaceArgsForCall)
-}
-
-func (fake *CFAppRepository) GetNamespaceCalls(stub func(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = stub
-}
-
-func (fake *CFAppRepository) GetNamespaceArgsForCall(i int) (context.Context, authorization.Info, string) {
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
-	argsForCall := fake.getNamespaceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *CFAppRepository) GetNamespaceReturns(result1 repositories.SpaceRecord, result2 error) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = nil
-	fake.getNamespaceReturns = struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *CFAppRepository) GetNamespaceReturnsOnCall(i int, result1 repositories.SpaceRecord, result2 error) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = nil
-	if fake.getNamespaceReturnsOnCall == nil {
-		fake.getNamespaceReturnsOnCall = make(map[int]struct {
-			result1 repositories.SpaceRecord
-			result2 error
-		})
-	}
-	fake.getNamespaceReturnsOnCall[i] = struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -433,8 +352,6 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.getAppMutex.RUnlock()
 	fake.getAppByNameAndSpaceMutex.RLock()
 	defer fake.getAppByNameAndSpaceMutex.RUnlock()
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/api/actions/shared.go
+++ b/api/actions/shared.go
@@ -24,7 +24,6 @@ type CFProcessRepository interface {
 type CFAppRepository interface {
 	GetApp(context.Context, authorization.Info, string) (repositories.AppRecord, error)
 	GetAppByNameAndSpace(context.Context, authorization.Info, string, string) (repositories.AppRecord, error)
-	GetNamespace(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)
 	CreateOrPatchAppEnvVars(context.Context, authorization.Info, repositories.CreateOrPatchAppEnvVarsMessage) (repositories.AppEnvVarsRecord, error)
 	CreateApp(context.Context, authorization.Info, repositories.CreateAppMessage) (repositories.AppRecord, error)
 }

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -109,16 +109,8 @@ func (h *AppHandler) appGetHandler(authInfo authorization.Info, w http.ResponseW
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	err = writeJsonResponse(w, presenter.ForApp(app, h.serverURL), http.StatusOK)
@@ -245,13 +237,7 @@ func (h *AppHandler) appSetCurrentDropletHandler(authInfo authorization.Info, w 
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		if errors.As(err, new(repositories.PermissionDeniedOrNotFoundError)) {
-			h.logger.Error(err, "App not found", "appGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-		} else {
-			h.logger.Error(err, "Error fetching app", "appGUID", appGUID)
-			writeUnknownErrorResponse(w)
-		}
+		h.handleGetAppErr(err, w, appGUID)
 		return
 	}
 
@@ -312,13 +298,7 @@ func (h *AppHandler) appGetCurrentDropletHandler(authInfo authorization.Info, w 
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		if errors.As(err, new(repositories.PermissionDeniedOrNotFoundError)) {
-			h.logger.Error(err, "App not found", "appGUID", app.GUID)
-			writeNotFoundErrorResponse(w, "App")
-		} else {
-			h.logger.Error(err, "Error fetching app", "appGUID", app.GUID)
-			writeUnknownErrorResponse(w)
-		}
+		h.handleGetAppErr(err, w, appGUID)
 		return
 	}
 
@@ -362,16 +342,8 @@ func (h *AppHandler) appStartHandler(authInfo authorization.Info, w http.Respons
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 	if app.DropletGUID == "" {
 		h.logger.Info("App droplet not set before start", "AppGUID", appGUID)
@@ -406,16 +378,8 @@ func (h *AppHandler) appStopHandler(authInfo authorization.Info, w http.Response
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	app, err = h.appRepo.SetAppDesiredState(ctx, authInfo, repositories.SetAppDesiredStateMessage{
@@ -445,16 +409,8 @@ func (h *AppHandler) getProcessesForAppHandler(authInfo authorization.Info, w ht
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
-			h.logger.Info("Permission denied or app not found", "AppGUID", appGUID, "err", err)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	fetchProcessesForAppMessage := repositories.ListProcessesMessage{
@@ -485,16 +441,8 @@ func (h *AppHandler) getRoutesForAppHandler(authInfo authorization.Info, w http.
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	routes, err := h.lookupAppRouteAndDomainList(ctx, authInfo, app.GUID, app.SpaceGUID)
@@ -557,16 +505,8 @@ func (h *AppHandler) appRestartHandler(authInfo authorization.Info, w http.Respo
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	if app.DropletGUID == "" {
@@ -628,17 +568,8 @@ func (h *AppHandler) appDeleteHandler(authInfo authorization.Info, w http.Respon
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
-
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	err = h.appRepo.DeleteApp(ctx, authInfo, repositories.DeleteAppMessage{
@@ -680,16 +611,8 @@ func (h *AppHandler) appPatchEnvVarsHandler(authInfo authorization.Info, w http.
 
 	app, err := h.appRepo.GetApp(ctx, authInfo, appGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("App not found", "AppGUID", appGUID)
-			writeNotFoundErrorResponse(w, "App")
-			return
-		default:
-			h.logger.Error(err, "Failed to fetch app", "AppGUID", appGUID)
-			writeUnknownErrorResponse(w)
-			return
-		}
+		h.handleGetAppErr(err, w, appGUID)
+		return
 	}
 
 	envVarsRecord, err := h.appRepo.PatchAppEnvVars(ctx, authInfo, payload.ToMessage(appGUID, app.SpaceGUID))
@@ -732,6 +655,20 @@ func (h *AppHandler) appGetEnvHandler(authInfo authorization.Info, w http.Respon
 	err = writeJsonResponse(w, presenter.ForAppEnv(envVars), http.StatusOK)
 	if err != nil {
 		h.logger.Error(err, "Failed to render response", "AppGUID", appGUID)
+		writeUnknownErrorResponse(w)
+	}
+}
+
+func (h *AppHandler) handleGetAppErr(err error, w http.ResponseWriter, appGUID string) {
+	switch err.(type) {
+	case repositories.NotFoundError:
+		h.logger.Info("App not found", "AppGUID", appGUID)
+		writeNotFoundErrorResponse(w, "App")
+	case repositories.ForbiddenError:
+		h.logger.Info("App forbidden", "AppGUID", appGUID)
+		writeNotFoundErrorResponse(w, "App")
+	default:
+		h.logger.Error(err, "Failed to fetch app from Kubernetes", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
 	}
 }

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -524,7 +524,7 @@ func (h *AppHandler) appRestartHandler(authInfo authorization.Info, w http.Respo
 		})
 		if err != nil {
 			switch err.(type) {
-			case repositories.PermissionDeniedOrNotFoundError:
+			case repositories.ForbiddenError:
 				h.logger.Info("failed to stop app", "AppGUID", appGUID)
 				writeNotAuthorizedErrorResponse(w)
 				return
@@ -543,7 +543,7 @@ func (h *AppHandler) appRestartHandler(authInfo authorization.Info, w http.Respo
 	})
 	if err != nil {
 		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
+		case repositories.ForbiddenError:
 			h.logger.Info("failed to start app", "AppGUID", appGUID)
 			writeNotAuthorizedErrorResponse(w)
 			return

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -37,6 +37,7 @@ var _ = Describe("AppHandler", func() {
 		scaleAppProcessFunc *fake.ScaleAppProcess
 		domainRepo          *fake.CFDomainRepository
 		podRepo             *fake.PodRepository
+		spaceRepo           *fake.SpaceRepository
 		req                 *http.Request
 	)
 
@@ -48,6 +49,7 @@ var _ = Describe("AppHandler", func() {
 		domainRepo = new(fake.CFDomainRepository)
 		podRepo = new(fake.PodRepository)
 		scaleAppProcessFunc = new(fake.ScaleAppProcess)
+		spaceRepo = new(fake.SpaceRepository)
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -60,6 +62,7 @@ var _ = Describe("AppHandler", func() {
 			routeRepo,
 			domainRepo,
 			podRepo,
+			spaceRepo,
 			scaleAppProcessFunc.Spy,
 			decoderValidator,
 		)
@@ -341,10 +344,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the space does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(
-					repositories.SpaceRecord{},
-					repositories.PermissionDeniedOrNotFoundError{Err: errors.New("not found")},
-				)
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NotFoundError{})
 
 				requestBody := initializeCreateAppRequestBody(testAppName, "no-such-guid", nil, nil, nil)
 				queuePostRequest(requestBody)

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -2538,7 +2538,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to stop the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
+					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.ForbiddenError{})
 				})
 
 				It("returns a forbidden error", func() {
@@ -2548,7 +2548,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to start the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
+					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.ForbiddenError{})
 				})
 
 				It("returns a forbidden error", func() {
@@ -2649,7 +2649,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("no permissions to start the app", func() {
 			BeforeEach(func() {
-				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
+				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
 			})
 
 			It("returns a forbidden error", func() {

--- a/api/apis/fake/cfapp_repository.go
+++ b/api/apis/fake/cfapp_repository.go
@@ -100,21 +100,6 @@ type CFAppRepository struct {
 		result1 map[string]string
 		result2 error
 	}
-	GetNamespaceStub        func(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)
-	getNamespaceMutex       sync.RWMutex
-	getNamespaceArgsForCall []struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 string
-	}
-	getNamespaceReturns struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}
-	getNamespaceReturnsOnCall map[int]struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}
 	ListAppsStub        func(context.Context, authorization.Info, repositories.ListAppsMessage) ([]repositories.AppRecord, error)
 	listAppsMutex       sync.RWMutex
 	listAppsArgsForCall []struct {
@@ -573,72 +558,6 @@ func (fake *CFAppRepository) GetAppEnvReturnsOnCall(i int, result1 map[string]st
 	}{result1, result2}
 }
 
-func (fake *CFAppRepository) GetNamespace(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.SpaceRecord, error) {
-	fake.getNamespaceMutex.Lock()
-	ret, specificReturn := fake.getNamespaceReturnsOnCall[len(fake.getNamespaceArgsForCall)]
-	fake.getNamespaceArgsForCall = append(fake.getNamespaceArgsForCall, struct {
-		arg1 context.Context
-		arg2 authorization.Info
-		arg3 string
-	}{arg1, arg2, arg3})
-	stub := fake.GetNamespaceStub
-	fakeReturns := fake.getNamespaceReturns
-	fake.recordInvocation("GetNamespace", []interface{}{arg1, arg2, arg3})
-	fake.getNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *CFAppRepository) GetNamespaceCallCount() int {
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
-	return len(fake.getNamespaceArgsForCall)
-}
-
-func (fake *CFAppRepository) GetNamespaceCalls(stub func(context.Context, authorization.Info, string) (repositories.SpaceRecord, error)) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = stub
-}
-
-func (fake *CFAppRepository) GetNamespaceArgsForCall(i int) (context.Context, authorization.Info, string) {
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
-	argsForCall := fake.getNamespaceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *CFAppRepository) GetNamespaceReturns(result1 repositories.SpaceRecord, result2 error) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = nil
-	fake.getNamespaceReturns = struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *CFAppRepository) GetNamespaceReturnsOnCall(i int, result1 repositories.SpaceRecord, result2 error) {
-	fake.getNamespaceMutex.Lock()
-	defer fake.getNamespaceMutex.Unlock()
-	fake.GetNamespaceStub = nil
-	if fake.getNamespaceReturnsOnCall == nil {
-		fake.getNamespaceReturnsOnCall = make(map[int]struct {
-			result1 repositories.SpaceRecord
-			result2 error
-		})
-	}
-	fake.getNamespaceReturnsOnCall[i] = struct {
-		result1 repositories.SpaceRecord
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *CFAppRepository) ListApps(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListAppsMessage) ([]repositories.AppRecord, error) {
 	fake.listAppsMutex.Lock()
 	ret, specificReturn := fake.listAppsReturnsOnCall[len(fake.listAppsArgsForCall)]
@@ -918,8 +837,6 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.getAppByNameAndSpaceMutex.RUnlock()
 	fake.getAppEnvMutex.RLock()
 	defer fake.getAppEnvMutex.RUnlock()
-	fake.getNamespaceMutex.RLock()
-	defer fake.getNamespaceMutex.RUnlock()
 	fake.listAppsMutex.RLock()
 	defer fake.listAppsMutex.RUnlock()
 	fake.patchAppEnvVarsMutex.RLock()

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -10,8 +10,6 @@ import (
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/actions"
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
-	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
-	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
@@ -28,11 +26,7 @@ import (
 
 var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint", func() {
 	BeforeEach(func() {
-		clientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
-		identityProvider := new(fake.IdentityProvider)
-		namespacePermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
-
-		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, namespacePermissions)
+		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 		processRepo := repositories.NewProcessRepo(k8sClient)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
@@ -43,7 +37,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 			logf.Log.WithName("integration tests"),
 			*serverURL,
 			actions.NewApplyManifest(appRepo, domainRepo, processRepo, routeRepo).Invoke,
-			repositories.NewOrgRepo("cf", k8sClient, clientFactory, namespacePermissions, 1*time.Minute, true),
+			repositories.NewOrgRepo("cf", k8sClient, clientFactory, nsPermissions, 1*time.Minute, true),
 			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)

--- a/api/apis/integration/build_test.go
+++ b/api/apis/integration/build_test.go
@@ -23,9 +23,8 @@ var _ = Describe("Build", func() {
 	)
 
 	BeforeEach(func() {
-		userClientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
-		buildRepo := repositories.NewBuildRepo(k8sClient, userClientFactory)
-		packageRepo := repositories.NewPackageRepo(k8sClient, userClientFactory)
+		buildRepo := repositories.NewBuildRepo(k8sClient, clientFactory)
+		packageRepo := repositories.NewPackageRepo(k8sClient, clientFactory)
 		decoderValidator, err := apis.NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/api/apis/integration/droplet_test.go
+++ b/api/apis/integration/droplet_test.go
@@ -21,7 +21,6 @@ var _ = Describe("Droplet", func() {
 	)
 
 	BeforeEach(func() {
-		clientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
 		dropletRepo := repositories.NewDropletRepo(k8sClient, clientFactory)
 
 		dropletHandler = apis.NewDropletHandler(

--- a/api/apis/integration/route_test.go
+++ b/api/apis/integration/route_test.go
@@ -5,10 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
-	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
-	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 
@@ -29,10 +28,8 @@ var _ = Describe("Route Handler", func() {
 	)
 
 	BeforeEach(func() {
-		clientFactory := repositories.NewUnprivilegedClientFactory(k8sConfig)
-		identityProvider := new(fake.IdentityProvider)
-		nsPermissions := authorization.NewNamespacePermissions(k8sClient, identityProvider, "root-ns")
 		appRepo := repositories.NewAppRepo(k8sClient, clientFactory, nsPermissions)
+		orgRepo := repositories.NewOrgRepo("root-ns", k8sClient, clientFactory, nsPermissions, time.Minute, true)
 		routeRepo := repositories.NewRouteRepo(k8sClient, clientFactory)
 		domainRepo := repositories.NewDomainRepo(k8sClient)
 		decoderValidator, err := NewDefaultDecoderValidator()
@@ -44,6 +41,7 @@ var _ = Describe("Route Handler", func() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			orgRepo,
 			decoderValidator,
 		)
 		apiHandler.RegisterRoutes(router)

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -166,8 +166,11 @@ func (h PackageHandler) packageCreateHandler(authInfo authorization.Info, w http
 	appRecord, err := h.appRepo.GetApp(r.Context(), authInfo, payload.Relationships.App.Data.GUID)
 	if err != nil {
 		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
+		case repositories.NotFoundError:
 			h.logger.Info("App not found", "App GUID", payload.Relationships.App.Data.GUID)
+			writeUnprocessableEntityError(w, "App is invalid. Ensure it exists and you have access to it.")
+		case repositories.ForbiddenError:
+			h.logger.Info("App forbidden", "App GUID", payload.Relationships.App.Data.GUID)
 			writeUnprocessableEntityError(w, "App is invalid. Ensure it exists and you have access to it.")
 		default:
 			h.logger.Info("Error finding App", "App GUID", payload.Relationships.App.Data.GUID)

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -645,7 +645,23 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.PermissionDeniedOrNotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+			})
+
+			JustBeforeEach(func() {
+				makePostRequest(validBody)
+			})
+
+			It("returns an unprocessable entity error", func() {
+				expectUnprocessableEntityError("App is invalid. Ensure it exists and you have access to it.")
+			})
+
+			itDoesntCreateAPackage()
+		})
+
+		When("the app is not accessible", func() {
+			BeforeEach(func() {
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
 			})
 
 			JustBeforeEach(func() {
@@ -671,6 +687,7 @@ var _ = Describe("PackageHandler", func() {
 			It("returns an error", func() {
 				expectUnknownError()
 			})
+
 			itDoesntCreateAPackage()
 		})
 

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -229,7 +229,7 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, w http.Re
 	domain, err := h.domainRepo.GetDomain(ctx, authInfo, domainGUID)
 	if err != nil {
 		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
+		case repositories.NotFoundError:
 			h.logger.Info("Domain not found", "Domain GUID", domainGUID)
 			writeUnprocessableEntityError(w, "Invalid domain. Ensure that the domain exists and you have access to it.")
 			return

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -43,6 +43,7 @@ type RouteHandler struct {
 	routeRepo        CFRouteRepository
 	domainRepo       CFDomainRepository
 	appRepo          CFAppRepository
+	spaceRepo        SpaceRepository
 	decoderValidator *DecoderValidator
 }
 
@@ -52,6 +53,7 @@ func NewRouteHandler(
 	routeRepo CFRouteRepository,
 	domainRepo CFDomainRepository,
 	appRepo CFAppRepository,
+	spaceRepo SpaceRepository,
 	decoderValidator *DecoderValidator,
 ) *RouteHandler {
 	return &RouteHandler{
@@ -60,6 +62,7 @@ func NewRouteHandler(
 		routeRepo:        routeRepo,
 		domainRepo:       domainRepo,
 		appRepo:          appRepo,
+		spaceRepo:        spaceRepo,
 		decoderValidator: decoderValidator,
 	}
 }
@@ -207,16 +210,16 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, w http.Re
 		return
 	}
 
-	namespaceGUID := payload.Relationships.Space.Data.GUID
-	_, err := h.appRepo.GetNamespace(ctx, authInfo, namespaceGUID)
+	spaceGUID := payload.Relationships.Space.Data.GUID
+	_, err := h.spaceRepo.GetSpace(ctx, authInfo, spaceGUID)
 	if err != nil {
 		switch err.(type) {
-		case repositories.PermissionDeniedOrNotFoundError:
-			h.logger.Info("Namespace not found", "Namespace GUID", namespaceGUID)
+		case repositories.NotFoundError:
+			h.logger.Info("Space not found", "spaceGUID", spaceGUID)
 			writeUnprocessableEntityError(w, "Invalid space. Ensure that the space exists and you have access to it.")
 			return
 		default:
-			h.logger.Error(err, "Failed to fetch namespace from Kubernetes", "Namespace GUID", namespaceGUID)
+			h.logger.Error(err, "Failed to fetch space from Kubernetes", "spaceGUID", spaceGUID)
 			writeUnknownErrorResponse(w)
 			return
 		}

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -549,6 +549,16 @@ var _ = Describe("RouteHandler", func() {
 			})
 		})
 
+		When("the domain cannot be found", func() {
+			BeforeEach(func() {
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NotFoundError{})
+			})
+
+			It("returns an error", func() {
+				expectUnknownError()
+			})
+		})
+
 		When("there is a failure finding a Domain", func() {
 			BeforeEach(func() {
 				domainRepo.GetDomainReturns(repositories.DomainRecord{}, errors.New("unknown!"))
@@ -958,9 +968,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain does not exist", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{},
-					repositories.PermissionDeniedOrNotFoundError{Err: errors.New("not found")})
-
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NotFoundError{})
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, testSpaceGUID, "no-such-domain", nil, nil)
 			})
 
@@ -971,9 +979,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("GetDomain returns an unknown error", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{},
-					errors.New("random error"))
-
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, errors.New("random error"))
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, testSpaceGUID, "no-such-domain", nil, nil)
 			})
 

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -34,6 +34,7 @@ var _ = Describe("RouteHandler", func() {
 		routeRepo  *fake.CFRouteRepository
 		domainRepo *fake.CFDomainRepository
 		appRepo    *fake.CFAppRepository
+		spaceRepo  *fake.SpaceRepository
 
 		requestMethod string
 		requestPath   string
@@ -44,6 +45,7 @@ var _ = Describe("RouteHandler", func() {
 		routeRepo = new(fake.CFRouteRepository)
 		domainRepo = new(fake.CFDomainRepository)
 		appRepo = new(fake.CFAppRepository)
+		spaceRepo = new(fake.SpaceRepository)
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -53,6 +55,7 @@ var _ = Describe("RouteHandler", func() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			spaceRepo,
 			decoderValidator,
 		)
 		routeHandler.RegisterRoutes(router)
@@ -602,7 +605,7 @@ var _ = Describe("RouteHandler", func() {
 			requestMethod = http.MethodPost
 			requestPath = "/v3/routes"
 
-			appRepo.GetNamespaceReturns(repositories.SpaceRecord{
+			spaceRepo.GetSpaceReturns(repositories.SpaceRecord{
 				Name: testSpaceGUID,
 			}, nil)
 
@@ -630,9 +633,9 @@ var _ = Describe("RouteHandler", func() {
 		When("the space exists and the route does not exist and", func() {
 			When("a plain POST test route request is sent without metadata", func() {
 				It("checks that the specified namespace exists", func() {
-					Expect(appRepo.GetNamespaceCallCount()).To(Equal(1), "Repo GetNamespace was not called")
-					_, _, actualSpaceGUID := appRepo.GetNamespaceArgsForCall(0)
-					Expect(actualSpaceGUID).To(Equal(testSpaceGUID), "GetNamespace was not passed the correct GUID")
+					Expect(spaceRepo.GetSpaceCallCount()).To(Equal(1))
+					_, _, actualSpaceGUID := spaceRepo.GetSpaceArgsForCall(0)
+					Expect(actualSpaceGUID).To(Equal(testSpaceGUID))
 				})
 
 				It("checks that the specified domain exists", func() {
@@ -929,8 +932,8 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the space does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(repositories.SpaceRecord{},
-					repositories.PermissionDeniedOrNotFoundError{Err: errors.New("not found")})
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{},
+					repositories.NotFoundError{Err: errors.New("not found")})
 
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, "no-such-space", testDomainGUID, nil, nil)
 			})
@@ -940,9 +943,9 @@ var _ = Describe("RouteHandler", func() {
 			})
 		})
 
-		When("GetNamespace returns an unknown error", func() {
+		When("GetSpace returns an unknown error", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(repositories.SpaceRecord{},
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{},
 					errors.New("random error"))
 
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, "no-such-space", testDomainGUID, nil, nil)
@@ -955,10 +958,6 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(repositories.SpaceRecord{
-					Name: testSpaceGUID,
-				}, nil)
-
 				domainRepo.GetDomainReturns(repositories.DomainRecord{},
 					repositories.PermissionDeniedOrNotFoundError{Err: errors.New("not found")})
 
@@ -972,10 +971,6 @@ var _ = Describe("RouteHandler", func() {
 
 		When("GetDomain returns an unknown error", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(repositories.SpaceRecord{
-					Name: testSpaceGUID,
-				}, nil)
-
 				domainRepo.GetDomainReturns(repositories.DomainRecord{},
 					errors.New("random error"))
 
@@ -989,15 +984,6 @@ var _ = Describe("RouteHandler", func() {
 
 		When("CreateRoute returns an unknown error", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(repositories.SpaceRecord{
-					Name: testSpaceGUID,
-				}, nil)
-
-				domainRepo.GetDomainReturns(repositories.DomainRecord{
-					GUID: testDomainGUID,
-					Name: testDomainName,
-				}, nil)
-
 				routeRepo.CreateRouteReturns(repositories.RouteRecord{},
 					errors.New("random error"))
 

--- a/api/apis/service_instance_handler_test.go
+++ b/api/apis/service_instance_handler_test.go
@@ -32,12 +32,12 @@ var _ = Describe("ServiceInstanceHandler", func() {
 	var (
 		req                 *http.Request
 		serviceInstanceRepo *fake.CFServiceInstanceRepository
-		appRepo             *fake.CFAppRepository
+		spaceRepo           *fake.SpaceRepository
 	)
 
 	BeforeEach(func() {
 		serviceInstanceRepo = new(fake.CFServiceInstanceRepository)
-		appRepo = new(fake.CFAppRepository)
+		spaceRepo = new(fake.SpaceRepository)
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -45,7 +45,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 			logf.Log.WithName(testServiceInstanceHandlerLoggerName),
 			*serverURL,
 			serviceInstanceRepo,
-			appRepo,
+			spaceRepo,
 			decoderValidator,
 		)
 		serviceInstanceHandler.RegisterRoutes(router)
@@ -308,9 +308,9 @@ var _ = Describe("ServiceInstanceHandler", func() {
 
 		When("the space does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(
+				spaceRepo.GetSpaceReturns(
 					repositories.SpaceRecord{},
-					repositories.PermissionDeniedOrNotFoundError{Err: errors.New("not found")},
+					repositories.NotFoundError{Err: errors.New("not found")},
 				)
 
 				makePostRequest(validBody)
@@ -321,9 +321,9 @@ var _ = Describe("ServiceInstanceHandler", func() {
 			})
 		})
 
-		When("the get namespace returns an unknown error", func() {
+		When("the get space returns an unknown error", func() {
 			BeforeEach(func() {
-				appRepo.GetNamespaceReturns(
+				spaceRepo.GetSpaceReturns(
 					repositories.SpaceRecord{},
 					errors.New("unknown"),
 				)

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -98,7 +98,7 @@ func (h *SpaceHandler) SpaceCreateHandler(info authorization.Info, w http.Respon
 			return
 		}
 
-		if errors.As(err, &repositories.PermissionDeniedOrNotFoundError{}) {
+		if errors.As(err, &repositories.NotFoundError{}) {
 			h.logger.Error(err, "org does not exist or forbidden")
 			writeUnprocessableEntityError(w, "Invalid organization. Ensure the organization exists and you have access to it.")
 			return

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Spaces", func() {
 
 		When("the repo returns a not found or permission denied error", func() {
 			BeforeEach(func() {
-				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.PermissionDeniedOrNotFoundError{Err: errors.New("nope")})
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NotFoundError{Err: errors.New("nope")})
 			})
 
 			It("returns an unauthorised error", func() {

--- a/api/main.go
+++ b/api/main.go
@@ -148,6 +148,7 @@ func main() {
 			routeRepo,
 			domainRepo,
 			podRepo,
+			orgRepo,
 			scaleAppProcessAction.Invoke,
 			decoderValidator,
 		),
@@ -157,6 +158,7 @@ func main() {
 			routeRepo,
 			domainRepo,
 			appRepo,
+			orgRepo,
 			decoderValidator,
 		),
 		apis.NewServiceRouteBindingHandler(
@@ -237,7 +239,7 @@ func main() {
 			ctrl.Log.WithName("ServiceInstanceHandler"),
 			*serverURL,
 			serviceInstanceRepo,
-			appRepo,
+			orgRepo,
 			decoderValidator,
 		),
 	}

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -339,22 +339,6 @@ func returnAppList(appList []workloadsv1alpha1.CFApp) []AppRecord {
 	return appRecords
 }
 
-func (f *AppRepo) GetNamespace(ctx context.Context, authInfo authorization.Info, nsGUID string) (SpaceRecord, error) {
-	namespace := &corev1.Namespace{}
-	err := f.privilegedClient.Get(ctx, types.NamespacedName{Name: nsGUID}, namespace)
-	if err != nil {
-		switch errtype := err.(type) {
-		case *k8serrors.StatusError:
-			reason := errtype.Status().Reason
-			if reason == metav1.StatusReasonNotFound || reason == metav1.StatusReasonUnauthorized {
-				return SpaceRecord{}, PermissionDeniedOrNotFoundError{Err: err}
-			}
-		}
-		return SpaceRecord{}, err
-	}
-	return v1NamespaceToSpaceRecord(namespace), nil
-}
-
 func (f *AppRepo) PatchAppEnvVars(ctx context.Context, authInfo authorization.Info, message PatchAppEnvVarsMessage) (AppEnvVarsRecord, error) {
 	secretObj := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -560,14 +544,6 @@ func returnApp(apps []workloadsv1alpha1.CFApp) (AppRecord, error) {
 	}
 
 	return cfAppToAppRecord(apps[0]), nil
-}
-
-func v1NamespaceToSpaceRecord(namespace *corev1.Namespace) SpaceRecord {
-	// TODO How do we derive Organization GUID here?
-	return SpaceRecord{
-		Name:             namespace.Name,
-		OrganizationGUID: "",
-	}
 }
 
 func appEnvVarsRecordToSecret(envVars CreateOrPatchAppEnvVarsMessage) corev1.Secret {

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -431,7 +431,7 @@ func (f *AppRepo) SetAppDesiredState(ctx context.Context, authInfo authorization
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return AppRecord{}, PermissionDeniedOrNotFoundError{Err: err}
+			return AppRecord{}, NewForbiddenError(err)
 		}
 
 		return AppRecord{}, fmt.Errorf("err in client.Patch: %w", err)

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -56,50 +56,59 @@ var _ = Describe("AppRepository", func() {
 	})
 
 	Describe("GetApp", func() {
-		When("on the happy path", func() {
+		var (
+			appGUID string
+			app     repositories.AppRecord
+			getErr  error
+		)
+
+		BeforeEach(func() {
+			cfApp1 = createApp(space1.Name)
+			appGUID = cfApp1.Name
+		})
+
+		JustBeforeEach(func() {
+			app, getErr = appRepo.GetApp(testCtx, authInfo, appGUID)
+		})
+
+		When("authorized in the space", func() {
 			BeforeEach(func() {
-				cfApp1 = createApp(space1.Name)
-				cfApp2 = createApp(space2.Name)
-				createRoleBinding(testCtx, userName, spaceDeveloperClusterRole.Name, space2.Name)
+				createRoleBinding(testCtx, userName, spaceDeveloperClusterRole.Name, space1.Name)
 			})
 
 			AfterEach(func() {
 				Expect(k8sClient.Delete(context.Background(), cfApp1)).To(Succeed())
-				Expect(k8sClient.Delete(context.Background(), cfApp2)).To(Succeed())
 			})
 
 			It("can fetch the AppRecord CR we're looking for", func() {
-				app, err := appRepo.GetApp(testCtx, authInfo, cfApp2.Name)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(getErr).NotTo(HaveOccurred())
 
-				Expect(app.GUID).To(Equal(cfApp2.Name))
-				Expect(app.EtcdUID).To(Equal(cfApp2.GetUID()))
+				Expect(app.GUID).To(Equal(cfApp1.Name))
+				Expect(app.EtcdUID).To(Equal(cfApp1.GetUID()))
 				Expect(app.Revision).To(Equal(CFAppRevisionValue))
-				Expect(app.Name).To(Equal(cfApp2.Spec.Name))
-				Expect(app.SpaceGUID).To(Equal(space2.Name))
+				Expect(app.Name).To(Equal(cfApp1.Spec.Name))
+				Expect(app.SpaceGUID).To(Equal(space1.Name))
 				Expect(app.State).To(Equal(DesiredState("STOPPED")))
-				Expect(app.DropletGUID).To(Equal(cfApp2.Spec.CurrentDropletRef.Name))
+				Expect(app.DropletGUID).To(Equal(cfApp1.Spec.CurrentDropletRef.Name))
 				Expect(app.Lifecycle).To(Equal(Lifecycle{
-					Type: string(cfApp2.Spec.Lifecycle.Type),
+					Type: string(cfApp1.Spec.Lifecycle.Type),
 					Data: LifecycleData{
-						Buildpacks: cfApp2.Spec.Lifecycle.Data.Buildpacks,
-						Stack:      cfApp2.Spec.Lifecycle.Data.Stack,
+						Buildpacks: cfApp1.Spec.Lifecycle.Data.Buildpacks,
+						Stack:      cfApp1.Spec.Lifecycle.Data.Stack,
 					},
 				}))
 			})
+		})
 
-			When("the user is not authorized in the space", func() {
-				It("returns a permission denied or not found error", func() {
-					_, err := appRepo.GetApp(testCtx, authInfo, cfApp1.Name)
-					Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
-				})
+		When("the user is not authorized in the space", func() {
+			It("returns a forbidden error", func() {
+				Expect(getErr).To(BeAssignableToTypeOf(repositories.ForbiddenError{}))
 			})
 		})
 
 		When("duplicate Apps exist across namespaces with the same GUIDs", func() {
 			BeforeEach(func() {
-				cfApp1 = createAppWithGUID(space1.Name, "test-guid")
-				cfApp2 = createAppWithGUID(space2.Name, "test-guid")
+				cfApp2 = createAppWithGUID(space2.Name, appGUID)
 			})
 
 			AfterEach(func() {
@@ -108,17 +117,19 @@ var _ = Describe("AppRepository", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := appRepo.GetApp(testCtx, authInfo, "test-guid")
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("duplicate apps exist"))
+				Expect(getErr).To(HaveOccurred())
+				Expect(getErr).To(MatchError("get-app duplicate apps exist"))
 			})
 		})
 
-		When("no Apps exist", func() {
+		When("the app guid is not found", func() {
+			BeforeEach(func() {
+				appGUID = "does-not-exist"
+			})
+
 			It("returns an error", func() {
-				_, err := appRepo.GetApp(testCtx, authInfo, "i don't exist")
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(NotFoundError{ResourceType: "App"}))
+				Expect(getErr).To(HaveOccurred())
+				Expect(getErr).To(MatchError(NotFoundError{ResourceType: "App"}))
 			})
 		})
 	})

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -778,16 +778,6 @@ var _ = Describe("AppRepository", func() {
 		})
 	})
 
-	Describe("GetNamespace", func() {
-		When("space does not exist", func() {
-			It("returns an unauthorized or not found err", func() {
-				_, err := appRepo.GetNamespace(context.Background(), authInfo, "some-guid")
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
-			})
-		})
-	})
-
 	Describe("SetCurrentDroplet", func() {
 		const (
 			appGUID     = "the-app-guid"

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -978,7 +978,7 @@ var _ = Describe("AppRepository", func() {
 
 		When("not allowed to set the application state", func() {
 			It("returns a forbidden error", func() {
-				Expect(returnedErr).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
+				Expect(returnedErr).To(BeAssignableToTypeOf(repositories.ForbiddenError{}))
 			})
 		})
 	})

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -75,7 +75,7 @@ var _ = Describe("DomainRepository", func() {
 		When("no CFDomain exists", func() {
 			It("returns an error", func() {
 				_, err := domainRepo.GetDomain(testCtx, authInfo, "non-existent-domain-guid")
-				Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
+				Expect(err).To(BeAssignableToTypeOf(repositories.NotFoundError{}))
 			})
 		})
 	})

--- a/api/repositories/errors.go
+++ b/api/repositories/errors.go
@@ -5,6 +5,13 @@ import (
 	"fmt"
 )
 
+func NewNotFoundError(resourceType string, baseError error) NotFoundError {
+	return NotFoundError{
+		Err:          baseError,
+		ResourceType: resourceType,
+	}
+}
+
 type NotFoundError struct {
 	Err          error
 	ResourceType string

--- a/api/repositories/errors.go
+++ b/api/repositories/errors.go
@@ -29,30 +29,6 @@ func (e NotFoundError) Unwrap() error {
 	return e.Err
 }
 
-type PermissionDeniedOrNotFoundError struct {
-	Err error
-}
-
-func (e PermissionDeniedOrNotFoundError) Error() string {
-	return errMessage("Resource not found or permission denied", e.Err)
-}
-
-func (e PermissionDeniedOrNotFoundError) Unwrap() error {
-	return e.Err
-}
-
-type ResourceNotFoundError struct {
-	Err error
-}
-
-func (e ResourceNotFoundError) Error() string {
-	return errMessage("Resource not found", e.Err)
-}
-
-func (e ResourceNotFoundError) Unwrap() error {
-	return e.Err
-}
-
 type ForbiddenError struct {
 	err error
 }

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -157,7 +157,7 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, org Cr
 
 func (r *OrgRepo) CreateSpace(ctx context.Context, info authorization.Info, message CreateSpaceMessage) (SpaceRecord, error) {
 	_, err := r.GetOrg(ctx, info, message.OrganizationGUID)
-	if errors.As(err, &PermissionDeniedOrNotFoundError{}) {
+	if errors.As(err, &NotFoundError{}) {
 		return SpaceRecord{}, err
 	}
 	if err != nil {
@@ -436,7 +436,7 @@ func (r *OrgRepo) GetOrg(ctx context.Context, info authorization.Info, orgGUID s
 	}
 
 	if len(orgRecords) == 0 {
-		return OrgRecord{}, PermissionDeniedOrNotFoundError{}
+		return OrgRecord{}, NewNotFoundError("Org", err)
 	}
 
 	return orgRecords[0], nil

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -235,7 +235,7 @@ var _ = Describe("OrgRepository", func() {
 							Name:             "some-name",
 							OrganizationGUID: "does-not-exist",
 						})
-						Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
+						Expect(err).To(BeAssignableToTypeOf(repositories.NotFoundError{}))
 					})
 				})
 
@@ -252,7 +252,7 @@ var _ = Describe("OrgRepository", func() {
 							Name:             "some-name",
 							OrganizationGUID: otherOrg.Name,
 						})
-						Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
+						Expect(err).To(BeAssignableToTypeOf(repositories.NotFoundError{}))
 					})
 				})
 			})
@@ -662,17 +662,10 @@ var _ = Describe("OrgRepository", func() {
 				})
 			})
 
-			When("the org doesn't exist", func() {
+			When("the org isn't found", func() {
 				It("errors", func() {
 					_, err := orgRepo.GetOrg(ctx, authInfo, "non-existent-org")
-					Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
-				})
-			})
-
-			When("the user doesn't have permissions to see the org", func() {
-				It("returns an error", func() {
-					_, err := orgRepo.GetOrg(ctx, authInfo, orgAnchor.Name)
-					Expect(err).To(BeAssignableToTypeOf(repositories.PermissionDeniedOrNotFoundError{}))
+					Expect(err).To(BeAssignableToTypeOf(repositories.NotFoundError{}))
 				})
 			})
 		})

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -94,11 +94,6 @@ var _ = Describe("Apps", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("fails", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
-			Expect(resp.Body()).To(ContainSubstring("CF-NotAuthorized"))
-		})
-
 		When("the user has space developer role in the space", func() {
 			BeforeEach(func() {
 				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, space1GUID)
@@ -106,6 +101,17 @@ var _ = Describe("Apps", func() {
 
 			It("succeeds", func() {
 				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			})
+		})
+
+		When("the user cannot create apps in the space", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, space1GUID)
+			})
+
+			It("fails", func() {
+				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp.Body()).To(ContainSubstring("CF-NotAuthorized"))
 			})
 		})
 	})

--- a/docs/architecture-decisions/0013-repo-errors.md
+++ b/docs/architecture-decisions/0013-repo-errors.md
@@ -1,0 +1,62 @@
+# Not found and forbidden errors returned from the repositories package
+
+Date: 2022-02-07
+
+## Status
+
+Review
+
+## Context
+
+There has been a proliferation of error types that are returned from
+repositories methods, namely `NotFoundError`, `ResourceNotFoundError`,
+`ForbiddenError` and `PermissionDeniedOrNotFoundError`. The first two are
+clearly duplicates, and the last is intended to return either a not found error
+or a forbidden error.
+
+The code contains a mixture of NotFound errors and PermissionDeniedOrNotFound
+errors, and more Forbidden errors have been appearing recently. It is not
+possible to know whether a repositories method would return a NotFound or a
+PermissionDeniedOrNotFound error when a resource is not found. Or equally
+whether it would return a Forbidden or a PermissionDeniedOrNotFound error when
+a user's role does not grant access to the resource.
+
+The consequence is that mistakes have been made in the handlers which call the
+repo methods. For example, there are plenty of unit tests faking
+PermissionDeniedOrNotFoundError responses, where the repo code will only ever
+return a NotFoundError. The go language does not provide any type help with
+returned errors, as they all implement the error interface, so we need to make
+it as easy as possible to get error checking correct.
+
+It should also be known that the CF API converts forbidden errors to not found
+errors in certain circumstances to prevent information leakage to unauthorized
+users. Generally, when perform a get of a single resource, a forbidden error
+should be returned as a 404 not found error. When listing resources, forbidden
+resources should be excluded from the list without error. And when modifying
+resources, unauthorized gets while fetching related objects should return a 404
+response, whereas an unauthorized update on a resource should return a 403
+response.
+
+## Decision
+
+We should use only the NotFoundError and ForbiddenError types.
+
+PermissionDeniedOrNotFoundError and ResourceNotFoundError are to be deleted.
+
+Other errors encountered in the repositories package, not intended to be
+specifically handled, can be returned as wrapped errors using
+`fmt.Errorf("<detail>: %w", err)`. We would expect these to trigger a 500
+error response.
+
+Handlers are responsible for determining the end user error based on the errors
+returned from the repositories package.
+
+## Consequences
+
+1. Errors returned from the repositories package when resources are not found
+   or forbidden are predictable.
+1. Unit tests are less likely to fake the wrong errors
+1. Detailed information about the intent of the error is retained until the
+   point at which it is converted to a user error.
+1. k8s errors, although wrapped, are kept inside the repositories packages
+1. No need to check wrapped errors inside the apis package


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/403

## What is this change about?
The `ResourceNotFoundError` type was not used, so this could be simply deleted.

`PermissionDeniedOrNotFoundError` introduced confusion. E.g. `GetApp()` would return `NotFoundError` when no app was found, but some handlers would check for the `PermissionDeniedOrNotFoundError`, and omit the `NotFoundError` check. So we had a lot of erroneous 500 status responses to api calls which should have been 404s.

As described in the associated ADR, we believe that we should take the simple approach of returning `NotFoundError` when a resource is not found, and `ForbiddenError` when it is forbidden to the user. This way we communicate the result clearly to the handler layer without requiring it to introspect wrapped k8s errors. It is up to the handlers to return the appropriate CF error based on what errors are returned from the various repo method calls.

This also makes it simpler to write handlers and handler tests, as there won't be a choice of error types for a particular error.

**Note** while removing `PermissionDeneidOrNotFound` from the app repository `GetNamespace` method, we saw this method was superseded by `GetSpace` from the org repository, so we updated callers and removed this method.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green CI. No user visible change.

## Tag your pair, your PM, and/or team
@eirini
