### PR TITLE
Improve E2E tests failure messages

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("returns apps only in authorized spaces", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 
 			Expect(result.Resources).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{"GUID": Equal(app1GUID)}),
@@ -100,7 +100,7 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("succeeds", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			})
 		})
 
@@ -110,8 +110,8 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("fails", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
-				Expect(resp.Body()).To(ContainSubstring("CF-NotAuthorized"))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
+				Expect(resp).To(HaveRestyBody(ContainSubstring("CF-NotAuthorized")))
 			})
 		})
 	})
@@ -131,7 +131,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("can fetch the app", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.GUID).To(Equal(appGUID))
 		})
 	})
@@ -151,7 +151,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("successfully lists the empty set of processes", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(BeEmpty())
 		})
 	})
@@ -171,7 +171,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("successfully lists the empty set of routes", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(BeEmpty())
 		})
 	})
@@ -205,7 +205,7 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("succeeds", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(result.GUID).To(Equal(buildGUID))
 			})
 		})
@@ -230,7 +230,7 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("returns 200", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(result.Data.GUID).To(Equal(buildGUID))
 			})
 		})
@@ -249,7 +249,7 @@ var _ = Describe("Apps", func() {
 			})
 
 			It("succeeds", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(result.State).To(Equal("STARTED"))
 			})
 		})

--- a/api/tests/e2e/builds_test.go
+++ b/api/tests/e2e/builds_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Builds", func() {
 		})
 
 		It("returns the build", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.GUID).To(Equal(buildGUID))
 		})
 	})
@@ -64,7 +64,7 @@ var _ = Describe("Builds", func() {
 		})
 
 		It("returns the build", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			Expect(result.Package.GUID).To(Equal(pkgGUID))
 		})
 	})

