### PR TITLE
DRAFT: Experiment with error handling

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,6 +11,7 @@ COPY controllers/apis controllers/apis/
 COPY controllers/webhooks controllers/webhooks/
 COPY api/actions api/actions/
 COPY api/apis api/apis/
+COPY api/apierr api/apierr/
 COPY api/authorization api/authorization/
 COPY api/payloads api/payloads/
 COPY api/presenter api/presenter/

--- a/api/apierr/errors.go
+++ b/api/apierr/errors.go
@@ -10,6 +10,7 @@ type ApiError interface {
 	Title() string
 	Code() int
 	HttpStatus() int
+	Unwrap() error
 }
 
 type apiError struct {

--- a/api/apierr/errors.go
+++ b/api/apierr/errors.go
@@ -1,0 +1,169 @@
+package apierr
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type ApiError interface {
+	Detail() string
+	Title() string
+	Code() int
+	HttpStatus() int
+}
+
+type apiError struct {
+	cause      error
+	detail     string
+	title      string
+	code       int
+	httpStatus int
+}
+
+func (e apiError) Error() string {
+	return e.cause.Error()
+}
+
+func (e apiError) Unwrap() error {
+	return e.cause
+}
+
+func (e apiError) Detail() string {
+	return e.detail
+}
+
+func (e apiError) Title() string {
+	return e.title
+}
+
+func (e apiError) Code() int {
+	return e.code
+}
+
+func (e apiError) HttpStatus() int {
+	return e.httpStatus
+}
+
+type ForbiddenError struct {
+	apiError
+	resourceType string
+}
+
+func (e ForbiddenError) ResourceType() string {
+	return e.resourceType
+}
+
+func NewForbiddenError(cause error, resourceType string) ForbiddenError {
+	return ForbiddenError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-NotAuthorized",
+			detail:     "You are not authorized to perform the requested action",
+			code:       10003,
+			httpStatus: http.StatusForbidden,
+		},
+		resourceType: resourceType,
+	}
+}
+
+// ------
+type NotFoundError struct {
+	apiError
+}
+
+func NewNotFoundError(cause error, resourceType string) NotFoundError {
+	return NotFoundError{
+		apiError{
+			cause:      cause,
+			title:      "CF-ResourceNotFound",
+			detail:     fmt.Sprintf("%s not found", resourceType),
+			code:       10010,
+			httpStatus: http.StatusNotFound,
+		},
+	}
+}
+
+// ------
+type InvalidAuthError struct {
+	apiError
+}
+
+func NewInvalidAuthError(cause error) InvalidAuthError {
+	return InvalidAuthError{
+		apiError{
+			cause:      cause,
+			title:      "CF-InvalidAuthToken",
+			detail:     "Invalid Auth Token",
+			code:       1000,
+			httpStatus: http.StatusUnauthorized,
+		},
+	}
+}
+
+// ------
+type NotAuthenticatedError struct {
+	apiError
+}
+
+func NewNotAuthenticatedError(cause error) NotAuthenticatedError {
+	return NotAuthenticatedError{
+		apiError{
+			cause:      cause,
+			title:      "CF-NotAuthenticated",
+			detail:     "Authentication error",
+			code:       10002,
+			httpStatus: http.StatusUnauthorized,
+		},
+	}
+}
+
+// -----
+type UnknownError struct {
+	apiError
+}
+
+func NewUnknownError(cause error) UnknownError {
+	return UnknownError{
+		apiError{
+			cause:      cause,
+			title:      "UnknownError",
+			detail:     "An unknown error occurred.",
+			code:       10001,
+			httpStatus: http.StatusInternalServerError,
+		},
+	}
+}
+
+// -----
+type UnprocessableEntityError struct {
+	apiError
+}
+
+func NewUnprocessableEntityError(cause error, detail string) UnprocessableEntityError {
+	return UnprocessableEntityError{
+		apiError{
+			cause:      cause,
+			title:      "CF-UnprocessableEntity",
+			detail:     detail,
+			code:       10008,
+			httpStatus: http.StatusUnprocessableEntity,
+		},
+	}
+}
+
+// -----
+type MessageParseError struct {
+	apiError
+}
+
+func NewMessageParseError(cause error) UnprocessableEntityError {
+	return UnprocessableEntityError{
+		apiError{
+			cause:      cause,
+			title:      "CF-MessageParseError",
+			detail:     "Request invalid due to parse error: invalid request body",
+			code:       1001,
+			httpStatus: http.StatusBadRequest,
+		},
+	}
+}

