### PR TITLE
Fix e2e/package test flake

### DIFF
--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -26,6 +26,8 @@ var _ = Describe("Orgs", func() {
 		BeforeEach(func() {
 			client = adminClient
 			orgName = generateGUID("my-org")
+			result = resource{}
+			resultErr = cfErrs{}
 		})
 
 		AfterEach(func() {

--- a/api/tests/e2e/roles_test.go
+++ b/api/tests/e2e/roles_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Roles", func() {
 		userName = uuid.NewString()
 		orgGUID = createOrg(uuid.NewString())
 		client = adminClient
+		result = roleResource{}
 	})
 
 	AfterEach(func() {

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Spaces", func() {
 			orgGUID = createOrg(generateGUID("org"))
 			parentGUID = orgGUID
 			createOrgRole("organization_user", rbacv1.ServiceAccountKind, serviceAccountName, orgGUID)
+			resultErr = cfErrs{}
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Always reset vars used in tests. In particular, the object used in SetError does not get updated if the rest call does not fail, so you must ensure it is reset each time if you are going to check it on happy paths.

## Does this PR introduce a breaking change?
Nope

## Acceptance Steps
`make test-e2e`

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