--- a/api/tests/e2e/droplets_test.go
+++ b/api/tests/e2e/droplets_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 
+	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -40,12 +41,11 @@ var _ = Describe("Droplets", func() {
 		})
 
 		JustBeforeEach(func() {
-			Eventually(func() (int, error) {
-				resp, err := certClient.R().
+			Eventually(func() (*resty.Response, error) {
+				return certClient.R().
 					SetResult(&result).
 					Get("/v3/droplets/" + buildGUID)
-				return resp.StatusCode(), err
-			}).Should(Equal(http.StatusOK))
+			}).Should(HaveRestyStatusCode(http.StatusOK))
 		})
 
 		It("returns the droplet", func() {

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -354,7 +354,7 @@ func createRole(roleName, kind, orgSpaceType, userName, orgSpaceGUID string) {
 		Post(rolesURL)
 
 	ExpectWithOffset(2, err).NotTo(HaveOccurred())
-	ExpectWithOffset(2, resp.StatusCode()).To(Equal(http.StatusCreated))
+	ExpectWithOffset(2, resp).To(HaveRestyStatusCode(http.StatusCreated))
 }
 
 func createOrgRole(roleName, kind, userName, orgGUID string) {
@@ -493,7 +493,7 @@ func createApp(spaceGUID, name string) string {
 		Post("/v3/apps")
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 
 	return app.GUID
 }
@@ -506,7 +506,7 @@ func getProcess(appGUID, processType string) string {
 		Get("/v3/processes?app_guids=" + appGUID)
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 	Expect(processList.Resources).To(HaveLen(1))
 
 	return processList.Resources[0].GUID
@@ -527,7 +527,7 @@ func createPackage(appGUID string) string {
 		Post("/v3/packages")
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 
 	return pkg.GUID
 }
@@ -541,17 +541,17 @@ func createBuild(packageGUID string) string {
 		Post("/v3/builds")
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 
 	return build.GUID
 }
 
 func waitForDroplet(buildGUID string) {
-	Eventually(func() (int, error) {
+	Eventually(func() (*resty.Response, error) {
 		resp, err := adminClient.R().
 			Get("/v3/droplets/" + buildGUID)
-		return resp.StatusCode(), err
-	}).Should(Equal(http.StatusOK))
+		return resp, err
+	}).Should(HaveRestyStatusCode(http.StatusOK))
 }
 
 func setCurrentDroplet(appGUID, dropletGUID string) {
@@ -560,7 +560,7 @@ func setCurrentDroplet(appGUID, dropletGUID string) {
 		Patch("/v3/apps/" + appGUID + "/relationships/current_droplet")
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 }
 
 func startApp(appGUID string) {
@@ -568,7 +568,7 @@ func startApp(appGUID string) {
 		Post("/v3/apps/" + appGUID + "/actions/start")
 
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 }
 
 func uploadNodeApp(pkgGUID string) {
@@ -577,7 +577,7 @@ func uploadNodeApp(pkgGUID string) {
 			"bits": "assets/node.zip",
 		}).Post("/v3/packages/" + pkgGUID + "/upload")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+	Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 }
 
 // pushNodeApp creates a running node app in the given space

--- a/api/tests/e2e/helpers/resty.go
+++ b/api/tests/e2e/helpers/resty.go
@@ -1,0 +1,50 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+)
+
+type actualRestyResponse struct {
+	*resty.Response
+}
+
+func NewActualRestyResponse(response *resty.Response) actualRestyResponse {
+	return actualRestyResponse{Response: response}
+}
+
+func (m actualRestyResponse) GomegaString() string {
+	return fmt.Sprintf(`
+    Request: %s %s
+    Request body:
+        %+v
+    HTTP Status code: %d
+    Response body:
+        %s`,
+		m.Request.Method, m.Request.URL,
+		objectToPrettyJson(m.Request.Body),
+		m.StatusCode(),
+		formatAsPrettyJson(m.Body()),
+	)
+}
+
+func objectToPrettyJson(obj interface{}) string {
+	prettyJson, err := json.MarshalIndent(obj, "        ", "  ")
+	if err != nil {
+		return fmt.Sprintf("%+v", obj)
+	}
+
+	return string(prettyJson)
+}
+
+func formatAsPrettyJson(b []byte) string {
+	var prettyBuf bytes.Buffer
+	if err := json.Indent(&prettyBuf, b, "        ", "  "); err != nil {
+		return string(b)
+	}
+
+	return prettyBuf.String()
+}

--- a/api/tests/e2e/matchers_test.go
+++ b/api/tests/e2e/matchers_test.go
@@ -1,0 +1,88 @@
+package e2e_test
+
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/tests/e2e/helpers"
+	"github.com/go-resty/resty/v2"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/matchers"
+	"github.com/onsi/gomega/types"
+)
+
+func HaveRestyStatusCode(expected int) types.GomegaMatcher {
+	return &haveRestyStatusCode{
+		expected: expected,
+	}
+}
+
+type haveRestyStatusCode struct {
+	expected int
+}
+
+func (matcher *haveRestyStatusCode) Match(actual interface{}) (bool, error) {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return false, fmt.Errorf("HaveRestyStatusCode matcher expects a resty.Response")
+	}
+
+	return response.StatusCode() == matcher.expected, nil
+}
+
+func (matcher *haveRestyStatusCode) FailureMessage(actual interface{}) string {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return fmt.Sprintf("%v is not a resty.Response", actual)
+	}
+
+	return format.Message(helpers.NewActualRestyResponse(response), "to have HTTP Status code", matcher.expected)
+}
+
+func (matcher *haveRestyStatusCode) NegatedFailureMessage(actual interface{}) string {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return fmt.Sprintf("%v is not a resty.Response", actual)
+	}
+
+	return format.Message(helpers.NewActualRestyResponse(response), "not to have HTTP Status code", matcher.expected)
+}
+
+func HaveRestyBody(expected interface{}) types.GomegaMatcher {
+	switch e := expected.(type) {
+	case types.GomegaMatcher:
+		return &haveRestyBody{matcher: e}
+	default:
+		return &haveRestyBody{matcher: &matchers.EqualMatcher{Expected: expected}}
+	}
+}
+
+type haveRestyBody struct {
+	matcher types.GomegaMatcher
+}
+
+func (m *haveRestyBody) Match(actual interface{}) (bool, error) {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return false, fmt.Errorf("%v is not a resty.Response", actual)
+	}
+
+	return m.matcher.Match(response.Body())
+}
+
+func (m *haveRestyBody) FailureMessage(actual interface{}) string {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return fmt.Sprintf("%v is not a resty.Response", actual)
+	}
+
+	return format.Message(helpers.NewActualRestyResponse(response), "to have body", m.matcher)
+}
+
+func (m *haveRestyBody) NegatedFailureMessage(actual interface{}) string {
+	response, ok := actual.(*resty.Response)
+	if !ok {
+		return fmt.Sprintf("%v is not a resty.Response", actual)
+	}
+
+	return format.Message(helpers.NewActualRestyResponse(response), "not to have body", m.matcher)
+}

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Orgs", func() {
 		})
 
 		It("succeeds", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			Expect(result.Name).To(Equal(orgName))
 			Expect(result.GUID).NotTo(BeEmpty())
 		})
@@ -62,7 +62,7 @@ var _ = Describe("Orgs", func() {
 			})
 
 			It("returns an unprocessable entity error", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(resultErr.Errors).To(HaveLen(1))
 				Expect(resultErr.Errors[0].Code).To(BeNumerically("==", 10008))
 				Expect(resultErr.Errors[0].Detail).To(MatchRegexp(fmt.Sprintf(`Organization '%s' already exists.`, orgName)))
@@ -76,7 +76,7 @@ var _ = Describe("Orgs", func() {
 			})
 
 			It("returns a forbidden error", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 			})
 		})
 	})