--- a/api/apis/auth_aware_handler.go
+++ b/api/apis/auth_aware_handler.go
@@ -3,7 +3,9 @@ package apis
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierr"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 )
@@ -31,5 +33,36 @@ func (wrapper *AuthAwareHandlerFuncWrapper) Wrap(delegate AuthAwareHandlerFunc) 
 		}
 
 		delegate(authInfo, w, r)
+	}
+}
+
+type AuthAwareHandlerFunc__NewStyle func(authInfo authorization.Info, r *http.Request) (int, interface{}, error)
+
+type AuthAwareHandlerFuncWrapper__NewStyle struct {
+	logger logr.Logger
+}
+
+func NewAuthAwareHandlerFuncWrapper__NewStyle(logger logr.Logger) *AuthAwareHandlerFuncWrapper__NewStyle {
+	return &AuthAwareHandlerFuncWrapper__NewStyle{logger: logger}
+}
+
+func (wrapper *AuthAwareHandlerFuncWrapper__NewStyle) Wrap(delegate AuthAwareHandlerFunc__NewStyle) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add(headers.ContentType, "application/json")
+
+		authInfo, ok := authorization.InfoFromContext(r.Context())
+		if !ok {
+			wrapper.logger.Error(nil, "unable to get auth info")
+			writeErrorResponse(w, presenter.ForError(apierr.NewUnknownError(nil)))
+			return
+		}
+
+		status, result, err := delegate(authInfo, r)
+		if err != nil {
+			writeErrorResponse(w, presenter.ForError(err))
+			return
+		}
+
+		writeResponse(w, status, result)
 	}
 }

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -20,6 +20,7 @@ const (
 //counterfeiter:generate -o fake -fake-name CFDropletRepository . CFDropletRepository
 type CFDropletRepository interface {
 	GetDroplet(context.Context, authorization.Info, string) (repositories.DropletRecord, error)
+	GetDroplet__NewStyle(context.Context, authorization.Info, string) (repositories.DropletRecord, error)
 	ListDroplets(context.Context, authorization.Info, repositories.ListDropletsMessage) ([]repositories.DropletRecord, error)
 }
 

--- a/api/apis/fake/cfapp_repository.go
+++ b/api/apis/fake/cfapp_repository.go
@@ -100,6 +100,21 @@ type CFAppRepository struct {
 		result1 map[string]string
 		result2 error
 	}
+	GetApp__NewStyleStub        func(context.Context, authorization.Info, string) (repositories.AppRecord, error)
+	getApp__NewStyleMutex       sync.RWMutex
+	getApp__NewStyleArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}
+	getApp__NewStyleReturns struct {
+		result1 repositories.AppRecord
+		result2 error
+	}
+	getApp__NewStyleReturnsOnCall map[int]struct {
+		result1 repositories.AppRecord
+		result2 error
+	}
 	ListAppsStub        func(context.Context, authorization.Info, repositories.ListAppsMessage) ([]repositories.AppRecord, error)
 	listAppsMutex       sync.RWMutex
 	listAppsArgsForCall []struct {
@@ -558,6 +573,72 @@ func (fake *CFAppRepository) GetAppEnvReturnsOnCall(i int, result1 map[string]st
 	}{result1, result2}
 }
 
