### PR TITLE
706 update e2e process stats tests

### DIFF
--- a/api/repositories/pod_repository_test.go
+++ b/api/repositories/pod_repository_test.go
@@ -279,6 +279,22 @@ var _ = Describe("PodRepository", func() {
 				})
 			})
 
+			When("MetricsFetcherFunction returns a not found error for the PodMetrics", func() {
+				BeforeEach(func() {
+					message.Instances = 2
+					metricFetcherFn.Returns(nil, errors.New("podmetrics.metrics.k8s.io \\\"Blah\\\" not found"))
+				})
+				It("fetches all the pods and sets the usage stats with empty values", func() {
+					Expect(listStatsErr).NotTo(HaveOccurred())
+					Expect(records).To(ConsistOf(
+						[]PodStatsRecord{
+							{Type: "web", Index: 0, State: "RUNNING"},
+							{Type: "web", Index: 1, State: "DOWN"},
+						},
+					))
+				})
+			})
+
 			When("MetricFetcherFunction return some other error", func() {
 				BeforeEach(func() {
 					message.Instances = 2

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/tests/e2e/helpers"
 
 	"github.com/go-resty/resty/v2"
@@ -93,12 +94,7 @@ type dropletResource struct {
 }
 
 type statsResourceList struct {
-	Resources []statsResource `json:"resources"`
-}
-
-type statsResource struct {
-	Type  string `json:"type"`
-	State string `json:"state"`
+	Resources []presenter.ProcessStatsResource `json:"resources"`
 }
 
 type manifestResource struct {

--- a/dependencies/kpack/cluster_store.yaml
+++ b/dependencies/kpack/cluster_store.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sources:
   - image: gcr.io/paketo-buildpacks/java
-  - image: gcr.io/paketo-buildpacks/nodejs
+  - image: gcr.io/paketo-buildpacks/nodejs:0.13
   - image: gcr.io/paketo-buildpacks/ruby
   - image: gcr.io/paketo-buildpacks/procfile
   - image: gcr.io/paketo-buildpacks/go

--- a/dependencies/metrics-server-local-0.6.1.yaml
+++ b/dependencies/metrics-server-local-0.6.1.yaml
@@ -1,0 +1,198 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+        - args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+            - --kubelet-insecure-tls
+            - --kubelet-preferred-address-types=InternalIP
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 4443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+        - emptyDir: {}
+          name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -162,6 +162,14 @@ install_dependencies() {
     fi
 
     "$SCRIPT_DIR/install-dependencies.sh"
+
+    # install metrics server only on local cluster
+    DEP_DIR="$(cd "${SCRIPT_DIR}/../dependencies" && pwd)"
+    echo "*********************************************"
+    echo "Installing metrics-server"
+    echo "*********************************************"
+    kubectl apply -f "${DEP_DIR}/metrics-server-local-0.6.1.yaml"
+
   }
   popd >/dev/null
 }


### PR DESCRIPTION
Co-authored-by: Ashwin Krishna <krishnaas@vmware.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
Resolves #706 

## What is this change about?
<!-- _Please describe the change here._ -->
Adds an e2e test for the GET process_stats endpoint when metrics server is present
Adds metrics-server to kind deployment script

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
Run tests.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@akrishna90 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
