### PR TITLE
Unauthorized errors from k8s translates to NotAuthenticatedError

### DIFF
--- a/api/repositories/k8s_client.go
+++ b/api/repositories/k8s_client.go
@@ -48,7 +48,7 @@ func (f UnprivilegedClientFactory) BuildClient(authInfo authorization.Info) (cli
 		config.KeyData = pem.EncodeToMemory(keyBlock)
 
 	default:
-		return nil, authorization.NotAuthenticatedError{}
+		return nil, authorization.InvalidAuthError{}
 	}
 
 	// This does an API call within the controller-runtime code and is
@@ -57,7 +57,7 @@ func (f UnprivilegedClientFactory) BuildClient(authInfo authorization.Info) (cli
 	userClient, err := client.NewWithWatch(config, client.Options{})
 	if err != nil {
 		if k8serrors.IsUnauthorized(err) {
-			return nil, authorization.InvalidAuthError{}
+			return nil, authorization.NotAuthenticatedError{}
 		}
 		return nil, err
 	}


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No.

## What is this change about?
<!-- _Please describe the change here._ -->

An UnauthorizedError for the underlying k8s comes as a result of user not being authenticated and we believe this needs to be translated as a NotAuthenticatedError.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
`make tests` should pass

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

