### PR TITLE
include=app support in service_credential_bindings

### DIFF
--- a/api/payloads/service_binding.go
+++ b/api/payloads/service_binding.go
@@ -32,8 +32,9 @@ func (l *ServiceBindingList) ToMessage() repositories.ListServiceBindingsMessage
 
 type ServiceBindingList struct {
 	ServiceInstanceGuids *string `schema:"service_instance_guids"`
+	Include              *string `schema:"include" validate:"oneof=app"`
 }
 
 func (l *ServiceBindingList) SupportedFilterKeys() []string {
-	return []string{"service_instance_guids"}
+	return []string{"service_instance_guids, include"}
 }

--- a/api/presenter/service_binding.go
+++ b/api/presenter/service_binding.go
@@ -76,11 +76,19 @@ func ForServiceBinding(record repositories.ServiceBindingRecord, baseURL url.URL
 	}
 }
 
-func ForServiceBindingList(serviceBindingRecord []repositories.ServiceBindingRecord, baseURL, requestURL url.URL) ListResponse {
+func ForServiceBindingList(serviceBindingRecord []repositories.ServiceBindingRecord, appRecords []repositories.AppRecord, baseURL, requestURL url.URL) ListResponse {
 	serviceBindingResponses := make([]interface{}, 0, len(serviceBindingRecord))
 	for _, serviceBinding := range serviceBindingRecord {
 		serviceBindingResponses = append(serviceBindingResponses, ForServiceBinding(serviceBinding, baseURL))
 	}
 
-	return ForList(serviceBindingResponses, baseURL, requestURL)
+	ret := ForList(serviceBindingResponses, baseURL, requestURL)
+	if len(appRecords) > 0 {
+		appData := IncludedData{}
+		for _, appRecord := range appRecords {
+			appData.Apps = append(appData.Apps, ForApp(appRecord, baseURL))
+		}
+		ret.Included = &appData
+	}
+	return ret
 }

--- a/api/presenter/shared.go
+++ b/api/presenter/shared.go
@@ -38,6 +38,7 @@ type Link struct {
 type ListResponse struct {
 	PaginationData PaginationData `json:"pagination"`
 	Resources      []interface{}  `json:"resources"`
+	Included       *IncludedData  `json:"included,omitempty"`
 }
 
 type PaginationData struct {
@@ -47,6 +48,10 @@ type PaginationData struct {
 	Last         PageRef `json:"last"`
 	Next         *int    `json:"next"`
 	Previous     *int    `json:"previous"`
+}
+
+type IncludedData struct {
+	Apps []interface{} `json:"apps"`
 }
 
 type PageRef struct {

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -158,7 +158,7 @@ func (r *ServiceInstanceRepo) GetServiceInstance(ctx context.Context, authInfo a
 
 	var serviceInstance servicesv1alpha1.CFServiceInstance
 	if err := userClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: guid}, &serviceInstance); err != nil {
-		return ServiceInstanceRecord{}, fmt.Errorf("failed to get serivice instance: %w", wrapK8sErr(err, ServiceInstanceResourceType))
+		return ServiceInstanceRecord{}, fmt.Errorf("failed to get service instance: %w", wrapK8sErr(err, ServiceInstanceResourceType))
 	}
 
 	return cfServiceInstanceToServiceInstanceRecord(serviceInstance), nil

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -73,6 +73,13 @@ type relationship struct {
 type resourceList struct {
 	Resources []resource `json:"resources"`
 }
+type resourceListWithInclusion struct {
+	Resources []resource    `json:"resources"`
+	Included  *includedApps `json:",omitempty"`
+}
+type includedApps struct {
+	Apps []resource `json:"apps"`
+}
 
 type appResource struct {
 	resource `json:",inline"`
@@ -565,6 +572,20 @@ func listServiceInstances() resourceList {
 	Expect(resp.StatusCode()).To(Equal(http.StatusOK))
 
 	return serviceInstances
+}
+
+func createServiceBinding(appGUID, instanceGUID string) {
+	resp, err := adminClient.R().
+		SetBody(typedResource{
+			Type: "app",
+			resource: resource{
+				Relationships: relationships{"app": {Data: resource{GUID: appGUID}}, "service_instance": {Data: resource{GUID: instanceGUID}}},
+			},
+		}).
+		Post("/v3/service_credential_bindings")
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
 }
 
 func createPackage(appGUID string) string {

--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -1,0 +1,99 @@
+package e2e_test
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+var _ = Describe("Service Bindings", func() {
+	Describe("List", func() {
+		var (
+			appGUID      string
+			orgGUID      string
+			spaceGUID    string
+			instanceGUID string
+			httpResp     *resty.Response
+			httpError    error
+			queryString  string
+			result       resourceListWithInclusion
+		)
+
+		BeforeEach(func() {
+			orgGUID = createOrg(generateGUID("org"))
+			time.Sleep(time.Second) // this appears to reduce flakes, but should be removed once we have better logic to determine org/space readiness
+			spaceGUID = createSpace(generateGUID("space1"), orgGUID)
+			time.Sleep(time.Second)
+			createOrgRole("organization_user", rbacv1.UserKind, certUserName, orgGUID)
+			instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"))
+			appGUID = createApp(spaceGUID, generateGUID("app"))
+			createServiceBinding(appGUID, instanceGUID)
+
+			queryString = ""
+			result = resourceListWithInclusion{}
+		})
+
+		JustBeforeEach(func() {
+			httpResp, httpError = certClient.R().SetResult(&result).Get("/v3/service_credential_bindings" + queryString)
+		})
+
+		AfterEach(func() {
+			deleteOrg(orgGUID)
+		})
+
+		It("Returns an empty list", func() {
+			Expect(httpError).NotTo(HaveOccurred())
+			Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+			Expect(result.Resources).To(HaveLen(0))
+		})
+
+		When("the user has space manager role", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("succeeds", func() {
+				Expect(httpError).NotTo(HaveOccurred())
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+				Expect(result.Resources).To(HaveLen(1))
+			})
+		})
+
+		When("the user has space developer role", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("succeeds", func() {
+				Expect(httpError).NotTo(HaveOccurred())
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+				Expect(result.Resources).To(HaveLen(1))
+			})
+
+			It("doesn't return anything in the 'included' list", func() {
+				Expect(result.Included).To(BeNil())
+			})
+
+			When("the 'include=app' querystring is set", func() {
+				BeforeEach(func() {
+					queryString = `?include=app`
+				})
+
+				It("returns an app in the 'included' list", func() {
+					Expect(httpError).NotTo(HaveOccurred())
+					Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
+					Expect(result.Resources).To(HaveLen(1))
+					Expect(result.Included).NotTo(BeNil())
+					Expect(result.Included.Apps).To(ConsistOf(
+						MatchFields(IgnoreExtras, Fields{"GUID": Equal(appGUID)}),
+					))
+				})
+			})
+		})
+	})
+})

--- a/controllers/config/cf_roles/cf_space_manager.yaml
+++ b/controllers/config/cf_roles/cf_space_manager.yaml
@@ -32,3 +32,10 @@ rules:
   verbs:
   - list
   - get
+
+- apiGroups:
+    - services.cloudfoundry.org
+  resources:
+    - cfservicebindings
+  verbs:
+    - list

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -2200,6 +2200,12 @@ rules:
   verbs:
   - list
   - get
+- apiGroups:
+  - services.cloudfoundry.org
+  resources:
+  - cfservicebindings
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#627]
## What is this change about?
This PR adds include=app support in service_credential_bindings
- /v3/service_credential_bindings can now accept a ?include=app
  querystring
- when specified, the handler includes bound applications in the
  response payload
- added e2e tests for listServiceBindings handler
- add list CFServiceBindings to space_manager RBAC so that space
  managers have read access to service bindings

## Does this PR introduce a breaking change?
no

## Acceptance Steps
[#627]

## Tag your pair, your PM, and/or team
@akrishna90 
