### PR TITLE
Add error handling for process permissions errors

### DIFF
--- a/api/apis/integration/process_test.go
+++ b/api/apis/integration/process_test.go
@@ -1,0 +1,110 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	workloads "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("Process", func() {
+	var (
+		namespace      *corev1.Namespace
+		processHandler *apis.ProcessHandler
+		appGUID        string
+	)
+
+	BeforeEach(func() {
+		processRepo := repositories.NewProcessRepo(k8sClient, clientFactory)
+
+		processHandler = apis.NewProcessHandler(
+			logf.Log.WithName("integration tests"),
+			*serverURL,
+			processRepo,
+			nil,
+			nil,
+			nil,
+		)
+		processHandler.RegisterRoutes(router)
+
+		appGUID = generateGUID()
+		namespaceGUID := generateGUID()
+		namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceGUID}}
+		Expect(
+			k8sClient.Create(ctx, namespace),
+		).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+	})
+
+	Describe("get", func() {
+		var process *workloads.CFProcess
+
+		BeforeEach(func() {
+			processGUID := generateGUID()
+			process = &workloads.CFProcess{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      processGUID,
+					Namespace: namespace.Name,
+					Labels: map[string]string{
+						"workloads.cloudfoundry.org/app-guid": appGUID,
+					},
+				},
+				Spec: workloads.CFProcessSpec{
+					AppRef: corev1.LocalObjectReference{
+						Name: appGUID,
+					},
+					ProcessType: "web",
+					Command:     "",
+					HealthCheck: workloads.HealthCheck{
+						Type: "process",
+						Data: workloads.HealthCheckData{
+							InvocationTimeoutSeconds: 0,
+							TimeoutSeconds:           0,
+						},
+					},
+					DesiredInstances: 1,
+					MemoryMB:         500,
+					DiskQuotaMB:      512,
+					Ports:            []int32{8080},
+				},
+			}
+			Expect(k8sClient.Create(ctx, process)).To(Succeed())
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			req, err = http.NewRequestWithContext(ctx, http.MethodGet, serverURI("/v3/processes/"+process.Name), nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			router.ServeHTTP(rr, req)
+		})
+
+		When("the user is not authorized to get processes in the space", func() {
+			It("returns a not found error", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+			})
+		})
+
+		When("the user is a space developer", func() {
+			BeforeEach(func() {
+				createRoleBinding(ctx, userName, spaceDeveloperRole.Name, namespace.Name)
+			})
+
+			It("returns the process", func() {
+				Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+				Expect(rr).To(HaveHTTPBody(ContainSubstring(fmt.Sprintf(`"guid":"%s"`, process.Name))), rr.Body.String())
+			})
+		})
+	})
+})

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -81,7 +81,7 @@ func (h *ProcessHandler) processGetHandler(authInfo authorization.Info, w http.R
 
 	process, err := h.processRepo.GetProcess(ctx, authInfo, processGUID)
 	if err != nil {
-		h.logError(w, processGUID, err)
+		h.writeErrorResponse(w, processGUID, err)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (h *ProcessHandler) processGetSidecarsHandler(authInfo authorization.Info, 
 
 	_, err := h.processRepo.GetProcess(ctx, authInfo, processGUID)
 	if err != nil {
-		h.logError(w, processGUID, err)
+		h.writeErrorResponse(w, processGUID, err)
 		return
 	}
 
@@ -135,8 +135,17 @@ func (h *ProcessHandler) processScaleHandler(authInfo authorization.Info, w http
 
 	processRecord, err := h.scaleProcess(ctx, authInfo, processGUID, payload.ToRecord())
 	if err != nil {
-		h.logError(w, processGUID, err)
-		return
+		// TODO replace this error handling with a call to the writeErrorResponse helper function when we implement #623
+		switch err.(type) {
+		case repositories.NotFoundError:
+			h.logger.Info("Process not found", "processGUID", processGUID)
+			writeNotFoundErrorResponse(w, "Process")
+			return
+		default:
+			h.logger.Error(err, "Failed due to error from Kubernetes", "processGUID", processGUID)
+			writeUnknownErrorResponse(w)
+			return
+		}
 	}
 
 	writeResponse(w, http.StatusOK, presenter.ForProcess(processRecord, h.serverURL))
@@ -151,7 +160,7 @@ func (h *ProcessHandler) processGetStatsHandler(authInfo authorization.Info, w h
 
 	records, err := h.fetchProcessStats(ctx, authInfo, processGUID)
 	if err != nil {
-		h.logError(w, processGUID, err)
+		h.writeErrorResponse(w, processGUID, err)
 		return
 	}
 
@@ -219,40 +228,20 @@ func (h *ProcessHandler) processPatchHandler(authInfo authorization.Info, w http
 
 	process, err := h.processRepo.GetProcess(ctx, authInfo, processGUID)
 	if err != nil {
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("process not found", "ProcessGUID", processGUID)
-			writeNotFoundErrorResponse(w, "Process")
-		case repositories.ForbiddenError:
-			h.logger.Info("process not accessible to user", "ProcessGUID", processGUID)
-			writeNotFoundErrorResponse(w, "Process")
-		default:
-			h.logger.Error(err, "Failed to fetch process from Kubernetes", "ProcessGUID", processGUID)
-			writeUnknownErrorResponse(w)
-		}
+		h.writeErrorResponse(w, processGUID, err)
 		return
 	}
 
 	updatedProcess, err := h.processRepo.PatchProcess(ctx, authInfo, payload.ToProcessPatchMessage(processGUID, process.SpaceGUID))
 	if err != nil {
-		switch err.(type) {
-		case repositories.NotFoundError:
-			h.logger.Info("process not found", "ProcessGUID", processGUID)
-			writeNotFoundErrorResponse(w, "Process")
-		case repositories.ForbiddenError:
-			h.logger.Info("process not accessible to user", "ProcessGUID", processGUID)
-			writeNotFoundErrorResponse(w, "Process")
-		default:
-			h.logger.Error(err, "Failed to patch process from Kubernetes", "ProcessGUID", processGUID)
-			writeUnknownErrorResponse(w)
-		}
+		h.writeErrorResponse(w, processGUID, err)
 		return
 	}
 
 	writeResponse(w, http.StatusOK, presenter.ForProcess(updatedProcess, h.serverURL))
 }
 
-func (h *ProcessHandler) logError(w http.ResponseWriter, processGUID string, err error) {
+func (h *ProcessHandler) writeErrorResponse(w http.ResponseWriter, processGUID string, err error) {
 	switch tycerr := err.(type) {
 	case repositories.NotFoundError:
 		h.logger.Info(fmt.Sprintf("%s not found", tycerr.ResourceType), "ProcessGUID", processGUID)

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -168,7 +168,16 @@ var _ = Describe("ProcessHandler", func() {
 					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
 				})
 
-				It("returns an error", func() {
+				It("returns a not-found error", func() {
+					expectNotFoundError("Process not found")
+				})
+			})
+			When("the user lacks access", func() {
+				BeforeEach(func() {
+					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError(errors.New("access denied or something")))
+				})
+
+				It("returns a not-found error", func() {
 					expectNotFoundError("Process not found")
 				})
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#554

## What is this change about?
This PR adds error handling for process permissions errors to the process handler in the API shim. This addresses the defect that @kieron-dev pointed out on #633, cleans up the error handling helper, and adds unit and integration tests.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
see #554

## Tag your pair, your PM, and/or team
I was soloing today, but I am hoping @kieron-dev or @gcapizzi will have a look.
