### PR TITLE
Add required params to /v3/service_instances

### DIFF
--- a/api/apis/service_instance_handler.go
+++ b/api/apis/service_instance_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/gorilla/schema"
 
@@ -120,6 +121,12 @@ func (h *ServiceInstanceHandler) serviceInstanceListHandler(authInfo authorizati
 		h.logger.Error(err, "Unable to parse request query parameters")
 		writeUnknownErrorResponse(w)
 		return
+	}
+
+	for k := range r.Form {
+		if strings.HasPrefix(k, "fields[") || k == "per_page" {
+			r.Form.Del(k)
+		}
 	}
 
 	listFilter := new(payloads.ServiceInstanceList)

--- a/api/payloads/service_instance.go
+++ b/api/payloads/service_instance.go
@@ -1,6 +1,10 @@
 package payloads
 
-import "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+import (
+	"strings"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+)
 
 type ServiceInstanceCreate struct {
 	Name          string                       `json:"name" validate:"required"`
@@ -30,15 +34,18 @@ func (p ServiceInstanceCreate) ToServiceInstanceCreateMessage() repositories.Cre
 type ServiceInstanceList struct {
 	Names      *string `schema:"names"`
 	SpaceGuids *string `schema:"space_guids"`
+	OrderBy    string  `schema:"order_by"`
 }
 
 func (l *ServiceInstanceList) ToMessage() repositories.ListServiceInstanceMessage {
 	return repositories.ListServiceInstanceMessage{
-		Names:      ParseArrayParam(l.Names),
-		SpaceGuids: ParseArrayParam(l.SpaceGuids),
+		Names:           ParseArrayParam(l.Names),
+		SpaceGuids:      ParseArrayParam(l.SpaceGuids),
+		OrderBy:         strings.TrimPrefix(l.OrderBy, "-"),
+		DescendingOrder: strings.HasPrefix(l.OrderBy, "-"),
 	}
 }
 
 func (l *ServiceInstanceList) SupportedFilterKeys() []string {
-	return []string{"names", "space_guids"}
+	return []string{"names", "space_guids", "fields", "order_by", "per_page"}
 }

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,8 +55,10 @@ type CreateServiceInstanceMessage struct {
 }
 
 type ListServiceInstanceMessage struct {
-	Names      []string
-	SpaceGuids []string
+	Names           []string
+	SpaceGuids      []string
+	OrderBy         string
+	DescendingOrder bool
 }
 
 type ServiceInstanceRecord struct {
@@ -125,7 +129,9 @@ func (r *ServiceInstanceRepo) ListServiceInstances(ctx context.Context, authInfo
 		filteredServiceInstances = append(filteredServiceInstances, applyServiceInstanceListFilter(serviceInstanceList.Items, message)...)
 	}
 
-	return returnServiceInstanceList(filteredServiceInstances), nil
+	orderedServiceInstances := orderServiceInstances(filteredServiceInstances, message)
+
+	return returnServiceInstanceList(orderedServiceInstances), nil
 }
 
 func (m CreateServiceInstanceMessage) toCFServiceInstance() servicesv1alpha1.CFServiceInstance {
@@ -220,4 +226,30 @@ func returnServiceInstanceList(serviceInstanceList []servicesv1alpha1.CFServiceI
 		serviceInstanceRecords = append(serviceInstanceRecords, cfServiceInstanceToServiceInstanceRecord(serviceInstance))
 	}
 	return serviceInstanceRecords
+}
+
+func orderServiceInstances(serviceInstances []servicesv1alpha1.CFServiceInstance, message ListServiceInstanceMessage) []servicesv1alpha1.CFServiceInstance {
+	sort.Slice(serviceInstances, func(i, j int) bool {
+		var ret bool
+
+		if message.OrderBy == "created_at" {
+			ret = serviceInstances[i].CreationTimestamp.Before(&serviceInstances[j].CreationTimestamp)
+		} else if message.OrderBy == "updated_at" {
+			// Ignoring the errors that could be returned as there is no way to handle them
+			updateTime1, _ := getTimeLastUpdatedTimestamp(&serviceInstances[i].ObjectMeta)
+			updateTime2, _ := getTimeLastUpdatedTimestamp(&serviceInstances[j].ObjectMeta)
+			ret = strings.Compare(updateTime1, updateTime2) == -1
+		} else {
+			// Default to sorting by name
+			ret = serviceInstances[i].Spec.Name < serviceInstances[j].Spec.Name
+		}
+
+		if message.DescendingOrder {
+			return !ret
+		} else {
+			return ret
+		}
+	})
+
+	return serviceInstances
 }

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -255,6 +255,177 @@ var _ = Describe("ServiceInstanceRepository", func() {
 					))
 				})
 			})