@@ -134,7 +134,7 @@ var _ = Describe("Orgs", func() {
 		})
 
 		It("returns orgs that the service account has a role in", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(org1Name)}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(org2Name)}),

--- a/api/tests/e2e/packages_test.go
+++ b/api/tests/e2e/packages_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Package", func() {
 		})
 
 		It("fails with a resource not found error", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 			Expect(resultErr.Errors).To(HaveLen(1))
 			Expect(resultErr.Errors[0].Title).To(Equal("CF-UnprocessableEntity"))
 			Expect(resultErr.Errors[0].Code).To(Equal(10008))
@@ -67,7 +67,7 @@ var _ = Describe("Package", func() {
 
 			It("succeeds", func() {
 				Expect(resultErr.Errors).To(HaveLen(0))
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 				Expect(result.GUID).ToNot(BeEmpty())
 			})
 		})
@@ -78,7 +78,7 @@ var _ = Describe("Package", func() {
 			})
 
 			It("fails with a forbidden error", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 				Expect(resultErr.Errors).To(HaveLen(1))
 				Expect(resultErr.Errors[0].Title).To(Equal("CF-NotAuthorized"))
 				Expect(resultErr.Errors[0].Code).To(Equal(10003))
@@ -110,7 +110,7 @@ var _ = Describe("Package", func() {
 			})
 
 			It("fails with a forbidden error", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 				Expect(resultErr.Errors).To(HaveLen(1))
 				Expect(resultErr.Errors[0].Title).To(Equal("CF-NotAuthorized"))
 				Expect(resultErr.Errors[0].Code).To(Equal(10003))
@@ -124,7 +124,7 @@ var _ = Describe("Package", func() {
 			})
 
 			It("succeeds", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			})
 		})
 	})

--- a/api/tests/e2e/processes_test.go
+++ b/api/tests/e2e/processes_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Processes", func() {
 		})
 
 		It("fails without space permissions", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusNotFound))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusNotFound))
 			Expect(listErr.Errors).To(HaveLen(1))
 			Expect(listErr.Errors[0].Code).To(Equal(10010))
 			Expect(listErr.Errors[0].Title).To(Equal("CF-ResourceNotFound"))
@@ -74,7 +74,7 @@ var _ = Describe("Processes", func() {
 			})
 
 			It("lists the (empty list of) sidecars", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK), string(resp.Body()))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(list.Resources).To(BeEmpty())
 			})
 		})
@@ -90,7 +90,7 @@ var _ = Describe("Processes", func() {
 		})
 
 		It("can fetch the process", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.GUID).To(Equal(processGUID))
 		})
 	})

--- a/api/tests/e2e/roles_test.go
+++ b/api/tests/e2e/roles_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Roles", func() {
 		})
 
 		It("creates a role binding", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			Expect(result.GUID).ToNot(BeEmpty())
 			Expect(result.Type).To(Equal("organization_manager"))
 			Expect(result.Relationships).To(HaveKey("user"))
@@ -64,7 +64,7 @@ var _ = Describe("Roles", func() {
 			})
 
 			It("returns 403 Forbidden", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 			})
 		})
 	})
@@ -95,7 +95,7 @@ var _ = Describe("Roles", func() {
 		})
 
 		It("creates a role binding", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 			Expect(result.GUID).ToNot(BeEmpty())
 			Expect(result.Type).To(Equal("space_developer"))
 			Expect(result.Relationships).To(HaveKey("user"))
@@ -110,7 +110,7 @@ var _ = Describe("Roles", func() {
 			})
 
 			It("returns 403 Forbidden", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 			})
 		})
 	})

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Spaces", func() {
 			})
 
 			It("creates a space", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusCreated))
 				Expect(result.Name).To(Equal(spaceName))
 				Expect(result.GUID).NotTo(BeEmpty())
 			})
@@ -69,7 +69,7 @@ var _ = Describe("Spaces", func() {
 				})
 
 				It("returns an unprocessable entity error", func() {
-					Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
+					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(resultErr.Errors).To(HaveLen(1))
 					Expect(resultErr.Errors[0].Code).To(BeNumerically("==", 10008))
 					Expect(resultErr.Errors[0].Detail).To(MatchRegexp(fmt.Sprintf(`Space '%s' already exists.`, spaceName)))
@@ -84,7 +84,7 @@ var _ = Describe("Spaces", func() {
 				})
 
 				It("denies the request", func() {
-					Expect(resp.StatusCode()).To(Equal(http.StatusUnprocessableEntity))
+					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(resultErr.Errors).To(HaveLen(1))
 					Expect(resultErr.Errors[0].Code).To(BeNumerically("==", 10008))
 					Expect(resultErr.Errors[0].Detail).To(Equal("Invalid organization. Ensure the organization exists and you have access to it."))
@@ -99,7 +99,7 @@ var _ = Describe("Spaces", func() {
 			})
 
 			It("returns a forbidden error", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusForbidden))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusForbidden))
 			})
 		})
 	})
