### PR TITLE
Authorize stopping apps

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -366,6 +366,12 @@ func (h *AppHandler) appStopHandler(authInfo authorization.Info, w http.Response
 		DesiredState: AppStoppedState,
 	})
 	if err != nil {
+		if errors.As(err, &repositories.ForbiddenError{}) {
+			h.logger.Info("failed to stop app", "AppGUID", appGUID, "error", err)
+			writeNotAuthorizedErrorResponse(w)
+			return
+		}
+
 		h.logger.Error(err, "Failed to update app in Kubernetes", "AppGUID", appGUID)
 		writeUnknownErrorResponse(w)
 		return

--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -1323,7 +1323,17 @@ var _ = Describe("AppHandler", func() {
 			})
 		})
 
-		When("there is some other error fetching the app", func() {
+		When("fetching the app is forbidden", func() {
+			BeforeEach(func() {
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+			})
+
+			It("returns a not found error", func() {
+				expectNotFoundError("App not found")
+			})
+		})
+
+		When("there is an unknown error fetching the app", func() {
 			BeforeEach(func() {
 				appRepo.GetAppReturns(repositories.AppRecord{}, errors.New("unknown!"))
 			})
@@ -1431,7 +1441,17 @@ var _ = Describe("AppHandler", func() {
 			})
 		})
 
-		When("there is some other error updating app desiredState", func() {
+		When("updating the app desired state is not allowed", func() {
+			BeforeEach(func() {
+				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, repositories.NewForbiddenError("App", nil))
+			})
+
+			It("returns a forbidden error", func() {
+				expectNotAuthorizedError()
+			})
+		})
+
+		When("there is an unknown error updating app desiredState", func() {
 			BeforeEach(func() {
 				appRepo.SetAppDesiredStateReturns(repositories.AppRecord{}, errors.New("unknown!"))
 			})

--- a/api/apis/integration/app_test.go
+++ b/api/apis/integration/app_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	hnsv1alpha2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 
@@ -278,6 +279,50 @@ var _ = Describe("App Handler", func() {
 				It("restarts the app", func() {
 					Expect(rr).To(HaveHTTPStatus(http.StatusOK))
 					Expect(rr).To(HaveHTTPBody(ContainSubstring(`"state":"STARTED"`)), rr.Body.String())
+				})
+			})
+		})
+
+		Describe("stop app", func() {
+			BeforeEach(func() {
+				stoppedApp := app.DeepCopy()
+				stoppedApp.Spec.DesiredState = "STARTED"
+				Expect(k8sClient.Patch(ctx, stoppedApp, client.MergeFrom(app))).To(Succeed())
+			})
+
+			JustBeforeEach(func() {
+				var err error
+				req, err = http.NewRequestWithContext(ctx, http.MethodPost, serverURI("/v3/apps/"+app.Name+"/actions/stop"), nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				router.ServeHTTP(rr, req)
+			})
+
+			When("the user is not authorized in the space", func() {
+				It("returns a not found status", func() {
+					Expect(rr).To(HaveHTTPStatus(http.StatusNotFound))
+					Expect(rr).To(HaveHTTPBody(ContainSubstring("App not found")), rr.Body.String())
+				})
+			})
+
+			When("the user has readonly access to the app", func() {
+				BeforeEach(func() {
+					createRoleBinding(ctx, userName, spaceManagerRole.Name, spaceGUID)
+				})
+
+				It("returns a forbidden error", func() {
+					Expect(rr).To(HaveHTTPStatus(http.StatusForbidden))
+				})
+			})
+
+			When("the user is a space developer", func() {
+				BeforeEach(func() {
+					createRoleBinding(ctx, userName, spaceDeveloperRole.Name, spaceGUID)
+				})
+
+				It("stops the app", func() {
+					Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+					Expect(rr).To(HaveHTTPBody(ContainSubstring(`"state":"STOPPED"`)), rr.Body.String())
 				})
 			})
 		})

--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -253,5 +253,20 @@ var _ = Describe("Apps", func() {
 				Expect(result.State).To(Equal("STARTED"))
 			})
 		})
+
+		Describe("Stop an app", func() {
+			var result appResource
+
+			JustBeforeEach(func() {
+				var err error
+				resp, err = certClient.R().SetResult(&result).Post("/v3/apps/" + appGUID + "/actions/stop")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("succeeds", func() {
+				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
+				Expect(result.State).To(Equal("STOPPED"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/622

## What is this change about?
The authorization was pretty much already in place, just minor changes
in errors handling and backfilling missing tests

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See story

@cloudfoundry/cf-k8s 