### PR TITLE
Modified repo test helpers to include k8sClient.create

### DIFF
--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -49,8 +49,7 @@ var _ = Describe("ProcessRepo", func() {
 		)
 
 		BeforeEach(func() {
-			cfProcess1 = initializeProcessCR(process1GUID, namespace1.Name, app1GUID)
-			Expect(k8sClient.Create(context.Background(), cfProcess1)).To(Succeed())
+			cfProcess1 = createProcessCR(context.Background(), k8sClient, process1GUID, namespace1.Name, app1GUID)
 			getProcessGUID = process1GUID
 		})
 
@@ -109,7 +108,6 @@ var _ = Describe("ProcessRepo", func() {
 			var (
 				namespace2 *corev1.Namespace
 				app2GUID   string
-				cfProcess2 *workloadsv1alpha1.CFProcess
 			)
 
 			When("duplicate Processes exist across namespaces with the same GUIDs", func() {
@@ -119,8 +117,7 @@ var _ = Describe("ProcessRepo", func() {
 					namespace2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: prefixedGUID("namespace2")}}
 					Expect(k8sClient.Create(context.Background(), namespace2)).To(Succeed())
 
-					cfProcess2 = initializeProcessCR(process1GUID, namespace2.Name, app2GUID)
-					Expect(k8sClient.Create(context.Background(), cfProcess2)).To(Succeed())
+					_ = createProcessCR(context.Background(), k8sClient, process1GUID, namespace2.Name, app2GUID)
 				})
 
 				It("returns an untyped error", func() {
@@ -153,9 +150,6 @@ var _ = Describe("ProcessRepo", func() {
 			app2GUID       string
 			process2GUID   string
 
-			cfProcess1 *workloadsv1alpha1.CFProcess
-			cfProcess2 *workloadsv1alpha1.CFProcess
-
 			listProcessesMessage repositories.ListProcessesMessage
 			processes            []repositories.ProcessRecord
 		)
@@ -167,11 +161,8 @@ var _ = Describe("ProcessRepo", func() {
 
 			Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace2GUID}})).To(Succeed())
 
-			cfProcess1 = initializeProcessCR(process1GUID, namespace1.Name, app1GUID)
-			Expect(k8sClient.Create(ctx, cfProcess1)).To(Succeed())
-
-			cfProcess2 = initializeProcessCR(process2GUID, namespace2GUID, app1GUID)
-			Expect(k8sClient.Create(ctx, cfProcess2)).To(Succeed())
+			_ = createProcessCR(context.Background(), k8sClient, process1GUID, namespace1.Name, app1GUID)
+			_ = createProcessCR(context.Background(), k8sClient, process2GUID, namespace2GUID, app1GUID)
 
 			listProcessesMessage = repositories.ListProcessesMessage{
 				AppGUID: []string{app1GUID},
@@ -227,8 +218,7 @@ var _ = Describe("ProcessRepo", func() {
 		)
 
 		BeforeEach(func() {
-			cfProcess = initializeProcessCR(process1GUID, namespace1.Name, app1GUID)
-			Expect(k8sClient.Create(context.Background(), cfProcess)).To(Succeed())
+			cfProcess = createProcessCR(context.Background(), k8sClient, process1GUID, namespace1.Name, app1GUID)
 
 			scaleProcessMessage = &repositories.ScaleProcessMessage{
 				GUID:               process1GUID,


### PR DESCRIPTION
Co-authored-by: Julian Hjortshoj <hjortshojj@vmware.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
Resolves #647 

## What is this change about?
<!-- _Please describe the change here._ -->
Updates api repo test helper functions to wrap `k8sClient.Create` call into initializing the CRs.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No


## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Run tests and confirm they pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@julian-hj 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