@@ -188,7 +188,7 @@ var _ = Describe("Spaces", func() {
 		})
 
 		It("lists the spaces the user has role in", func() {
-			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 			Expect(result.Resources).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(space11Name)}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(space12Name)}),
@@ -212,7 +212,7 @@ var _ = Describe("Spaces", func() {
 			})
 
 			It("only lists spaces beloging to the orgs", func() {
-				Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(result.Resources).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{"Name": Equal(space11Name)}),
 					MatchFields(IgnoreExtras, Fields{"Name": Equal(space12Name)}),

--- a/api/tests/e2e/whoami_test.go
+++ b/api/tests/e2e/whoami_test.go
@@ -51,7 +51,7 @@ var _ = Describe("WhoAmI", func() {
 			})
 
 			It("returns an unauthorized error", func() {
-				Expect(httpResp.StatusCode()).To(Equal(http.StatusUnauthorized))
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusUnauthorized))
 			})
 		})
 	})
@@ -72,7 +72,7 @@ var _ = Describe("WhoAmI", func() {
 			})
 
 			It("returns an unauthorized error", func() {
-				Expect(httpResp.StatusCode()).To(Equal(http.StatusUnauthorized))
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusUnauthorized))
 			})
 		})
 
@@ -83,14 +83,14 @@ var _ = Describe("WhoAmI", func() {
 			})
 
 			It("returns an unauthorized error", func() {
-				Expect(httpResp.StatusCode()).To(Equal(http.StatusUnauthorized))
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusUnauthorized))
 			})
 		})
 	})
 
 	When("no Authorization header is available in the request", func() {
 		It("returns unauthorized error", func() {
-			Expect(httpResp.StatusCode()).To(Equal(http.StatusUnauthorized))
+			Expect(httpResp).To(HaveRestyStatusCode(http.StatusUnauthorized))
 		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/638

## What is this change about?
Introduce custom Gomega matchers to verify `resty.Response` status code  and body.

The custom matchers use a wrapper over `resty.Response` that implements the [`GomegaStringer`](https://github.com/onsi/gomega/blob/d01bc22577e88a1c7afa2448e81ee8e43a598d28/format/format.go#L61-L66)  interface and prints the `resty.Reponse` in a developers' friendly way. Thus we could make use of the Gomega's [`Message`](https://github.com/onsi/gomega/blob/d01bc22577e88a1c7afa2448e81ee8e43a598d28/format/format.go#L82) utility to display failure messages in a standard manner.

The body matcher can take either a value (then the standard `Equal` matcher is used to check the value), or a Gomega matcher.

Failure examples:

* Unexpected HTTP status code:

```
Expected
    <helpers.actualRestyResponse>:
    Request: POST http://localhost/v3/apps
    Request body:
        {
          "name": "app-524d3e94-8995",
          "relationships": {
            "space": {
              "data": {
                "guid": "b5cc5137-2aa4-46c9-813e-28742c85fa5c"
              }
            }
          }
        }
    HTTP Status code: 403
    Response body:
        {
          "errors": [
            {
              "detail": "You are not authorized to perform the requested action",
              "title": "CF-NotAuthorized",
              "code": 10003
            }
          ]
        }

to have HTTP Status code
    <int>: 418
In [It] at: /home/danailster/workspace/cf-k8s-controllers/api/tests/e2e/apps_test.go:113

```

* Unexpected response body:

```
Expected
    <helpers.actualRestyResponse>:
    Request: POST http://localhost/v3/apps
    Request body:
        {
          "name": "app-efcb8a47-4481",
          "relationships": {
            "space": {
              "data": {
                "guid": "727d22bc-8913-4308-bba4-a420b39f5d7a"
              }
            }
          }
        }
    HTTP Status code: 403
    Response body:
        {
          "errors": [
            {
              "detail": "You are not authorized to perform the requested action",
              "title": "CF-NotAuthorized",
              "code": 10003
            }
          ]
        }

to have body
    <*matchers.ContainSubstringMatcher | 0xc000599590>: {
        Substr: "CF-NotFound",
        Args: nil,
    }
In [It] at: /home/danailster/workspace/cf-k8s-controllers/api/tests/e2e/apps_test.go:113

```

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@kieron-dev 