+
+			When("the OrderBy field is set to 'name'", func() {
+				BeforeEach(func() {
+					filters = ListServiceInstanceMessage{
+						SpaceGuids: []string{
+							cfServiceInstance1.Namespace,
+							cfServiceInstance2.Namespace,
+							cfServiceInstance3.Namespace,
+						},
+						OrderBy: "name",
+					}
+				})
+
+				It("eventually returns the ServiceBindings in ascending name order", func() {
+					var serviceInstanceList []ServiceInstanceRecord
+					Eventually(func() []ServiceInstanceRecord {
+						var err error
+						serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+						Expect(err).NotTo(HaveOccurred())
+						return serviceInstanceList
+					}, timeCheckThreshold*time.Second).Should(HaveLen(3))
+					Expect(serviceInstanceList[0]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance1.Name)}))
+					Expect(serviceInstanceList[1]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance2.Name)}))
+					Expect(serviceInstanceList[2]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance3.Name)}))
+				})
+
+				When("the DescendingOrder field is true", func() {
+					BeforeEach(func() {
+						filters.DescendingOrder = true
+					})
+
+					It("eventually returns the ServiceBindings in descending name order", func() {
+						var serviceInstanceList []ServiceInstanceRecord
+						Eventually(func() []ServiceInstanceRecord {
+							var err error
+							serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+							Expect(err).NotTo(HaveOccurred())
+							return serviceInstanceList
+						}, timeCheckThreshold*time.Second).Should(HaveLen(3))
+						Expect(serviceInstanceList[0]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance3.Name)}))
+						Expect(serviceInstanceList[1]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance2.Name)}))
+						Expect(serviceInstanceList[2]).To(MatchFields(IgnoreExtras, Fields{"GUID": Equal(cfServiceInstance1.Name)}))
+					})
+				})
+			})
+
+			When("the OrderBy field is set to 'created_at'", func() {
+				BeforeEach(func() {
+					filters = ListServiceInstanceMessage{
+						SpaceGuids: []string{
+							cfServiceInstance1.Namespace,
+							cfServiceInstance2.Namespace,
+							cfServiceInstance3.Namespace,
+						},
+						OrderBy: "created_at",
+					}
+					time.Sleep(time.Second)
+					createServiceInstance(space3.Name, "another-service-instance")
+				})
+
+				It("eventually returns the ServiceBindings in ascending creation order", func() {
+					var serviceInstanceList []ServiceInstanceRecord
+					Eventually(func() []ServiceInstanceRecord {
+						var err error
+						serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+						Expect(err).NotTo(HaveOccurred())
+						return serviceInstanceList
+					}, timeCheckThreshold*time.Second).Should(HaveLen(4))
+					createTime1, err := time.Parse(time.RFC3339, serviceInstanceList[0].CreatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					createTime2, err := time.Parse(time.RFC3339, serviceInstanceList[1].CreatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					createTime3, err := time.Parse(time.RFC3339, serviceInstanceList[2].CreatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					createTime4, err := time.Parse(time.RFC3339, serviceInstanceList[3].CreatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(createTime1).To(BeTemporally("<=", createTime2))
+					Expect(createTime2).To(BeTemporally("<=", createTime3))
+					Expect(createTime3).To(BeTemporally("<=", createTime4))
+				})
+
+				When("the DescendingOrder field is true", func() {
+					BeforeEach(func() {
+						filters.DescendingOrder = true
+					})
+
+					It("eventually returns the ServiceBindings in descending creation order", func() {
+						var serviceInstanceList []ServiceInstanceRecord
+						Eventually(func() []ServiceInstanceRecord {
+							var err error
+							serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+							Expect(err).NotTo(HaveOccurred())
+							return serviceInstanceList
+						}, timeCheckThreshold*time.Second).Should(HaveLen(4))
+						createTime1, err := time.Parse(time.RFC3339, serviceInstanceList[0].CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						createTime2, err := time.Parse(time.RFC3339, serviceInstanceList[1].CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						createTime3, err := time.Parse(time.RFC3339, serviceInstanceList[2].CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						createTime4, err := time.Parse(time.RFC3339, serviceInstanceList[3].CreatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(createTime1).To(BeTemporally(">=", createTime2))
+						Expect(createTime2).To(BeTemporally(">=", createTime3))
+						Expect(createTime3).To(BeTemporally(">=", createTime4))
+					})
+				})
+			})
+
+			When("the OrderBy field is set to 'updated_at'", func() {
+				BeforeEach(func() {
+					filters = ListServiceInstanceMessage{
+						SpaceGuids: []string{
+							cfServiceInstance1.Namespace,
+							cfServiceInstance2.Namespace,
+							cfServiceInstance3.Namespace,
+						},
+						OrderBy: "updated_at",
+					}
+					time.Sleep(time.Second)
+					createServiceInstance(space3.Name, "another-service-instance")
+				})
+
+				It("eventually returns the ServiceBindings in ascending update order", func() {
+					var serviceInstanceList []ServiceInstanceRecord
+					Eventually(func() []ServiceInstanceRecord {
+						var err error
+						serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+						Expect(err).NotTo(HaveOccurred())
+						return serviceInstanceList
+					}, timeCheckThreshold*time.Second).Should(HaveLen(4))
+					updateTime1, err := time.Parse(time.RFC3339, serviceInstanceList[0].UpdatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					updateTime2, err := time.Parse(time.RFC3339, serviceInstanceList[1].UpdatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					updateTime3, err := time.Parse(time.RFC3339, serviceInstanceList[2].UpdatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					updateTime4, err := time.Parse(time.RFC3339, serviceInstanceList[3].UpdatedAt)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(updateTime1).To(BeTemporally("<=", updateTime2))
+					Expect(updateTime2).To(BeTemporally("<=", updateTime3))
+					Expect(updateTime3).To(BeTemporally("<=", updateTime4))
+				})
+
+				When("the DescendingOrder field is true", func() {
+					BeforeEach(func() {
+						filters.DescendingOrder = true
+					})
+
+					It("eventually returns the ServiceBindings in descending update order", func() {
+						var serviceInstanceList []ServiceInstanceRecord
+						Eventually(func() []ServiceInstanceRecord {
+							var err error
+							serviceInstanceList, err = serviceInstanceRepo.ListServiceInstances(testCtx, authInfo, filters)
+							Expect(err).NotTo(HaveOccurred())
+							return serviceInstanceList
+						}, timeCheckThreshold*time.Second).Should(HaveLen(4))
+						updateTime1, err := time.Parse(time.RFC3339, serviceInstanceList[0].UpdatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						updateTime2, err := time.Parse(time.RFC3339, serviceInstanceList[1].UpdatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						updateTime3, err := time.Parse(time.RFC3339, serviceInstanceList[2].UpdatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						updateTime4, err := time.Parse(time.RFC3339, serviceInstanceList[3].UpdatedAt)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(updateTime1).To(BeTemporally(">=", updateTime2))
+						Expect(updateTime2).To(BeTemporally(">=", updateTime3))
+						Expect(updateTime3).To(BeTemporally(">=", updateTime4))
+					})
+				})
+			})
 		})
 	})
 })

--- a/docs/api.md
+++ b/docs/api.md
@@ -411,6 +411,10 @@ curl "https://localhost:9000/v3/service_instances" \
   }'
 ```
 
+#### [List Service Instances](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#list-service-instances)
+**Query Parameters:** Currently supports filtering by service instance
+`names` and `space_guids` and ordering by `name`, `created_at` or `updated_at`.
+The `fields` and `per_page` parameters will be silently ignored.
 
 ### User Identity
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#599

## What is this change about?
This PR adds the required query parameters to GET /v3/service_instances to support the `cf services` command.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #599 

## Tag your pair, your PM, and/or team
@julian-hj @gnovv 