+func (fake *CFAppRepository) GetApp__NewStyle(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.AppRecord, error) {
+	fake.getApp__NewStyleMutex.Lock()
+	ret, specificReturn := fake.getApp__NewStyleReturnsOnCall[len(fake.getApp__NewStyleArgsForCall)]
+	fake.getApp__NewStyleArgsForCall = append(fake.getApp__NewStyleArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetApp__NewStyleStub
+	fakeReturns := fake.getApp__NewStyleReturns
+	fake.recordInvocation("GetApp__NewStyle", []interface{}{arg1, arg2, arg3})
+	fake.getApp__NewStyleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFAppRepository) GetApp__NewStyleCallCount() int {
+	fake.getApp__NewStyleMutex.RLock()
+	defer fake.getApp__NewStyleMutex.RUnlock()
+	return len(fake.getApp__NewStyleArgsForCall)
+}
+
+func (fake *CFAppRepository) GetApp__NewStyleCalls(stub func(context.Context, authorization.Info, string) (repositories.AppRecord, error)) {
+	fake.getApp__NewStyleMutex.Lock()
+	defer fake.getApp__NewStyleMutex.Unlock()
+	fake.GetApp__NewStyleStub = stub
+}
+
+func (fake *CFAppRepository) GetApp__NewStyleArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.getApp__NewStyleMutex.RLock()
+	defer fake.getApp__NewStyleMutex.RUnlock()
+	argsForCall := fake.getApp__NewStyleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFAppRepository) GetApp__NewStyleReturns(result1 repositories.AppRecord, result2 error) {
+	fake.getApp__NewStyleMutex.Lock()
+	defer fake.getApp__NewStyleMutex.Unlock()
+	fake.GetApp__NewStyleStub = nil
+	fake.getApp__NewStyleReturns = struct {
+		result1 repositories.AppRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFAppRepository) GetApp__NewStyleReturnsOnCall(i int, result1 repositories.AppRecord, result2 error) {
+	fake.getApp__NewStyleMutex.Lock()
+	defer fake.getApp__NewStyleMutex.Unlock()
+	fake.GetApp__NewStyleStub = nil
+	if fake.getApp__NewStyleReturnsOnCall == nil {
+		fake.getApp__NewStyleReturnsOnCall = make(map[int]struct {
+			result1 repositories.AppRecord
+			result2 error
+		})
+	}
+	fake.getApp__NewStyleReturnsOnCall[i] = struct {
+		result1 repositories.AppRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFAppRepository) ListApps(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListAppsMessage) ([]repositories.AppRecord, error) {
 	fake.listAppsMutex.Lock()
 	ret, specificReturn := fake.listAppsReturnsOnCall[len(fake.listAppsArgsForCall)]
@@ -837,6 +918,8 @@ func (fake *CFAppRepository) Invocations() map[string][][]interface{} {
 	defer fake.getAppByNameAndSpaceMutex.RUnlock()
 	fake.getAppEnvMutex.RLock()
 	defer fake.getAppEnvMutex.RUnlock()
+	fake.getApp__NewStyleMutex.RLock()
+	defer fake.getApp__NewStyleMutex.RUnlock()
 	fake.listAppsMutex.RLock()
 	defer fake.listAppsMutex.RUnlock()
 	fake.patchAppEnvVarsMutex.RLock()

--- a/api/apis/fake/cfdroplet_repository.go
+++ b/api/apis/fake/cfdroplet_repository.go
@@ -26,6 +26,21 @@ type CFDropletRepository struct {
 		result1 repositories.DropletRecord
 		result2 error
 	}
+	GetDroplet__NewStyleStub        func(context.Context, authorization.Info, string) (repositories.DropletRecord, error)
+	getDroplet__NewStyleMutex       sync.RWMutex
+	getDroplet__NewStyleArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}
+	getDroplet__NewStyleReturns struct {
+		result1 repositories.DropletRecord
+		result2 error
+	}
+	getDroplet__NewStyleReturnsOnCall map[int]struct {
+		result1 repositories.DropletRecord
+		result2 error
+	}
 	ListDropletsStub        func(context.Context, authorization.Info, repositories.ListDropletsMessage) ([]repositories.DropletRecord, error)
 	listDropletsMutex       sync.RWMutex
 	listDropletsArgsForCall []struct {
@@ -111,6 +126,72 @@ func (fake *CFDropletRepository) GetDropletReturnsOnCall(i int, result1 reposito
 	}{result1, result2}
 }
 
+func (fake *CFDropletRepository) GetDroplet__NewStyle(arg1 context.Context, arg2 authorization.Info, arg3 string) (repositories.DropletRecord, error) {
+	fake.getDroplet__NewStyleMutex.Lock()
+	ret, specificReturn := fake.getDroplet__NewStyleReturnsOnCall[len(fake.getDroplet__NewStyleArgsForCall)]
+	fake.getDroplet__NewStyleArgsForCall = append(fake.getDroplet__NewStyleArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetDroplet__NewStyleStub
+	fakeReturns := fake.getDroplet__NewStyleReturns
+	fake.recordInvocation("GetDroplet__NewStyle", []interface{}{arg1, arg2, arg3})
+	fake.getDroplet__NewStyleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CFDropletRepository) GetDroplet__NewStyleCallCount() int {
+	fake.getDroplet__NewStyleMutex.RLock()
+	defer fake.getDroplet__NewStyleMutex.RUnlock()
+	return len(fake.getDroplet__NewStyleArgsForCall)
+}
+
+func (fake *CFDropletRepository) GetDroplet__NewStyleCalls(stub func(context.Context, authorization.Info, string) (repositories.DropletRecord, error)) {
+	fake.getDroplet__NewStyleMutex.Lock()
+	defer fake.getDroplet__NewStyleMutex.Unlock()
+	fake.GetDroplet__NewStyleStub = stub
+}
+
+func (fake *CFDropletRepository) GetDroplet__NewStyleArgsForCall(i int) (context.Context, authorization.Info, string) {
+	fake.getDroplet__NewStyleMutex.RLock()
+	defer fake.getDroplet__NewStyleMutex.RUnlock()
+	argsForCall := fake.getDroplet__NewStyleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFDropletRepository) GetDroplet__NewStyleReturns(result1 repositories.DropletRecord, result2 error) {
+	fake.getDroplet__NewStyleMutex.Lock()
+	defer fake.getDroplet__NewStyleMutex.Unlock()
+	fake.GetDroplet__NewStyleStub = nil
+	fake.getDroplet__NewStyleReturns = struct {
+		result1 repositories.DropletRecord
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CFDropletRepository) GetDroplet__NewStyleReturnsOnCall(i int, result1 repositories.DropletRecord, result2 error) {
+	fake.getDroplet__NewStyleMutex.Lock()
+	defer fake.getDroplet__NewStyleMutex.Unlock()
+	fake.GetDroplet__NewStyleStub = nil
+	if fake.getDroplet__NewStyleReturnsOnCall == nil {
+		fake.getDroplet__NewStyleReturnsOnCall = make(map[int]struct {
+			result1 repositories.DropletRecord
+			result2 error
+		})
+	}
+	fake.getDroplet__NewStyleReturnsOnCall[i] = struct {
+		result1 repositories.DropletRecord
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CFDropletRepository) ListDroplets(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListDropletsMessage) ([]repositories.DropletRecord, error) {
 	fake.listDropletsMutex.Lock()
 	ret, specificReturn := fake.listDropletsReturnsOnCall[len(fake.listDropletsArgsForCall)]
@@ -182,6 +263,8 @@ func (fake *CFDropletRepository) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.getDropletMutex.RLock()
 	defer fake.getDropletMutex.RUnlock()
+	fake.getDroplet__NewStyleMutex.RLock()
+	defer fake.getDroplet__NewStyleMutex.RUnlock()
 	fake.listDropletsMutex.RLock()
 	defer fake.listDropletsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/api/apis/integration/app_test.go
+++ b/api/apis/integration/app_test.go
@@ -29,7 +29,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 )
 
-var _ = Describe("App Handler", func() {
+var _ = FDescribe("App Handler", func() {
 	var (
 		apiHandler *AppHandler
 		org, space *hnsv1alpha2.SubnamespaceAnchor

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -446,11 +446,7 @@ func (f *AppRepo) SetCurrentDroplet(ctx context.Context, authInfo authorization.
 
 	err = userClient.Patch(ctx, cfApp, client.MergeFrom(baseCFApp))
 	if err != nil {
-		if k8serrors.IsForbidden(err) {
-			return CurrentDropletRecord{}, apierr.NewForbiddenError(err, AppResourceType)
-		}
-
-		return CurrentDropletRecord{}, fmt.Errorf("err in client.Patch: %w", err)
+		return CurrentDropletRecord{}, wrapK8sError(fmt.Errorf("err in client.Patch: %w", err), AppResourceType)
 	}
 
 	return CurrentDropletRecord{

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Apps", func() {
 		})
 	})
 
-	Describe("Fetch an app", func() {
+	FDescribe("Fetch an app", func() {
 		var result resource
 
 		BeforeEach(func() {
@@ -210,7 +210,7 @@ var _ = Describe("Apps", func() {
 			})
 		})
 
-		Describe("Set app current droplet", func() {
+		FDescribe("Set app current droplet", func() {
 			type currentDropletResource struct {
 				Data resource `json:"data"`
 			}


### PR DESCRIPTION
We have modified GetApp and SetCurrentDroplet in the app handler as an example

The main changes are as follows:

Errors:
- We have a new single location for errors: the `apierr` package
- Errors within `apierr` are objects that replace the `writeXXXError` methods from `apis/shared.go`.
- These errors are raised throughout the system - mainly in repositories and handlers
- These errors have all the information, i.e. http status and error details, to write out API error messages

Repositories:
- Repo code calling k8s methods should map k8s errors to `apierr` errors using `wrapK8sError` which also takes the resourceType

Handlers:
- Handler methods now have a new signature: `handleXXX(authInfo authorization.Info, r *http.Request) (status int, responseObj interface{}, err error)`
    - They do not get the response writer any more as this is now responsibility of the endpoint function wrapper (see below)
    - Return status and responseObj for successful requests
    - Return an error for error responses
        - An `apierr` error will render a custom API error
        - Any other error will be an 'UnknownError' 500
- Handlers should modify ForbiddenError to NotFoundErrors where appropriate using the `apierr.AsNotFoundIfForbidden(err)` helper
- Handlers should modify NotFoundError or ForbiddenError to UnprocessableEntityErrors where appropriate using the `apierr.AsUnprocessableIfNotFoundOrForbidden(err)` helper
    - We assume mapping NotFound and Forbidden to Unprocessable is the only general case. If not, we might think about callbacks we could pass in to match certain errors and be more flexible
- A new wrapper in the routes wiring handles presenting the successful or error responses