### PR TITLE
Refactor repositories errors

### DIFF
--- a/api/actions/apply_manifest_test.go
+++ b/api/actions/apply_manifest_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ApplyManifest", func() {
 
 	When("the app does not exist", func() {
 		BeforeEach(func() {
-			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, repositories.NotFoundError{ResourceType: "App"})
+			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 		})
 
 		When("creating the app errors", func() {
@@ -157,7 +157,7 @@ var _ = Describe("ApplyManifest", func() {
 
 		When("the process doesn't exist", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
+				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
 			})
 
 			When("creating the process errors", func() {

--- a/api/actions/apply_manifest_test.go
+++ b/api/actions/apply_manifest_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ApplyManifest", func() {
 
 	When("the app does not exist", func() {
 		BeforeEach(func() {
-			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 		})
 
 		When("creating the app errors", func() {
@@ -157,7 +157,7 @@ var _ = Describe("ApplyManifest", func() {
 
 		When("the process doesn't exist", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 			})
 
 			When("creating the process errors", func() {

--- a/api/actions/scale_app_process_test.go
+++ b/api/actions/scale_app_process_test.go
@@ -137,7 +137,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NotFoundError{ResourceType: "App"}
+				toReturnErr = repositories.NewNotFoundError("App", nil)
 				appRepo.GetAppReturns(repositories.AppRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {
@@ -183,7 +183,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NotFoundError{ResourceType: "Process"}
+				toReturnErr = repositories.NewNotFoundError("Process", nil)
 				scaleProcessAction.Returns(repositories.ProcessRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {

--- a/api/actions/scale_app_process_test.go
+++ b/api/actions/scale_app_process_test.go
@@ -137,7 +137,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NewNotFoundError("App", nil)
+				toReturnErr = repositories.NewNotFoundError(repositories.AppResourceType, nil)
 				appRepo.GetAppReturns(repositories.AppRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {
@@ -183,7 +183,7 @@ var _ = Describe("ScaleAppProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NewNotFoundError("Process", nil)
+				toReturnErr = repositories.NewNotFoundError(repositories.ProcessResourceType, nil)
 				scaleProcessAction.Returns(repositories.ProcessRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {

--- a/api/actions/scale_process_test.go
+++ b/api/actions/scale_process_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ScaleProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NewNotFoundError("Process", nil)
+				toReturnErr = repositories.NewNotFoundError(repositories.ProcessResourceType, nil)
 				processRepo.GetProcessReturns(repositories.ProcessRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {

--- a/api/actions/scale_process_test.go
+++ b/api/actions/scale_process_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ScaleProcessAction", func() {
 		When("the error is \"not found\"", func() {
 			var toReturnErr error
 			BeforeEach(func() {
-				toReturnErr = repositories.NotFoundError{}
+				toReturnErr = repositories.NewNotFoundError("Process", nil)
 				processRepo.GetProcessReturns(repositories.ProcessRecord{}, toReturnErr)
 			})
 			It("returns an empty record", func() {

--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -444,7 +444,7 @@ func (h *AppHandler) appScaleProcessHandler(authInfo authorization.Info, w http.
 	if err != nil {
 		switch errType := err.(type) {
 		case repositories.NotFoundError:
-			resourceType := errType.ResourceType
+			resourceType := errType.ResourceType()
 			h.logger.Info(fmt.Sprintf("%s not found", resourceType), "appGUID", appGUID)
 			writeNotFoundErrorResponse(w, resourceType)
 			return

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -195,7 +195,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -826,7 +826,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("set droplet is forbidden", func() {
 			BeforeEach(func() {
-				appRepo.SetCurrentDropletReturns(repositories.CurrentDropletRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.SetCurrentDropletReturns(repositories.CurrentDropletRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns a not authenticated error", func() {
@@ -847,7 +847,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App cannot be accessed", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -869,7 +869,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet isn't accessible to the user", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError(repositories.DropletResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -1653,7 +1653,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be accessed", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -2270,7 +2270,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be accessed", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -2440,7 +2440,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2470,7 +2470,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the user cannot access the droplet", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError(repositories.DropletResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2550,7 +2550,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("no permissions to get the app", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2683,7 +2683,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to stop the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 				})
 
 				It("returns a forbidden error", func() {
@@ -2693,7 +2693,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to start the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 				})
 
 				It("returns a forbidden error", func() {
@@ -2794,7 +2794,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("no permissions to start the app", func() {
 			BeforeEach(func() {
-				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns a forbidden error", func() {
@@ -2937,7 +2937,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("there is a Forbidden error fetching the app env", func() {
 			BeforeEach(func() {
-				appRepo.GetAppEnvReturns(nil, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppEnvReturns(nil, repositories.NewForbiddenError(repositories.AppEnvResourceType, nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -184,7 +184,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -195,7 +195,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -344,7 +344,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the space does not exist", func() {
 			BeforeEach(func() {
-				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NotFoundError{})
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Space", nil))
 
 				requestBody := initializeCreateAppRequestBody(testAppName, "no-such-guid", nil, nil, nil)
 				queuePostRequest(requestBody)
@@ -826,7 +826,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("set droplet is forbidden", func() {
 			BeforeEach(func() {
-				appRepo.SetCurrentDropletReturns(repositories.CurrentDropletRecord{}, repositories.NewForbiddenError(nil))
+				appRepo.SetCurrentDropletReturns(repositories.CurrentDropletRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns a not authenticated error", func() {
@@ -836,7 +836,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -847,7 +847,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App cannot be accessed", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -858,7 +858,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet doesn't exist", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NotFoundError{})
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
 			})
 
 			It("returns an error", func() {
@@ -869,7 +869,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet isn't accessible to the user", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.ForbiddenError{})
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
 			})
 
 			It("returns an error", func() {
@@ -1048,7 +1048,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -1315,7 +1315,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -1643,7 +1643,7 @@ var _ = Describe("AppHandler", func() {
 		When("On the sad path and", func() {
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 				})
 
 				It("returns an error", func() {
@@ -1653,7 +1653,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be accessed", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 				})
 
 				It("returns an error", func() {
@@ -2042,7 +2042,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
+					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
 				})
 
 				It("returns an error", func() {
@@ -2052,7 +2052,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app doesn't exist", func() {
 				BeforeEach(func() {
-					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "App"})
+					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("App", nil))
 				})
 
 				It("returns an error", func() {
@@ -2260,7 +2260,7 @@ var _ = Describe("AppHandler", func() {
 		When("on the sad path and", func() {
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 				})
 
 				It("returns an error", func() {
@@ -2270,7 +2270,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be accessed", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 				})
 
 				It("returns an error", func() {
@@ -2430,7 +2430,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2440,7 +2440,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2460,7 +2460,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet doesn't exist", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NotFoundError{})
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
 			})
 
 			It("returns an error", func() {
@@ -2470,7 +2470,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the user cannot access the droplet", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError(nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
 			})
 
 			It("returns an error", func() {
@@ -2540,7 +2540,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2550,7 +2550,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("no permissions to get the app", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2683,7 +2683,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to stop the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.ForbiddenError{})
+					appRepo.SetAppDesiredStateReturnsOnCall(0, repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 				})
 
 				It("returns a forbidden error", func() {
@@ -2693,7 +2693,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("no permissions to start the app", func() {
 				BeforeEach(func() {
-					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.ForbiddenError{})
+					appRepo.SetAppDesiredStateReturnsOnCall(1, repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 				})
 
 				It("returns a forbidden error", func() {
@@ -2794,7 +2794,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("no permissions to start the app", func() {
 			BeforeEach(func() {
-				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns a forbidden error", func() {
@@ -2862,7 +2862,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2927,7 +2927,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppEnvReturns(nil, repositories.NotFoundError{ResourceType: "App"})
+				appRepo.GetAppEnvReturns(nil, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -2937,7 +2937,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("there is a Forbidden error fetching the app env", func() {
 			BeforeEach(func() {
-				appRepo.GetAppEnvReturns(nil, repositories.ForbiddenError{})
+				appRepo.GetAppEnvReturns(nil, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -3087,7 +3087,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 				})
 
 				// TODO: should we return code 100004 instead?

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -184,7 +184,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -344,7 +344,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the space does not exist", func() {
 			BeforeEach(func() {
-				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Space", nil))
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError(repositories.SpaceResourceType, nil))
 
 				requestBody := initializeCreateAppRequestBody(testAppName, "no-such-guid", nil, nil, nil)
 				queuePostRequest(requestBody)
@@ -836,7 +836,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -858,7 +858,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet doesn't exist", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError(repositories.DropletResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -1048,7 +1048,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			// TODO: should we return code 100004 instead?
@@ -1315,7 +1315,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -1643,7 +1643,7 @@ var _ = Describe("AppHandler", func() {
 		When("On the sad path and", func() {
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -1797,7 +1797,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app is not found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 				makeGetRequest(processTypeWeb)
 			})
 
@@ -1808,7 +1808,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app doesn't have a process of the given type", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 				makeGetRequest(processTypeWeb)
 			})
 			It("return a process not found error", func() {
@@ -2042,7 +2042,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -2052,7 +2052,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app doesn't exist", func() {
 				BeforeEach(func() {
-					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("App", nil))
+					scaleAppProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -2260,7 +2260,7 @@ var _ = Describe("AppHandler", func() {
 		When("on the sad path and", func() {
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -2430,7 +2430,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2460,7 +2460,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the Droplet doesn't exist", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError(repositories.DropletResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2540,7 +2540,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app does not exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2862,7 +2862,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the App doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -2927,7 +2927,7 @@ var _ = Describe("AppHandler", func() {
 
 		When("the app cannot be found", func() {
 			BeforeEach(func() {
-				appRepo.GetAppEnvReturns(nil, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppEnvReturns(nil, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -3087,7 +3087,7 @@ var _ = Describe("AppHandler", func() {
 
 			When("the app cannot be found", func() {
 				BeforeEach(func() {
-					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+					appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 				})
 
 				// TODO: should we return code 100004 instead?

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -323,7 +323,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user does not have access to the build", func() {
 			BeforeEach(func() {
-				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError("Build", nil))
+				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError(repositories.BuildResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -535,7 +535,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user is not authorized to create a build", func() {
 			BeforeEach(func() {
-				buildRepo.CreateBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError("Build", nil))
+				buildRepo.CreateBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError(repositories.BuildResourceType, nil))
 			})
 
 			It("returns a not authorized error", func() {
@@ -545,7 +545,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user is not authorized to get a package", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -313,7 +313,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the build cannot be found", func() {
 			BeforeEach(func() {
-				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NotFoundError{})
+				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewNotFoundError("Build", nil))
 			})
 
 			It("returns an error", func() {
@@ -323,7 +323,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user does not have access to the build", func() {
 			BeforeEach(func() {
-				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError(nil))
+				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError("Build", nil))
 			})
 
 			It("returns an error", func() {
@@ -502,7 +502,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the package doesn't exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NotFoundError{})
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
 			})
 
 			It("returns an error", func() {
@@ -535,7 +535,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user is not authorized to create a build", func() {
 			BeforeEach(func() {
-				buildRepo.CreateBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError(nil))
+				buildRepo.CreateBuildReturns(repositories.BuildRecord{}, repositories.NewForbiddenError("Build", nil))
 			})
 
 			It("returns a not authorized error", func() {
@@ -545,7 +545,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the user is not authorized to get a package", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/build_handler_test.go
+++ b/api/apis/build_handler_test.go
@@ -313,7 +313,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the build cannot be found", func() {
 			BeforeEach(func() {
-				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewNotFoundError("Build", nil))
+				buildRepo.GetBuildReturns(repositories.BuildRecord{}, repositories.NewNotFoundError(repositories.BuildResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -502,7 +502,7 @@ var _ = Describe("BuildHandler", func() {
 
 		When("the package doesn't exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/droplet_handler_test.go
+++ b/api/apis/droplet_handler_test.go
@@ -143,7 +143,7 @@ var _ = Describe("DropletHandler", func() {
 
 		When("the droplet cannot be found", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NotFoundError{})
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
 				router.ServeHTTP(rr, req)
 			})
 
@@ -154,7 +154,7 @@ var _ = Describe("DropletHandler", func() {
 
 		When("access to the droplet is forbidden", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError(nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
 				router.ServeHTTP(rr, req)
 			})
 

--- a/api/apis/droplet_handler_test.go
+++ b/api/apis/droplet_handler_test.go
@@ -143,7 +143,7 @@ var _ = Describe("DropletHandler", func() {
 
 		When("the droplet cannot be found", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewNotFoundError(repositories.DropletResourceType, nil))
 				router.ServeHTTP(rr, req)
 			})
 

--- a/api/apis/droplet_handler_test.go
+++ b/api/apis/droplet_handler_test.go
@@ -154,7 +154,7 @@ var _ = Describe("DropletHandler", func() {
 
 		When("access to the droplet is forbidden", func() {
 			BeforeEach(func() {
-				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError("Droplet", nil))
+				dropletRepo.GetDropletReturns(repositories.DropletRecord{}, repositories.NewForbiddenError(repositories.DropletResourceType, nil))
 				router.ServeHTTP(rr, req)
 			})
 

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -294,7 +294,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("user is not allowed to create an org", func() {
 			BeforeEach(func() {
-				orgRepo.CreateOrgReturns(repositories.OrgRecord{}, repositories.NewForbiddenError("Org", errors.New("nope")))
+				orgRepo.CreateOrgReturns(repositories.OrgRecord{}, repositories.NewForbiddenError(repositories.OrgResourceType, errors.New("nope")))
 				makePostRequest(`{"name": "the-org"}`)
 			})
 
@@ -544,7 +544,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("deleting the org is not authorized", func() {
 			BeforeEach(func() {
-				orgRepo.DeleteOrgReturns(repositories.NewForbiddenError("Org", nil))
+				orgRepo.DeleteOrgReturns(repositories.NewForbiddenError(repositories.OrgResourceType, nil))
 				router.ServeHTTP(rr, request)
 			})
 

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -566,7 +566,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("the org doesn't exist", func() {
 			BeforeEach(func() {
-				orgRepo.DeleteOrgReturns(repositories.NewNotFoundError("Org", nil))
+				orgRepo.DeleteOrgReturns(repositories.NewNotFoundError(repositories.OrgResourceType, nil))
 				router.ServeHTTP(rr, request)
 			})
 

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -294,7 +294,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("user is not allowed to create an org", func() {
 			BeforeEach(func() {
-				orgRepo.CreateOrgReturns(repositories.OrgRecord{}, repositories.NewForbiddenError(errors.New("nope")))
+				orgRepo.CreateOrgReturns(repositories.OrgRecord{}, repositories.NewForbiddenError("Org", errors.New("nope")))
 				makePostRequest(`{"name": "the-org"}`)
 			})
 
@@ -544,7 +544,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("deleting the org is not authorized", func() {
 			BeforeEach(func() {
-				orgRepo.DeleteOrgReturns(repositories.ForbiddenError{})
+				orgRepo.DeleteOrgReturns(repositories.NewForbiddenError("Org", nil))
 				router.ServeHTTP(rr, request)
 			})
 
@@ -566,7 +566,7 @@ var _ = Describe("OrgHandler", func() {
 
 		When("the org doesn't exist", func() {
 			BeforeEach(func() {
-				orgRepo.DeleteOrgReturns(repositories.NotFoundError{})
+				orgRepo.DeleteOrgReturns(repositories.NewNotFoundError("Org", nil))
 				router.ServeHTTP(rr, request)
 			})
 

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -602,7 +602,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an unprocessable entity error", func() {
@@ -719,7 +719,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the user is not allowed to create packages", func() {
 			BeforeEach(func() {
-				packageRepo.CreatePackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", errors.New("no")))
+				packageRepo.CreatePackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(repositories.PackageResourceType, errors.New("no")))
 			})
 
 			It("returns an unauthorized error", func() {
@@ -882,7 +882,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("getting the package is forbidden", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -894,7 +894,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("uploading the package is forbidden", func() {
 			BeforeEach(func() {
-				imageRepo.UploadSourceImageReturns("", repositories.NewForbiddenError("Package", nil))
+				imageRepo.UploadSourceImageReturns("", repositories.NewForbiddenError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -943,7 +943,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("updating the package is forbidden", func() {
 			BeforeEach(func() {
-				packageRepo.UpdatePackageSourceReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", errors.New("no")))
+				packageRepo.UpdatePackageSourceReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(repositories.PackageResourceType, errors.New("no")))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -148,7 +148,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the package is not there", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NotFoundError{})
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
 			})
 
 			It("returns status 404", func() {
@@ -590,7 +590,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NotFoundError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
 			})
 
 			It("returns an unprocessable entity error", func() {
@@ -602,7 +602,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app is not accessible", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.ForbiddenError{})
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an unprocessable entity error", func() {
@@ -719,7 +719,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the user is not allowed to create packages", func() {
 			BeforeEach(func() {
-				packageRepo.CreatePackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(errors.New("no")))
+				packageRepo.CreatePackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", errors.New("no")))
 			})
 
 			It("returns an unauthorized error", func() {
@@ -870,7 +870,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the record doesn't exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NotFoundError{})
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
 			})
 
 			It("returns an error", func() {
@@ -882,7 +882,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("getting the package is forbidden", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.ForbiddenError{})
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", nil))
 			})
 
 			It("returns an error", func() {
@@ -894,7 +894,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("uploading the package is forbidden", func() {
 			BeforeEach(func() {
-				imageRepo.UploadSourceImageReturns("", repositories.ForbiddenError{})
+				imageRepo.UploadSourceImageReturns("", repositories.NewForbiddenError("Package", nil))
 			})
 
 			It("returns an error", func() {
@@ -943,7 +943,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("updating the package is forbidden", func() {
 			BeforeEach(func() {
-				packageRepo.UpdatePackageSourceReturns(repositories.PackageRecord{}, repositories.NewForbiddenError(errors.New("no")))
+				packageRepo.UpdatePackageSourceReturns(repositories.PackageRecord{}, repositories.NewForbiddenError("Package", errors.New("no")))
 			})
 
 			It("returns an error", func() {
@@ -1149,7 +1149,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the package does not exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NotFoundError{})
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
 			})
 
 			It("returns the error", func() {

--- a/api/apis/package_handler_test.go
+++ b/api/apis/package_handler_test.go
@@ -148,7 +148,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the package is not there", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns status 404", func() {
@@ -590,7 +590,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the app doesn't exist", func() {
 			BeforeEach(func() {
-				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError("App", nil))
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an unprocessable entity error", func() {
@@ -870,7 +870,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the record doesn't exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -1149,7 +1149,7 @@ var _ = Describe("PackageHandler", func() {
 
 		When("the package does not exist", func() {
 			BeforeEach(func() {
-				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError("Package", nil))
+				packageRepo.GetPackageReturns(repositories.PackageRecord{}, repositories.NewNotFoundError(repositories.PackageResourceType, nil))
 			})
 
 			It("returns the error", func() {

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -244,8 +244,8 @@ func (h *ProcessHandler) processPatchHandler(authInfo authorization.Info, w http
 func (h *ProcessHandler) writeErrorResponse(w http.ResponseWriter, processGUID string, err error) {
 	switch tycerr := err.(type) {
 	case repositories.NotFoundError:
-		h.logger.Info(fmt.Sprintf("%s not found", tycerr.ResourceType), "ProcessGUID", processGUID)
-		writeNotFoundErrorResponse(w, tycerr.ResourceType)
+		h.logger.Info(fmt.Sprintf("%s not found", tycerr.ResourceType()), "ProcessGUID", processGUID)
+		writeNotFoundErrorResponse(w, tycerr.ResourceType())
 	case repositories.ForbiddenError:
 		h.logger.Info(fmt.Sprintf("%s forbidden", tycerr.ResourceType()), "ProcessGUID", processGUID)
 		writeNotFoundErrorResponse(w, tycerr.ResourceType())

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -165,7 +165,7 @@ var _ = Describe("ProcessHandler", func() {
 		When("on the sad path and", func() {
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 				})
 
 				It("returns a not-found error", func() {
@@ -250,7 +250,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process doesn't exist", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -512,7 +512,7 @@ var _ = Describe("ProcessHandler", func() {
 
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					scaleProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
+					scaleProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 				})
 
 				It("returns an error", func() {
@@ -667,7 +667,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process is not found", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewNotFoundError("Process", nil))
+				fetchProcessStats.Returns(nil, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))
 			})
 			It("an error", func() {
 				expectNotFoundError("Process not found")
@@ -676,7 +676,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the app is not found", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewNotFoundError("App", nil))
+				fetchProcessStats.Returns(nil, repositories.NewNotFoundError(repositories.AppResourceType, nil))
 			})
 			It("an error", func() {
 				expectNotFoundError("App not found")

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -174,7 +174,7 @@ var _ = Describe("ProcessHandler", func() {
 			})
 			When("the user lacks access", func() {
 				BeforeEach(func() {
-					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", errors.New("access denied or something")))
+					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError(repositories.ProcessResourceType, errors.New("access denied or something")))
 				})
 
 				It("returns a not-found error", func() {
@@ -260,7 +260,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process isn't accessible to the user", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", nil))
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError(repositories.ProcessResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -697,7 +697,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the app is not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("App", nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError(repositories.AppResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -707,7 +707,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process is not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("Process", nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError(repositories.ProcessResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -717,11 +717,11 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process stats are not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("Process stats", nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError(repositories.ProcessStatsResourceType, nil))
 			})
 
 			It("returns an error", func() {
-				expectNotFoundError("Process stats not found")
+				expectNotFoundError("Process Stats not found")
 			})
 		})
 	})
@@ -1061,7 +1061,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("user is not allowed to get a process", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", errors.New("nope")))
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError(repositories.ProcessResourceType, errors.New("nope")))
 				makePatchRequest(processGUID, validBody)
 			})
 

--- a/api/apis/process_handler_test.go
+++ b/api/apis/process_handler_test.go
@@ -165,7 +165,7 @@ var _ = Describe("ProcessHandler", func() {
 		When("on the sad path and", func() {
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
+					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
 				})
 
 				It("returns a not-found error", func() {
@@ -174,7 +174,7 @@ var _ = Describe("ProcessHandler", func() {
 			})
 			When("the user lacks access", func() {
 				BeforeEach(func() {
-					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenProcessError(errors.New("access denied or something")))
+					processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", errors.New("access denied or something")))
 				})
 
 				It("returns a not-found error", func() {
@@ -250,7 +250,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process doesn't exist", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
 			})
 
 			It("returns an error", func() {
@@ -260,7 +260,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process isn't accessible to the user", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenProcessError(nil))
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", nil))
 			})
 
 			It("returns an error", func() {
@@ -512,7 +512,7 @@ var _ = Describe("ProcessHandler", func() {
 
 			When("the process doesn't exist", func() {
 				BeforeEach(func() {
-					scaleProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NotFoundError{ResourceType: "Process"})
+					scaleProcessFunc.Returns(repositories.ProcessRecord{}, repositories.NewNotFoundError("Process", nil))
 				})
 
 				It("returns an error", func() {
@@ -667,7 +667,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process is not found", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NotFoundError{ResourceType: "Process"})
+				fetchProcessStats.Returns(nil, repositories.NewNotFoundError("Process", nil))
 			})
 			It("an error", func() {
 				expectNotFoundError("Process not found")
@@ -676,7 +676,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the app is not found", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NotFoundError{ResourceType: "App"})
+				fetchProcessStats.Returns(nil, repositories.NewNotFoundError("App", nil))
 			})
 			It("an error", func() {
 				expectNotFoundError("App not found")
@@ -697,7 +697,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the app is not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenAppError(nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("App", nil))
 			})
 
 			It("returns an error", func() {
@@ -707,7 +707,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process is not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenProcessError(nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("Process", nil))
 			})
 
 			It("returns an error", func() {
@@ -717,7 +717,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("the process stats are not authorized", func() {
 			BeforeEach(func() {
-				fetchProcessStats.Returns(nil, repositories.NewForbiddenProcessStatsError(nil))
+				fetchProcessStats.Returns(nil, repositories.NewForbiddenError("Process stats", nil))
 			})
 
 			It("returns an error", func() {
@@ -1061,7 +1061,7 @@ var _ = Describe("ProcessHandler", func() {
 
 		When("user is not allowed to get a process", func() {
 			BeforeEach(func() {
-				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenProcessError(errors.New("nope")))
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, repositories.NewForbiddenError("Process", errors.New("nope")))
 				makePatchRequest(processGUID, validBody)
 			})
 

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -329,7 +329,7 @@ var _ = Describe("RoleHandler", func() {
 
 		When("the user is not authorized", func() {
 			BeforeEach(func() {
-				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.NewForbiddenError(nil))
+				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.NewForbiddenError("Role", nil))
 			})
 
 			It("returns a unauthorized error", func() {

--- a/api/apis/role_handler_test.go
+++ b/api/apis/role_handler_test.go
@@ -329,7 +329,7 @@ var _ = Describe("RoleHandler", func() {
 
 		When("the user is not authorized", func() {
 			BeforeEach(func() {
-				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.NewForbiddenError("Role", nil))
+				roleRepo.CreateRoleReturns(repositories.RoleRecord{}, repositories.NewForbiddenError(repositories.RoleResourceType, nil))
 			})
 
 			It("returns a unauthorized error", func() {

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -1502,7 +1502,7 @@ var _ = Describe("RouteHandler", func() {
 
 			When("user is not allowed to create a route", func() {
 				BeforeEach(func() {
-					routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, repositories.NewForbiddenError("Route", errors.New("nope")))
+					routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, repositories.NewForbiddenError(repositories.RouteResourceType, errors.New("nope")))
 				})
 
 				It("returns an unauthorised error", func() {

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -169,7 +169,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route cannot be found", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", errors.New("not found")))
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError(repositories.RouteResourceType, errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -179,7 +179,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route's domain cannot be found", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", errors.New("not found")))
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError(repositories.DomainResourceType, errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -551,7 +551,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain cannot be found", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", nil))
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError(repositories.DomainResourceType, nil))
 			})
 
 			It("returns an error", func() {
@@ -943,7 +943,7 @@ var _ = Describe("RouteHandler", func() {
 		When("the space does not exist", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{},
-					repositories.NewNotFoundError("Space", errors.New("not found")))
+					repositories.NewNotFoundError(repositories.SpaceResourceType, errors.New("not found")))
 
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, "no-such-space", testDomainGUID, nil, nil)
 			})
@@ -968,7 +968,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain does not exist", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", nil))
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError(repositories.DomainResourceType, nil))
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, testSpaceGUID, "no-such-domain", nil, nil)
 			})
 
@@ -1177,7 +1177,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route cannot be found", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", errors.New("not found")))
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError(repositories.RouteResourceType, errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -1393,7 +1393,7 @@ var _ = Describe("RouteHandler", func() {
 
 			When("the route doesn't exist", func() {
 				BeforeEach(func() {
-					routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", nil))
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError(repositories.RouteResourceType, nil))
 				})
 
 				It("responds with 422 and an error", func() {
@@ -1713,7 +1713,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route doesn't exist", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", nil))
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError(repositories.RouteResourceType, nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -169,7 +169,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route cannot be found", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NotFoundError{Err: errors.New("not found")})
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -179,7 +179,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route's domain cannot be found", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NotFoundError{Err: errors.New("not found")})
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -551,7 +551,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain cannot be found", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NotFoundError{})
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", nil))
 			})
 
 			It("returns an error", func() {
@@ -943,7 +943,7 @@ var _ = Describe("RouteHandler", func() {
 		When("the space does not exist", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{},
-					repositories.NotFoundError{Err: errors.New("not found")})
+					repositories.NewNotFoundError("Space", errors.New("not found")))
 
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, "no-such-space", testDomainGUID, nil, nil)
 			})
@@ -968,7 +968,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the domain does not exist", func() {
 			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NotFoundError{})
+				domainRepo.GetDomainReturns(repositories.DomainRecord{}, repositories.NewNotFoundError("Domain", nil))
 				requestBody = initializeCreateRouteRequestBody(testRouteHost, testRoutePath, testSpaceGUID, "no-such-domain", nil, nil)
 			})
 
@@ -1177,7 +1177,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route cannot be found", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NotFoundError{Err: errors.New("not found")})
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", errors.New("not found")))
 			})
 
 			It("returns an error", func() {
@@ -1393,7 +1393,7 @@ var _ = Describe("RouteHandler", func() {
 
 			When("the route doesn't exist", func() {
 				BeforeEach(func() {
-					routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NotFoundError{})
+					routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", nil))
 				})
 
 				It("responds with 422 and an error", func() {
@@ -1502,7 +1502,7 @@ var _ = Describe("RouteHandler", func() {
 
 			When("user is not allowed to create a route", func() {
 				BeforeEach(func() {
-					routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, repositories.NewForbiddenError(errors.New("nope")))
+					routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, repositories.NewForbiddenError("Route", errors.New("nope")))
 				})
 
 				It("returns an unauthorised error", func() {
@@ -1713,7 +1713,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("the route doesn't exist", func() {
 			BeforeEach(func() {
-				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NotFoundError{})
+				routeRepo.GetRouteReturns(repositories.RouteRecord{}, repositories.NewNotFoundError("Route", nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/service_instance_handler_test.go
+++ b/api/apis/service_instance_handler_test.go
@@ -360,7 +360,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 
 		When("user is not allowed to create a service instance", func() {
 			BeforeEach(func() {
-				serviceInstanceRepo.CreateServiceInstanceReturns(repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError("Service Instance", errors.New("nope")))
+				serviceInstanceRepo.CreateServiceInstanceReturns(repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError(repositories.ServiceInstanceResourceType, errors.New("nope")))
 				makePostRequest(validBody)
 			})
 
@@ -684,7 +684,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 
 		When("user is not allowed to create a service instance", func() {
 			BeforeEach(func() {
-				serviceInstanceRepo.ListServiceInstancesReturns([]repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError("Service Instance", errors.New("not allowed")))
+				serviceInstanceRepo.ListServiceInstancesReturns([]repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError(repositories.ServiceInstanceResourceType, errors.New("not allowed")))
 				makeListRequest()
 			})
 

--- a/api/apis/service_instance_handler_test.go
+++ b/api/apis/service_instance_handler_test.go
@@ -310,7 +310,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(
 					repositories.SpaceRecord{},
-					repositories.NewNotFoundError("Space", errors.New("not found")),
+					repositories.NewNotFoundError(repositories.SpaceResourceType, errors.New("not found")),
 				)
 
 				makePostRequest(validBody)

--- a/api/apis/service_instance_handler_test.go
+++ b/api/apis/service_instance_handler_test.go
@@ -310,7 +310,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 			BeforeEach(func() {
 				spaceRepo.GetSpaceReturns(
 					repositories.SpaceRecord{},
-					repositories.NotFoundError{Err: errors.New("not found")},
+					repositories.NewNotFoundError("Space", errors.New("not found")),
 				)
 
 				makePostRequest(validBody)
@@ -360,7 +360,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 
 		When("user is not allowed to create a service instance", func() {
 			BeforeEach(func() {
-				serviceInstanceRepo.CreateServiceInstanceReturns(repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError(errors.New("nope")))
+				serviceInstanceRepo.CreateServiceInstanceReturns(repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError("Service Instance", errors.New("nope")))
 				makePostRequest(validBody)
 			})
 
@@ -684,7 +684,7 @@ var _ = Describe("ServiceInstanceHandler", func() {
 
 		When("user is not allowed to create a service instance", func() {
 			BeforeEach(func() {
-				serviceInstanceRepo.ListServiceInstancesReturns([]repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError(errors.New("not allowed")))
+				serviceInstanceRepo.ListServiceInstancesReturns([]repositories.ServiceInstanceRecord{}, repositories.NewForbiddenError("Service Instance", errors.New("not allowed")))
 				makeListRequest()
 			})
 

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Spaces", func() {
 
 		When("the repo returns a not found or permission denied error", func() {
 			BeforeEach(func() {
-				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Org", errors.New("nope")))
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError(repositories.OrgResourceType, errors.New("nope")))
 			})
 
 			It("returns an invalid org error", func() {
@@ -509,7 +509,7 @@ var _ = Describe("Spaces", func() {
 
 		When("the space doesn't exist", func() {
 			BeforeEach(func() {
-				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Space", nil))
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError(repositories.SpaceResourceType, nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Spaces", func() {
 
 		When("user is not allowed to create a space", func() {
 			BeforeEach(func() {
-				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewForbiddenError(errors.New("nope")))
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewForbiddenError("Space", errors.New("nope")))
 			})
 
 			It("returns an unauthorised error", func() {
@@ -158,10 +158,10 @@ var _ = Describe("Spaces", func() {
 
 		When("the repo returns a not found or permission denied error", func() {
 			BeforeEach(func() {
-				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NotFoundError{Err: errors.New("nope")})
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Org", errors.New("nope")))
 			})
 
-			It("returns an unauthorised error", func() {
+			It("returns an invalid org error", func() {
 				expectUnprocessableEntityError("Invalid organization. Ensure the organization exists and you have access to it.")
 			})
 		})
@@ -509,7 +509,7 @@ var _ = Describe("Spaces", func() {
 
 		When("the space doesn't exist", func() {
 			BeforeEach(func() {
-				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NotFoundError{})
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError("Space", nil))
 			})
 
 			It("returns an error", func() {

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Spaces", func() {
 
 		When("user is not allowed to create a space", func() {
 			BeforeEach(func() {
-				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewForbiddenError("Space", errors.New("nope")))
+				spaceRepo.CreateSpaceReturns(repositories.SpaceRecord{}, repositories.NewForbiddenError(repositories.SpaceResourceType, errors.New("nope")))
 			})
 
 			It("returns an unauthorised error", func() {

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -29,11 +29,12 @@ const (
 	StartedState DesiredState = "STARTED"
 	StoppedState DesiredState = "STOPPED"
 
-	Kind            string = "CFApp"
-	APIVersion      string = "workloads.cloudfoundry.org/v1alpha1"
-	TimestampFormat string = time.RFC3339
-	CFAppGUIDLabel  string = "workloads.cloudfoundry.org/app-guid"
-	AppResourceType string = "App"
+	Kind               string = "CFApp"
+	APIVersion         string = "workloads.cloudfoundry.org/v1alpha1"
+	TimestampFormat    string = time.RFC3339
+	CFAppGUIDLabel     string = "workloads.cloudfoundry.org/app-guid"
+	AppResourceType    string = "App"
+	AppEnvResourceType string = "App Env"
 )
 
 type AppRepo struct {
@@ -178,7 +179,7 @@ func (f *AppRepo) GetApp(ctx context.Context, authInfo authorization.Info, appGU
 
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: app.SpaceGUID, Name: app.GUID}, &workloadsv1alpha1.CFApp{})
 	if k8serrors.IsForbidden(err) {
-		return AppRecord{}, NewForbiddenError("App", err)
+		return AppRecord{}, NewForbiddenError(AppResourceType, err)
 	}
 
 	if err != nil { // untested
@@ -402,7 +403,7 @@ func (f *AppRepo) SetCurrentDroplet(ctx context.Context, authInfo authorization.
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return CurrentDropletRecord{}, NewForbiddenError("App", err)
+			return CurrentDropletRecord{}, NewForbiddenError(AppResourceType, err)
 		}
 
 		return CurrentDropletRecord{}, fmt.Errorf("err in client.Patch: %w", err)
@@ -432,7 +433,7 @@ func (f *AppRepo) SetAppDesiredState(ctx context.Context, authInfo authorization
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return AppRecord{}, NewForbiddenError("App", err)
+			return AppRecord{}, NewForbiddenError(AppResourceType, err)
 		}
 
 		return AppRecord{}, fmt.Errorf("err in client.Patch: %w", err)
@@ -475,7 +476,7 @@ func (f *AppRepo) GetAppEnv(ctx context.Context, authInfo authorization.Info, ap
 	err = userClient.Get(ctx, key, secret)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return nil, NewForbiddenError("App Env", err)
+			return nil, NewForbiddenError(AppEnvResourceType, err)
 		}
 		return nil, fmt.Errorf("error finding environment variable Secret %q for App %q: %w", app.envSecretName, app.GUID, err)
 	}

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -177,7 +177,7 @@ func (f *AppRepo) GetApp(ctx context.Context, authInfo authorization.Info, appGU
 
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: app.SpaceGUID, Name: app.GUID}, &workloadsv1alpha1.CFApp{})
 	if k8serrors.IsForbidden(err) {
-		return AppRecord{}, NewForbiddenAppError(err)
+		return AppRecord{}, NewForbiddenError("App", err)
 	}
 
 	if err != nil { // untested
@@ -401,7 +401,7 @@ func (f *AppRepo) SetCurrentDroplet(ctx context.Context, authInfo authorization.
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return CurrentDropletRecord{}, NewForbiddenError(err)
+			return CurrentDropletRecord{}, NewForbiddenError("App", err)
 		}
 
 		return CurrentDropletRecord{}, fmt.Errorf("err in client.Patch: %w", err)
@@ -431,7 +431,7 @@ func (f *AppRepo) SetAppDesiredState(ctx context.Context, authInfo authorization
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return AppRecord{}, NewForbiddenError(err)
+			return AppRecord{}, NewForbiddenError("App", err)
 		}
 
 		return AppRecord{}, fmt.Errorf("err in client.Patch: %w", err)
@@ -474,7 +474,7 @@ func (f *AppRepo) GetAppEnv(ctx context.Context, authInfo authorization.Info, ap
 	err = userClient.Get(ctx, key, secret)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return nil, NewForbiddenError(err)
+			return nil, NewForbiddenError("App Env", err)
 		}
 		return nil, fmt.Errorf("error finding environment variable Secret %q for App %q: %w", app.envSecretName, app.GUID, err)
 	}
@@ -537,7 +537,7 @@ func cfAppToAppRecord(cfApp workloadsv1alpha1.CFApp) AppRecord {
 
 func returnApp(apps []workloadsv1alpha1.CFApp) (AppRecord, error) {
 	if len(apps) == 0 {
-		return AppRecord{}, NotFoundError{ResourceType: "App"}
+		return AppRecord{}, NewNotFoundError("App", nil)
 	}
 	if len(apps) > 1 {
 		return AppRecord{}, errors.New("duplicate apps exist")

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -33,6 +33,7 @@ const (
 	APIVersion      string = "workloads.cloudfoundry.org/v1alpha1"
 	TimestampFormat string = time.RFC3339
 	CFAppGUIDLabel  string = "workloads.cloudfoundry.org/app-guid"
+	AppResourceType string = "App"
 )
 
 type AppRepo struct {
@@ -162,7 +163,7 @@ func (f *AppRepo) GetApp(ctx context.Context, authInfo authorization.Info, appGU
 	}
 
 	if len(appList.Items) == 0 {
-		return AppRecord{}, NewNotFoundError("App", nil)
+		return AppRecord{}, NewNotFoundError(AppResourceType, nil)
 	}
 	if len(appList.Items) > 1 {
 		return AppRecord{}, errors.New("get-app duplicate apps exist")
@@ -537,7 +538,7 @@ func cfAppToAppRecord(cfApp workloadsv1alpha1.CFApp) AppRecord {
 
 func returnApp(apps []workloadsv1alpha1.CFApp) (AppRecord, error) {
 	if len(apps) == 0 {
-		return AppRecord{}, NewNotFoundError("App", nil)
+		return AppRecord{}, NewNotFoundError(AppResourceType, nil)
 	}
 	if len(apps) > 1 {
 		return AppRecord{}, errors.New("duplicate apps exist")

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -131,7 +131,7 @@ var _ = Describe("AppRepository", func() {
 
 			It("returns an error", func() {
 				Expect(getErr).To(HaveOccurred())
-				Expect(getErr).To(MatchError(NotFoundError{ResourceType: "App"}))
+				Expect(getErr).To(MatchError(NewNotFoundError("App", nil)))
 			})
 		})
 	})
@@ -162,7 +162,7 @@ var _ = Describe("AppRepository", func() {
 			When("the App doesn't exist in the Space (but is in another Space)", func() {
 				It("returns a NotFoundError", func() {
 					_, err := appRepo.GetAppByNameAndSpace(context.Background(), authInfo, cfApp1.Spec.Name, space2.Name)
-					Expect(err).To(MatchError(NotFoundError{ResourceType: "App"}))
+					Expect(err).To(MatchError(NewNotFoundError("App", nil)))
 				})
 			})
 		})
@@ -851,7 +851,7 @@ var _ = Describe("AppRepository", func() {
 					DropletGUID: dropletGUID,
 					SpaceGUID:   spaceGUID,
 				})
-				Expect(err).To(MatchError(ContainSubstring("Forbidden")))
+				Expect(err).To(MatchError(ContainSubstring("App forbidden")))
 			})
 		})
 	})
@@ -1119,7 +1119,7 @@ var _ = Describe("AppRepository", func() {
 			It("returns an error", func() {
 				_, err := appRepo.GetAppEnv(testCtx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(NotFoundError{ResourceType: "App"}))
+				Expect(err).To(MatchError(NewNotFoundError("App", nil)))
 			})
 		})
 	})

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -131,7 +131,7 @@ var _ = Describe("AppRepository", func() {
 
 			It("returns an error", func() {
 				Expect(getErr).To(HaveOccurred())
-				Expect(getErr).To(MatchError(NewNotFoundError("App", nil)))
+				Expect(getErr).To(MatchError(NewNotFoundError(AppResourceType, nil)))
 			})
 		})
 	})
@@ -162,7 +162,7 @@ var _ = Describe("AppRepository", func() {
 			When("the App doesn't exist in the Space (but is in another Space)", func() {
 				It("returns a NotFoundError", func() {
 					_, err := appRepo.GetAppByNameAndSpace(context.Background(), authInfo, cfApp1.Spec.Name, space2.Name)
-					Expect(err).To(MatchError(NewNotFoundError("App", nil)))
+					Expect(err).To(MatchError(NewNotFoundError(AppResourceType, nil)))
 				})
 			})
 		})
@@ -1119,7 +1119,7 @@ var _ = Describe("AppRepository", func() {
 			It("returns an error", func() {
 				_, err := appRepo.GetAppEnv(testCtx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(NewNotFoundError("App", nil)))
+				Expect(err).To(MatchError(NewNotFoundError(AppResourceType, nil)))
 			})
 		})
 	})

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -82,7 +82,7 @@ func (b *BuildRepo) GetBuild(ctx context.Context, authInfo authorization.Info, b
 	foundBuild := workloadsv1alpha1.CFBuild{}
 	if err := userClient.Get(ctx, client.ObjectKeyFromObject(&builds[0]), &foundBuild); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return BuildRecord{}, NewForbiddenError("Build", err)
+			return BuildRecord{}, NewForbiddenError(BuildResourceType, err)
 		}
 		return BuildRecord{}, fmt.Errorf("failed to get build: %w", err)
 	}
@@ -146,7 +146,7 @@ func (b *BuildRepo) CreateBuild(ctx context.Context, authInfo authorization.Info
 
 	if err := userClient.Create(ctx, &cfBuild); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return BuildRecord{}, NewForbiddenError("Build", err)
+			return BuildRecord{}, NewForbiddenError(BuildResourceType, err)
 		}
 		return BuildRecord{}, err
 	}

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -23,6 +23,8 @@ const (
 
 	StagingConditionType   = "Staging"
 	SucceededConditionType = "Succeeded"
+
+	BuildResourceType = "Build"
 )
 
 type BuildRecord struct {
@@ -66,7 +68,7 @@ func (b *BuildRepo) GetBuild(ctx context.Context, authInfo authorization.Info, b
 	}
 	builds := buildList.Items
 	if len(builds) == 0 {
-		return BuildRecord{}, NewNotFoundError("Build", nil)
+		return BuildRecord{}, NewNotFoundError(BuildResourceType, nil)
 	}
 	if len(builds) > 1 {
 		return BuildRecord{}, errors.New("duplicate builds exist")

--- a/api/repositories/build_repository.go
+++ b/api/repositories/build_repository.go
@@ -66,7 +66,7 @@ func (b *BuildRepo) GetBuild(ctx context.Context, authInfo authorization.Info, b
 	}
 	builds := buildList.Items
 	if len(builds) == 0 {
-		return BuildRecord{}, NotFoundError{}
+		return BuildRecord{}, NewNotFoundError("Build", nil)
 	}
 	if len(builds) > 1 {
 		return BuildRecord{}, errors.New("duplicate builds exist")
@@ -80,7 +80,7 @@ func (b *BuildRepo) GetBuild(ctx context.Context, authInfo authorization.Info, b
 	foundBuild := workloadsv1alpha1.CFBuild{}
 	if err := userClient.Get(ctx, client.ObjectKeyFromObject(&builds[0]), &foundBuild); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return BuildRecord{}, NewForbiddenError(err)
+			return BuildRecord{}, NewForbiddenError("Build", err)
 		}
 		return BuildRecord{}, fmt.Errorf("failed to get build: %w", err)
 	}
@@ -144,7 +144,7 @@ func (b *BuildRepo) CreateBuild(ctx context.Context, authInfo authorization.Info
 
 	if err := userClient.Create(ctx, &cfBuild); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return BuildRecord{}, NewForbiddenError(err)
+			return BuildRecord{}, NewForbiddenError("Build", err)
 		}
 		return BuildRecord{}, err
 	}

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -256,7 +256,7 @@ var _ = Describe("BuildRepository", func() {
 			It("returns an error", func() {
 				_, err := buildRepo.GetBuild(ctx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(repositories.NotFoundError{}))
+				Expect(err).To(MatchError(repositories.NewNotFoundError("Build", nil)))
 			})
 		})
 

--- a/api/repositories/build_repository_test.go
+++ b/api/repositories/build_repository_test.go
@@ -256,7 +256,7 @@ var _ = Describe("BuildRepository", func() {
 			It("returns an error", func() {
 				_, err := buildRepo.GetBuild(ctx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(repositories.NewNotFoundError("Build", nil)))
+				Expect(err).To(MatchError(repositories.NewNotFoundError(repositories.BuildResourceType, nil)))
 			})
 		})
 

--- a/api/repositories/buildpack_repository_test.go
+++ b/api/repositories/buildpack_repository_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/gomega/gstruct"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -113,7 +112,7 @@ var _ = Describe("BuildpackRepository", func() {
 		Describe("List", func() {
 			It("returns records matching the buildpacks of the ClusterBuilder and no error", func() {
 				buildpackRepo = NewBuildpackRepository(userClientFactory)
-				spaceDeveloperClusterRole = createClusterRole(beforeCtx, repositories.SpaceDeveloperClusterRoleRules)
+				spaceDeveloperClusterRole = createClusterRole(beforeCtx, SpaceDeveloperClusterRoleRules)
 				createClusterRoleBinding(beforeCtx, userName, spaceDeveloperClusterRole.Name)
 
 				buildpackRecords, err := buildpackRepo.GetBuildpacksForBuilder(context.Background(), authInfo, clusterBuilder.Name)

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -69,7 +69,7 @@ func (r *DomainRepo) GetDomain(ctx context.Context, authInfo authorization.Info,
 	domain := &networkingv1alpha1.CFDomain{}
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: matchingDomain.Namespace, Name: matchingDomain.GUID}, domain)
 	if k8serrors.IsForbidden(err) {
-		return DomainRecord{}, NewForbiddenError(err)
+		return DomainRecord{}, NewForbiddenError("Domain", err)
 	}
 
 	if err != nil { // untested
@@ -100,10 +100,7 @@ func (r *DomainRepo) GetDomainByName(ctx context.Context, authInfo authorization
 	}
 
 	if len(domainRecords) == 0 {
-		return DomainRecord{}, NotFoundError{
-			Err:          err,
-			ResourceType: "Domain",
-		}
+		return DomainRecord{}, NewNotFoundError("Domain", err)
 	}
 
 	return domainRecords[0], nil

--- a/api/repositories/domain_repository.go
+++ b/api/repositories/domain_repository.go
@@ -17,7 +17,7 @@ import (
 //+kubebuilder:rbac:groups=networking.cloudfoundry.org,resources=cfdomains/status,verbs=get
 
 const (
-	DomainResourceType        = "Domain"
+	DomainResourceType = "Domain"
 )
 
 type DomainRepo struct {
@@ -53,12 +53,11 @@ func (r *DomainRepo) GetDomain(ctx context.Context, authInfo authorization.Info,
 	domainList := &networkingv1alpha1.CFDomainList{}
 	err := r.privilegedClient.List(ctx, domainList, client.MatchingFields{"metadata.name": domainGUID})
 	if err != nil {
-<<<<<<< HEAD
 		return DomainRecord{}, fmt.Errorf("get-domain: privileged list failed: %w", err)
 	}
 
 	if len(domainList.Items) == 0 {
-		return DomainRecord{}, NewNotFoundError("Domain", err)
+		return DomainRecord{}, NewNotFoundError(DomainResourceType, err)
 	}
 	if len(domainList.Items) > 1 {
 		return DomainRecord{}, errors.New("get-domain duplicate domains exist")
@@ -74,17 +73,11 @@ func (r *DomainRepo) GetDomain(ctx context.Context, authInfo authorization.Info,
 	domain := &networkingv1alpha1.CFDomain{}
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: matchingDomain.Namespace, Name: matchingDomain.GUID}, domain)
 	if k8serrors.IsForbidden(err) {
-		return DomainRecord{}, NewForbiddenError("Domain", err)
+		return DomainRecord{}, NewForbiddenError(DomainResourceType, err)
 	}
 
 	if err != nil { // untested
 		return DomainRecord{}, fmt.Errorf("get-domain user client get failed: %w", err)
-		switch {
-		case k8serrors.IsNotFound(err):
-			return DomainRecord{}, NewNotFoundError(DomainResourceType, err)
-		default:
-			return DomainRecord{}, fmt.Errorf("get-domain: k8s get failed: %w", err)
-		}
 	}
 
 	return cfDomainToDomainRecord(domain), nil

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -421,7 +421,7 @@ var _ = Describe("DomainRepository", func() {
 		When("No matches exist for the provided name", func() {
 			It("returns a domainRecord that matches the specified domain name, and no error", func() {
 				_, err := domainRepo.GetDomainByName(context.Background(), authInfo, "i-dont-exist")
-				Expect(err).To(MatchError(NotFoundError{ResourceType: "Domain"}))
+				Expect(err).To(MatchError(NewNotFoundError("Domain", nil)))
 			})
 		})
 	})

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 
@@ -20,7 +19,7 @@ import (
 var _ = Describe("DomainRepository", func() {
 	var (
 		testCtx                   context.Context
-		domainRepo                *repositories.DomainRepo
+		domainRepo                *DomainRepo
 		spaceDeveloperClusterRole *v1.ClusterRole
 		testNamespace             string
 	)
@@ -126,7 +125,7 @@ var _ = Describe("DomainRepository", func() {
 		When("no CFDomain exists", func() {
 			It("returns an error", func() {
 				_, err := domainRepo.GetDomain(testCtx, authInfo, "non-existent-domain-guid")
-				Expect(err).To(BeAssignableToTypeOf(repositories.NotFoundError{}))
+				Expect(err).To(BeAssignableToTypeOf(NotFoundError{}))
 			})
 		})
 	})

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -421,7 +421,7 @@ var _ = Describe("DomainRepository", func() {
 		When("No matches exist for the provided name", func() {
 			It("returns a domainRecord that matches the specified domain name, and no error", func() {
 				_, err := domainRepo.GetDomainByName(context.Background(), authInfo, "i-dont-exist")
-				Expect(err).To(MatchError(NewNotFoundError("Domain", nil)))
+				Expect(err).To(MatchError(NewNotFoundError(DomainResourceType, nil)))
 			})
 		})
 	})

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -55,7 +55,7 @@ func (r *DropletRepo) GetDroplet(ctx context.Context, authInfo authorization.Inf
 	}
 	builds := buildList.Items
 	if len(builds) == 0 {
-		return DropletRecord{}, NotFoundError{}
+		return DropletRecord{}, NewNotFoundError("Droplet", nil)
 	}
 	if len(builds) > 1 { // untested
 		return DropletRecord{}, errors.New("duplicate builds exist")
@@ -71,7 +71,7 @@ func (r *DropletRepo) GetDroplet(ctx context.Context, authInfo authorization.Inf
 	err = userClient.Get(ctx, client.ObjectKeyFromObject(&foundObj), &userDroplet)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return DropletRecord{}, NewForbiddenError(err)
+			return DropletRecord{}, NewForbiddenError("Droplet", err)
 		}
 
 		return DropletRecord{}, fmt.Errorf("get droplet failed: %w", err)
@@ -88,7 +88,7 @@ func returnDroplet(builds []workloadsv1alpha1.CFBuild) (DropletRecord, error) {
 		succeededStatus == metav1.ConditionTrue {
 		return cfBuildToDropletRecord(cfBuild), nil
 	}
-	return DropletRecord{}, NotFoundError{}
+	return DropletRecord{}, NewNotFoundError("Droplet", nil)
 }
 
 func cfBuildToDropletRecord(cfBuild workloadsv1alpha1.CFBuild) DropletRecord {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -16,6 +16,10 @@ import (
 
 // No kubebuilder RBAC tags required, because Build and Droplet are the same CR
 
+const (
+	DropletResourceType = "Droplet"
+)
+
 type DropletRepo struct {
 	privilegedClient  client.Client
 	userClientFactory UserK8sClientFactory
@@ -55,7 +59,7 @@ func (r *DropletRepo) GetDroplet(ctx context.Context, authInfo authorization.Inf
 	}
 	builds := buildList.Items
 	if len(builds) == 0 {
-		return DropletRecord{}, NewNotFoundError("Droplet", nil)
+		return DropletRecord{}, NewNotFoundError(DropletResourceType, nil)
 	}
 	if len(builds) > 1 { // untested
 		return DropletRecord{}, errors.New("duplicate builds exist")
@@ -88,7 +92,7 @@ func returnDroplet(builds []workloadsv1alpha1.CFBuild) (DropletRecord, error) {
 		succeededStatus == metav1.ConditionTrue {
 		return cfBuildToDropletRecord(cfBuild), nil
 	}
-	return DropletRecord{}, NewNotFoundError("Droplet", nil)
+	return DropletRecord{}, NewNotFoundError(DropletResourceType, nil)
 }
 
 func cfBuildToDropletRecord(cfBuild workloadsv1alpha1.CFBuild) DropletRecord {

--- a/api/repositories/droplet_repository.go
+++ b/api/repositories/droplet_repository.go
@@ -75,7 +75,7 @@ func (r *DropletRepo) GetDroplet(ctx context.Context, authInfo authorization.Inf
 	err = userClient.Get(ctx, client.ObjectKeyFromObject(&foundObj), &userDroplet)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return DropletRecord{}, NewForbiddenError("Droplet", err)
+			return DropletRecord{}, NewForbiddenError(DropletResourceType, err)
 		}
 
 		return DropletRecord{}, fmt.Errorf("get droplet failed: %w", err)

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -197,7 +197,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError(repositories.DropletResourceType, nil)))
 					})
 				})
 
@@ -219,7 +219,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError(repositories.DropletResourceType, nil)))
 					})
 				})
 
@@ -241,7 +241,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError(repositories.DropletResourceType, nil)))
 					})
 				})
 			})
@@ -250,7 +250,7 @@ var _ = Describe("DropletRepository", func() {
 				It("returns an error", func() {
 					_, err := dropletRepo.GetDroplet(testCtx, authInfo, "i don't exist")
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
+					Expect(err).To(MatchError(repositories.NewNotFoundError(repositories.DropletResourceType, nil)))
 				})
 			})
 		})

--- a/api/repositories/droplet_repository_test.go
+++ b/api/repositories/droplet_repository_test.go
@@ -197,7 +197,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NotFoundError{}))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
 					})
 				})
 
@@ -219,7 +219,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NotFoundError{}))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
 					})
 				})
 
@@ -241,7 +241,7 @@ var _ = Describe("DropletRepository", func() {
 					})
 
 					It("should return a NotFound error", func() {
-						Expect(fetchErr).To(MatchError(repositories.NotFoundError{}))
+						Expect(fetchErr).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
 					})
 				})
 			})
@@ -250,7 +250,7 @@ var _ = Describe("DropletRepository", func() {
 				It("returns an error", func() {
 					_, err := dropletRepo.GetDroplet(testCtx, authInfo, "i don't exist")
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(repositories.NotFoundError{}))
+					Expect(err).To(MatchError(repositories.NewNotFoundError("Droplet", nil)))
 				})
 			})
 		})

--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -61,7 +61,7 @@ func (r *ImageRepository) UploadSourceImage(ctx context.Context, authInfo author
 	}
 
 	if !authorized {
-		return "", NewForbiddenError(errors.New("not authorized to patch cfpackage"))
+		return "", NewForbiddenError("Package", errors.New("not authorized to patch cfpackage"))
 	}
 
 	image, err := r.builder.Build(ctx, srcReader)

--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -61,7 +61,7 @@ func (r *ImageRepository) UploadSourceImage(ctx context.Context, authInfo author
 	}
 
 	if !authorized {
-		return "", NewForbiddenError("Package", errors.New("not authorized to patch cfpackage"))
+		return "", NewForbiddenError(PackageResourceType, errors.New("not authorized to patch cfpackage"))
 	}
 
 	image, err := r.builder.Build(ctx, srcReader)

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -36,6 +36,9 @@ const (
 	OrgNameLabel          = "cloudfoundry.org/org-name"
 	SpaceNameLabel        = "cloudfoundry.org/space-name"
 	hierarchyMetadataName = "hierarchy"
+
+	OrgResourceType   = "Org"
+	SpaceResourceType = "Space"
 )
 
 type CreateOrgMessage struct {
@@ -423,7 +426,7 @@ func (r *OrgRepo) GetSpace(ctx context.Context, info authorization.Info, spaceGU
 	}
 
 	if len(spaceRecords) == 0 {
-		return SpaceRecord{}, NewNotFoundError("Space", nil)
+		return SpaceRecord{}, NewNotFoundError(SpaceResourceType, nil)
 	}
 
 	return spaceRecords[0], nil
@@ -436,7 +439,7 @@ func (r *OrgRepo) GetOrg(ctx context.Context, info authorization.Info, orgGUID s
 	}
 
 	if len(orgRecords) == 0 {
-		return OrgRecord{}, NewNotFoundError("Org", err)
+		return OrgRecord{}, NewNotFoundError(OrgResourceType, err)
 	}
 
 	return orgRecords[0], nil
@@ -448,7 +451,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	err = r.privilegedClient.Get(ctx, types.NamespacedName{Name: hierarchyMetadataName, Namespace: message.GUID}, &hierarchyObj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NewNotFoundError("Org", err)
+			return NewNotFoundError(OrgResourceType, err)
 		}
 		return err
 	}
@@ -462,7 +465,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	err = userClient.Update(ctx, &hierarchyObj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NewNotFoundError("Org", err)
+			return NewNotFoundError(OrgResourceType, err)
 		}
 		if apierrors.IsForbidden(err) {
 			return NewForbiddenError("Org", err)
@@ -478,7 +481,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NewNotFoundError("Org", err)
+			return NewNotFoundError(OrgResourceType, err)
 		}
 		if apierrors.IsForbidden(err) {
 			return NewForbiddenError("Org", err)

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -136,7 +136,7 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, org Cr
 	})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return OrgRecord{}, NewForbiddenError(err)
+			return OrgRecord{}, NewForbiddenError("Org", err)
 		}
 
 		return OrgRecord{}, err
@@ -180,7 +180,7 @@ func (r *OrgRepo) CreateSpace(ctx context.Context, info authorization.Info, mess
 	})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return SpaceRecord{}, NewForbiddenError(err)
+			return SpaceRecord{}, NewForbiddenError("Space", err)
 		}
 
 		return SpaceRecord{}, err
@@ -423,7 +423,7 @@ func (r *OrgRepo) GetSpace(ctx context.Context, info authorization.Info, spaceGU
 	}
 
 	if len(spaceRecords) == 0 {
-		return SpaceRecord{}, NotFoundError{ResourceType: "Space"}
+		return SpaceRecord{}, NewNotFoundError("Space", nil)
 	}
 
 	return spaceRecords[0], nil
@@ -448,9 +448,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	err = r.privilegedClient.Get(ctx, types.NamespacedName{Name: hierarchyMetadataName, Namespace: message.GUID}, &hierarchyObj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NotFoundError{
-				Err: err,
-			}
+			return NewNotFoundError("Org", err)
 		}
 		return err
 	}
@@ -464,14 +462,10 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	err = userClient.Update(ctx, &hierarchyObj)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NotFoundError{
-				Err: err,
-			}
+			return NewNotFoundError("Org", err)
 		}
 		if apierrors.IsForbidden(err) {
-			return ForbiddenError{
-				err: err,
-			}
+			return NewForbiddenError("Org", err)
 		}
 		return err
 	}
@@ -484,14 +478,10 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return NotFoundError{
-				Err: err,
-			}
+			return NewNotFoundError("Org", err)
 		}
 		if apierrors.IsForbidden(err) {
-			return ForbiddenError{
-				err: err,
-			}
+			return NewForbiddenError("Org", err)
 		}
 		return err
 	}
@@ -516,9 +506,7 @@ func (r *OrgRepo) DeleteSpace(ctx context.Context, info authorization.Info, mess
 		}
 
 		if apierrors.IsForbidden(err) {
-			return ForbiddenError{
-				err: err,
-			}
+			return NewForbiddenError("Space", err)
 		}
 
 		return err

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -139,7 +139,7 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, org Cr
 	})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return OrgRecord{}, NewForbiddenError("Org", err)
+			return OrgRecord{}, NewForbiddenError(OrgResourceType, err)
 		}
 
 		return OrgRecord{}, err
@@ -183,7 +183,7 @@ func (r *OrgRepo) CreateSpace(ctx context.Context, info authorization.Info, mess
 	})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return SpaceRecord{}, NewForbiddenError("Space", err)
+			return SpaceRecord{}, NewForbiddenError(SpaceResourceType, err)
 		}
 
 		return SpaceRecord{}, err
@@ -468,7 +468,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 			return NewNotFoundError(OrgResourceType, err)
 		}
 		if apierrors.IsForbidden(err) {
-			return NewForbiddenError("Org", err)
+			return NewForbiddenError(OrgResourceType, err)
 		}
 		return err
 	}
@@ -484,7 +484,7 @@ func (r *OrgRepo) DeleteOrg(ctx context.Context, info authorization.Info, messag
 			return NewNotFoundError(OrgResourceType, err)
 		}
 		if apierrors.IsForbidden(err) {
-			return NewForbiddenError("Org", err)
+			return NewForbiddenError(OrgResourceType, err)
 		}
 		return err
 	}
@@ -509,7 +509,7 @@ func (r *OrgRepo) DeleteSpace(ctx context.Context, info authorization.Info, mess
 		}
 
 		if apierrors.IsForbidden(err) {
-			return NewForbiddenError("Space", err)
+			return NewForbiddenError(SpaceResourceType, err)
 		}
 
 		return err

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -108,7 +108,7 @@ func (r *PackageRepo) CreatePackage(ctx context.Context, authInfo authorization.
 	err = userClient.Create(ctx, &cfPackage)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError("Package", err)
+			return PackageRecord{}, NewForbiddenError(PackageResourceType, err)
 		}
 		return PackageRecord{}, err
 	}
@@ -140,7 +140,7 @@ func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Inf
 	foundPackage := workloadsv1alpha1.CFPackage{}
 	if err := userClient.Get(ctx, client.ObjectKeyFromObject(&packages[0]), &foundPackage); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError("Package", err)
+			return PackageRecord{}, NewForbiddenError(PackageResourceType, err)
 		}
 		return PackageRecord{}, fmt.Errorf("get-package: get failed: %w", err)
 	}
@@ -225,7 +225,7 @@ func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authoriz
 	err = userClient.Patch(ctx, cfPackage, client.MergeFrom(baseCFPackage))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError("Package", err)
+			return PackageRecord{}, NewForbiddenError(PackageResourceType, err)
 		}
 		return PackageRecord{}, fmt.Errorf("err in client.Patch: %w", err) // untested
 	}

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -106,7 +106,7 @@ func (r *PackageRepo) CreatePackage(ctx context.Context, authInfo authorization.
 	err = userClient.Create(ctx, &cfPackage)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError(err)
+			return PackageRecord{}, NewForbiddenError("Package", err)
 		}
 		return PackageRecord{}, err
 	}
@@ -124,7 +124,7 @@ func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Inf
 
 	packages := packageList.Items
 	if len(packages) == 0 {
-		return PackageRecord{}, NotFoundError{}
+		return PackageRecord{}, NewNotFoundError("Package", nil)
 	}
 	if len(packages) > 1 {
 		return PackageRecord{}, errors.New("duplicate packages exist")
@@ -138,7 +138,7 @@ func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Inf
 	foundPackage := workloadsv1alpha1.CFPackage{}
 	if err := userClient.Get(ctx, client.ObjectKeyFromObject(&packages[0]), &foundPackage); err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError(err)
+			return PackageRecord{}, NewForbiddenError("Package", err)
 		}
 		return PackageRecord{}, fmt.Errorf("get-package: get failed: %w", err)
 	}
@@ -223,7 +223,7 @@ func (r *PackageRepo) UpdatePackageSource(ctx context.Context, authInfo authoriz
 	err = userClient.Patch(ctx, cfPackage, client.MergeFrom(baseCFPackage))
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return PackageRecord{}, NewForbiddenError(err)
+			return PackageRecord{}, NewForbiddenError("Package", err)
 		}
 		return PackageRecord{}, fmt.Errorf("err in client.Patch: %w", err) // untested
 	}

--- a/api/repositories/package_repository.go
+++ b/api/repositories/package_repository.go
@@ -23,6 +23,8 @@ const (
 
 	PackageStateAwaitingUpload = "AWAITING_UPLOAD"
 	PackageStateReady          = "READY"
+
+	PackageResourceType = "Package"
 )
 
 //+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfpackages,verbs=get;list;watch;create;update;patch;delete
@@ -124,7 +126,7 @@ func (r *PackageRepo) GetPackage(ctx context.Context, authInfo authorization.Inf
 
 	packages := packageList.Items
 	if len(packages) == 0 {
-		return PackageRecord{}, NewNotFoundError("Package", nil)
+		return PackageRecord{}, NewNotFoundError(PackageResourceType, nil)
 	}
 	if len(packages) > 1 {
 		return PackageRecord{}, errors.New("duplicate packages exist")

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -247,7 +247,7 @@ var _ = Describe("PackageRepository", func() {
 			It("returns an error", func() {
 				_, err := packageRepo.GetPackage(ctx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(repositories.NewNotFoundError("Package", nil)))
+				Expect(err).To(MatchError(repositories.NewNotFoundError(repositories.PackageResourceType, nil)))
 			})
 		})
 	})

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -247,7 +247,7 @@ var _ = Describe("PackageRepository", func() {
 			It("returns an error", func() {
 				_, err := packageRepo.GetPackage(ctx, authInfo, "i don't exist")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(repositories.NotFoundError{}))
+				Expect(err).To(MatchError(repositories.NewNotFoundError("Package", nil)))
 			})
 		})
 	})

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -100,7 +100,7 @@ func (r *PodRepo) listPods(ctx context.Context, authInfo authorization.Info, lis
 	err = userClient.List(ctx, &podList, &listOpts)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return nil, NewForbiddenProcessStatsError(err)
+			return nil, NewForbiddenError("Process stats", err)
 		}
 
 		return nil, fmt.Errorf("err in client.List: %w", err)

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -25,8 +25,9 @@ const (
 	RunningState           = "RUNNING"
 	pendingState           = "STARTING"
 	// All below statuses changed to "DOWN" until we decide what statuses we want to support in the future
-	crashedState = "DOWN"
-	unknownState = "DOWN"
+	crashedState             = "DOWN"
+	unknownState             = "DOWN"
+	ProcessStatsResourceType = "Process Stats"
 )
 
 type PodRepo struct {
@@ -100,7 +101,7 @@ func (r *PodRepo) listPods(ctx context.Context, authInfo authorization.Info, lis
 	err = userClient.List(ctx, &podList, &listOpts)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return nil, NewForbiddenError("Process stats", err)
+			return nil, NewForbiddenError(ProcessStatsResourceType, err)
 		}
 
 		return nil, fmt.Errorf("err in client.List: %w", err)

--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -188,7 +188,7 @@ var _ = Describe("PodRepository", func() {
 			It("returns a forbidden error", func() {
 				Expect(listStatsErr).To(BeAssignableToTypeOf(ForbiddenError{}))
 				forbiddenErr := listStatsErr.(ForbiddenError)
-				Expect(forbiddenErr.ResourceType()).To(Equal("Process stats"))
+				Expect(forbiddenErr.ResourceType()).To(Equal(ProcessStatsResourceType))
 			})
 		})
 	})

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -129,7 +129,7 @@ func (r *ProcessRepo) GetProcess(ctx context.Context, authInfo authorization.Inf
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: processList.Items[0].Namespace, Name: processList.Items[0].Name}, &process)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return ProcessRecord{}, NewForbiddenError("Process", err)
+			return ProcessRecord{}, NewForbiddenError(ProcessResourceType, err)
 		}
 
 		return ProcessRecord{}, fmt.Errorf("get-process: failed to get process with user client: %w", err)

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -20,6 +20,10 @@ import (
 //+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfprocesses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=workloads.cloudfoundry.org,resources=cfprocesses/status,verbs=get
 
+const (
+	ProcessResourceType = "Process"
+)
+
 func NewProcessRepo(privilegedClient client.Client, userClientFactory UserK8sClientFactory) *ProcessRepo {
 	return &ProcessRepo{
 		privilegedClient: privilegedClient,
@@ -110,7 +114,7 @@ func (r *ProcessRepo) GetProcess(ctx context.Context, authInfo authorization.Inf
 	}
 
 	if len(processList.Items) == 0 {
-		return ProcessRecord{}, NewNotFoundError("Process", nil)
+		return ProcessRecord{}, NewNotFoundError(ProcessResourceType, nil)
 	}
 	if len(processList.Items) > 1 {
 		return ProcessRecord{}, errors.New("duplicate processes exist")
@@ -262,7 +266,7 @@ func (r *ProcessRepo) PatchProcess(ctx context.Context, authInfo authorization.I
 
 func returnProcess(processes []workloadsv1alpha1.CFProcess) (ProcessRecord, error) {
 	if len(processes) == 0 {
-		return ProcessRecord{}, NewNotFoundError("Process", nil)
+		return ProcessRecord{}, NewNotFoundError(ProcessResourceType, nil)
 	}
 	if len(processes) > 1 {
 		return ProcessRecord{}, errors.New("duplicate processes exist")

--- a/api/repositories/process_repository.go
+++ b/api/repositories/process_repository.go
@@ -110,7 +110,7 @@ func (r *ProcessRepo) GetProcess(ctx context.Context, authInfo authorization.Inf
 	}
 
 	if len(processList.Items) == 0 {
-		return ProcessRecord{}, NotFoundError{ResourceType: "Process"}
+		return ProcessRecord{}, NewNotFoundError("Process", nil)
 	}
 	if len(processList.Items) > 1 {
 		return ProcessRecord{}, errors.New("duplicate processes exist")
@@ -125,7 +125,7 @@ func (r *ProcessRepo) GetProcess(ctx context.Context, authInfo authorization.Inf
 	err = userClient.Get(ctx, client.ObjectKey{Namespace: processList.Items[0].Namespace, Name: processList.Items[0].Name}, &process)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return ProcessRecord{}, NewForbiddenProcessError(err)
+			return ProcessRecord{}, NewForbiddenError("Process", err)
 		}
 
 		return ProcessRecord{}, fmt.Errorf("get-process: failed to get process with user client: %w", err)
@@ -262,7 +262,7 @@ func (r *ProcessRepo) PatchProcess(ctx context.Context, authInfo authorization.I
 
 func returnProcess(processes []workloadsv1alpha1.CFProcess) (ProcessRecord, error) {
 	if len(processes) == 0 {
-		return ProcessRecord{}, NotFoundError{ResourceType: "Process"}
+		return ProcessRecord{}, NewNotFoundError("Process", nil)
 	}
 	if len(processes) > 1 {
 		return ProcessRecord{}, errors.New("duplicate processes exist")

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -133,7 +133,7 @@ var _ = Describe("ProcessRepo", func() {
 
 				It("returns a not found error", func() {
 					Expect(getErr).To(HaveOccurred())
-					Expect(getErr).To(MatchError(repositories.NewNotFoundError("Process", nil)))
+					Expect(getErr).To(MatchError(repositories.NewNotFoundError(repositories.ProcessResourceType, nil)))
 				})
 			})
 
@@ -412,7 +412,7 @@ var _ = Describe("ProcessRepo", func() {
 		When("there is no matching process", func() {
 			It("returns a NotFoundError", func() {
 				_, err := processRepo.GetProcessByAppTypeAndSpace(ctx, authInfo, app1GUID, processType, namespace1.Name)
-				Expect(err).To(MatchError(repositories.NewNotFoundError("Process", nil)))
+				Expect(err).To(MatchError(repositories.NewNotFoundError(repositories.ProcessResourceType, nil)))
 			})
 		})
 	})

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -133,7 +133,7 @@ var _ = Describe("ProcessRepo", func() {
 
 				It("returns a not found error", func() {
 					Expect(getErr).To(HaveOccurred())
-					Expect(getErr).To(MatchError(repositories.NotFoundError{ResourceType: "Process"}))
+					Expect(getErr).To(MatchError(repositories.NewNotFoundError("Process", nil)))
 				})
 			})
 
@@ -412,7 +412,7 @@ var _ = Describe("ProcessRepo", func() {
 		When("there is no matching process", func() {
 			It("returns a NotFoundError", func() {
 				_, err := processRepo.GetProcessByAppTypeAndSpace(ctx, authInfo, app1GUID, processType, namespace1.Name)
-				Expect(err).To(MatchError(repositories.NotFoundError{ResourceType: "Process"}))
+				Expect(err).To(MatchError(repositories.NewNotFoundError("Process", nil)))
 			})
 		})
 	})

--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -131,7 +131,7 @@ func (r *RoleRepo) CreateRole(ctx context.Context, authInfo authorization.Info, 
 			return RoleRecord{}, ErrorDuplicateRoleBinding
 		}
 		if k8serrors.IsForbidden(err) {
-			return RoleRecord{}, NewForbiddenError(err)
+			return RoleRecord{}, NewForbiddenError("Role", err)
 		}
 		return RoleRecord{}, fmt.Errorf("failed to assign user %q to role %q: %w", role.User, role.Type, err)
 	}

--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -26,6 +26,8 @@ var (
 const (
 	RoleGuidLabel         = "cloudfoundry.org/role-guid"
 	roleBindingNamePrefix = "cf"
+
+	RoleResourceType = "Role"
 )
 
 //counterfeiter:generate -o fake -fake-name AuthorizedInChecker . AuthorizedInChecker
@@ -131,7 +133,7 @@ func (r *RoleRepo) CreateRole(ctx context.Context, authInfo authorization.Info, 
 			return RoleRecord{}, ErrorDuplicateRoleBinding
 		}
 		if k8serrors.IsForbidden(err) {
-			return RoleRecord{}, NewForbiddenError("Role", err)
+			return RoleRecord{}, NewForbiddenError(RoleResourceType, err)
 		}
 		return RoleRecord{}, fmt.Errorf("failed to assign user %q to role %q: %w", role.User, role.Type, err)
 	}

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -16,6 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	RouteResourceType = "Route"
+)
+
 //+kubebuilder:rbac:groups=networking.cloudfoundry.org,resources=cfroutes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.cloudfoundry.org,resources=cfroutes/status,verbs=get
 
@@ -271,7 +275,7 @@ func filterByAppDestination(routeList []networkingv1alpha1.CFRoute, appGUID stri
 
 func returnRoute(routeList []networkingv1alpha1.CFRoute) (RouteRecord, error) {
 	if len(routeList) == 0 {
-		return RouteRecord{}, NewNotFoundError("Route", nil)
+		return RouteRecord{}, NewNotFoundError(RouteResourceType, nil)
 	}
 
 	if len(routeList) > 1 {

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -351,7 +351,7 @@ func (f *RouteRepo) DeleteRoute(ctx context.Context, authInfo authorization.Info
 	}
 
 	if apierrors.IsForbidden(err) {
-		return NewForbiddenError("Route", err)
+		return NewForbiddenError(RouteResourceType, err)
 	}
 
 	return err

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -271,7 +271,7 @@ func filterByAppDestination(routeList []networkingv1alpha1.CFRoute, appGUID stri
 
 func returnRoute(routeList []networkingv1alpha1.CFRoute) (RouteRecord, error) {
 	if len(routeList) == 0 {
-		return RouteRecord{}, NotFoundError{}
+		return RouteRecord{}, NewNotFoundError("Route", nil)
 	}
 
 	if len(routeList) > 1 {
@@ -347,9 +347,7 @@ func (f *RouteRepo) DeleteRoute(ctx context.Context, authInfo authorization.Info
 	}
 
 	if apierrors.IsForbidden(err) {
-		return ForbiddenError{
-			err: err,
-		}
+		return NewForbiddenError("Route", err)
 	}
 
 	return err

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -178,7 +178,7 @@ var _ = Describe("RouteRepository", func() {
 		When("the CFRoute doesn't exist", func() {
 			It("returns an error", func() {
 				_, err := routeRepo.GetRoute(testCtx, authInfo, "non-existent-route-guid")
-				Expect(err).To(MatchError(NewNotFoundError("Route", nil)))
+				Expect(err).To(MatchError(NewNotFoundError(RouteResourceType, nil)))
 			})
 		})
 

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -178,7 +178,7 @@ var _ = Describe("RouteRepository", func() {
 		When("the CFRoute doesn't exist", func() {
 			It("returns an error", func() {
 				_, err := routeRepo.GetRoute(testCtx, authInfo, "non-existent-route-guid")
-				Expect(err).To(MatchError(NotFoundError{}))
+				Expect(err).To(MatchError(NewNotFoundError("Route", nil)))
 			})
 		})
 

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	LabelServiceBindingProvisionedService = "servicebinding.io/provisioned-service"
+	ServiceBindingResourceType            = "Service Binding"
 )
 
 type ServiceBindingRepo struct {
@@ -87,7 +88,7 @@ func (r *ServiceBindingRepo) CreateServiceBinding(ctx context.Context, authInfo 
 	err = userClient.Create(ctx, &cfServiceBinding)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return ServiceBindingRecord{}, NewForbiddenError(err)
+			return ServiceBindingRecord{}, NewForbiddenError(ServiceBindingResourceType, err)
 		}
 		return ServiceBindingRecord{}, err // untested
 	}
@@ -105,7 +106,7 @@ func (r *ServiceBindingRepo) ServiceBindingExists(ctx context.Context, authInfo 
 	err = userClient.List(ctx, serviceBindingList, client.InNamespace(spaceGUID))
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return false, NewForbiddenError(err)
+			return false, NewForbiddenError(ServiceBindingResourceType, err)
 		}
 		return false, err // untested
 	}

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -21,6 +21,7 @@ import (
 const (
 	CFServiceInstanceGUIDLabel          = "services.cloudfoundry.org/service-instance-guid"
 	ServiceInstanceCredentialSecretType = "servicebinding.io/user-provided"
+	ServiceInstanceResourceType         = "Service Instance"
 )
 
 type ServiceInstanceRepo struct {
@@ -77,7 +78,7 @@ func (r *ServiceInstanceRepo) CreateServiceInstance(ctx context.Context, authInf
 	err = userClient.Create(ctx, &cfServiceInstance)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
-			return ServiceInstanceRecord{}, NewForbiddenError("Service Instance", err)
+			return ServiceInstanceRecord{}, NewForbiddenError(ServiceInstanceResourceType, err)
 		}
 		// untested
 		return ServiceInstanceRecord{}, err

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -6,12 +6,10 @@ import (
 	"sort"
 	"strings"
 
-	servicesv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/services/v1alpha1"
-
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
+	servicesv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/services/v1alpha1"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,8 +76,8 @@ func (r *ServiceInstanceRepo) CreateServiceInstance(ctx context.Context, authInf
 	cfServiceInstance := message.toCFServiceInstance()
 	err = userClient.Create(ctx, &cfServiceInstance)
 	if err != nil {
-		if apierrors.IsForbidden(err) {
-			return ServiceInstanceRecord{}, NewForbiddenError(err)
+		if k8serrors.IsForbidden(err) {
+			return ServiceInstanceRecord{}, NewForbiddenError("Service Instance", err)
 		}
 		// untested
 		return ServiceInstanceRecord{}, err

--- a/api/repositories/service_instance_repository_test.go
+++ b/api/repositories/service_instance_repository_test.go
@@ -11,14 +11,13 @@ import (
 
 	servicesv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/services/v1alpha1"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
-	. "code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 )
 
 var _ = Describe("ServiceInstanceRepository", func() {
@@ -142,7 +141,7 @@ var _ = Describe("ServiceInstanceRepository", func() {
 		When("user does not have permissions to create ServiceInstances", func() {
 			It("returns a Forbidden error", func() {
 				_, err := serviceInstanceRepo.CreateServiceInstance(testCtx, authInfo, serviceInstanceCreateMessage)
-				Expect(err).To(BeAssignableToTypeOf(repositories.ForbiddenError{}))
+				Expect(err).To(BeAssignableToTypeOf(ForbiddenError{}))
 			})
 		})
 	})


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Improve the NotFoundError and ForbiddenError in repositories:
- Make internals private
- Use constructors for creation throughout
- Remove duplication between NotFound and Forbidden errors
- Backfill missing resource types in code and tests

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green CI

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-k8s 