### PR TITLE
Fix cross test contamination in controller units

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ issues:
     - path: _test\.go
       linters:
       - dupl
+    # We are getting false positives comparing the cfserviceinstance and cfservicebinding reconcile loops. This may
+    # become unnecessary later if the implementation diverges more.
     - path: service\w+_controller\.go
       linters:
         - dupl

--- a/api/tests/e2e/package_test.go
+++ b/api/tests/e2e/package_test.go
@@ -25,6 +25,9 @@ var _ = Describe("Package", func() {
 
 		spaceGUID = createSpace(generateGUID("space1"), orgGUID)
 		appGUID = createApp(spaceGUID, generateGUID("app"))
+
+		result = packageResource{}
+		resultErr = cfErrs{}
 	})
 
 	AfterEach(func() {

--- a/controllers/controllers/services/cfservicebinding_controller_test.go
+++ b/controllers/controllers/services/cfservicebinding_controller_test.go
@@ -46,6 +46,10 @@ var _ = Describe("CFServiceBinding.Reconcile", func() {
 	)
 
 	BeforeEach(func() {
+		getCFServiceBindingError = nil
+		getCFServiceBindingSecretError = nil
+		updateCFServiceBindingStatusError = nil
+
 		fakeClient = new(fake.Client)
 		fakeStatusWriter = new(fake.StatusWriter)
 		fakeClient.StatusReturns(fakeStatusWriter)
@@ -154,7 +158,7 @@ var _ = Describe("CFServiceBinding.Reconcile", func() {
 		})
 		When("The API errors setting status on the CFServiceBinding", func() {
 			BeforeEach(func() {
-				updateCFServiceBindingStatusError = errors.New("some random error")
+				updateCFServiceBindingStatusError = errors.New("another random error")
 			})
 
 			It("errors", func() {

--- a/controllers/controllers/services/cfserviceinstance_controller_test.go
+++ b/controllers/controllers/services/cfserviceinstance_controller_test.go
@@ -46,6 +46,10 @@ var _ = Describe("CFServiceInstance.Reconcile", func() {
 	)
 
 	BeforeEach(func() {
+		getCFServiceInstanceError = nil
+		getCFServiceInstanceSecretError = nil
+		updateCFServiceInstanceStatusError = nil
+
 		fakeClient = new(fake.Client)
 		fakeStatusWriter = new(fake.StatusWriter)
 		fakeClient.StatusReturns(fakeStatusWriter)


### PR DESCRIPTION
## Is there a related GitHub Issue?
#549

## What is this change about?
- cfservicebinding_controller_test and cfserviceinstance_controller_test
  had variables not getting re-initialized between test runs, causing
  flakiness.

## Does this PR introduce a breaking change?
no.

## Acceptance Steps
CI covers it.

## Tag your pair, your PM, and/or team
@davewalter 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
