### PR TITLE
Fix error in `POST /v3/builds`

### DIFF
--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -81,7 +81,7 @@ func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, w http.Re
 		switch err.(type) {
 		case repositories.ForbiddenError:
 			h.logger.Info("Package forbidden", "Package GUID", payload.Package.GUID)
-			writeNotFoundErrorResponse(w, "App")
+			writeUnprocessableEntityError(w, "Unable to use package. Ensure that the package exists and you have access to it.")
 		case repositories.NotFoundError:
 			h.logger.Info("Package not found", "Package GUID", payload.Package.GUID)
 			writeUnprocessableEntityError(w, "Unable to use package. Ensure that the package exists and you have access to it.")

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -548,8 +548,9 @@ var _ = Describe("BuildHandler", func() {
 				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(nil))
 			})
 
-			It("returns a not found error", func() {
-				expectNotFoundError("App not found")
+			It("returns an error", func() {
+				expectUnprocessableEntityError("Unable to use package. Ensure that the package exists and you have access to it.")
+				Expect(buildRepo.CreateBuildCallCount()).To(Equal(0))
 			})
 		})
 

--- a/api/apis/integration/build_test.go
+++ b/api/apis/integration/build_test.go
@@ -125,8 +125,8 @@ var _ = Describe("Build", func() {
 		})
 
 		When("the user is not authorized to get the package", func() {
-			It("returns a not found error", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+			It("returns an unprocessable entity error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
 			})
 		})
 	})


### PR DESCRIPTION
When creating a build for a package isn't authorised to see, the error should not be 404 but a 422. Fixes #543 for good.

