### PR TITLE
Add DomainNotFound error handling and missing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ With the load balancer provisioned, you must configure the ingress controller to
 ### Domain Management
 To be able to create workload routes via the CF API in the absence of the domain management endpoints, you must first create the appropriate `CFDomain` resource(s) for your cluster. Each desired domain name should be specified via the `spec.name` property of a distinct resource. The `metadata.name` for the resource can be set to any unique value (the API will use a GUID). See `controllers/config/samples/cfdomain.yaml` for an example.
 
+### Configuring Default Domain
+
+At the time of installation, platform operators can configure a default domain so that app developers can push an application without specifying domain information. 
+Operator can do so by setting the `defaultDomainName` at `api/config/base/apiconfig/cf_k8s_api_config.yaml`. The value should match `spec.name` on the `CFDomian` resource.
+
+Note: Platform operators are responsible for creating the required `CFDomain` resource. See `controllers/config/samples/cfdomain.yaml` for an example.
+
 ---
 ## Install Eirini-Controller
 

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -56,26 +56,35 @@ func (h *SpaceManifestHandler) RegisterRoutes(router *mux.Router) {
 }
 
 func (h *SpaceManifestHandler) applyManifestHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	vars := mux.Vars(r)
 	spaceGUID := vars["spaceGUID"]
 	var manifest payloads.Manifest
 	rme := h.decoderValidator.DecodeAndValidateYAMLPayload(r, &manifest)
 	if rme != nil {
-		w.Header().Set("Content-Type", "application/json")
 		writeRequestMalformedErrorResponse(w, rme)
 		return
 	}
 
 	err := h.applyManifestAction(r.Context(), authInfo, spaceGUID, h.defaultDomainName, manifest)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		h.logger.Error(err, "error applying the manifest")
-		writeUnknownErrorResponse(w)
+		h.handleApplyManifestErr(err, w)
 		return
 	}
 
 	w.Header().Set("Location", fmt.Sprintf("%s/v3/jobs/space.apply_manifest-%s", h.serverURL.String(), spaceGUID))
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *SpaceManifestHandler) handleApplyManifestErr(err error, w http.ResponseWriter) {
+	switch err.(type) {
+	case repositories.NotFoundError:
+		h.logger.Info("Domain not found", "error: ", err.Error())
+		writeNotFoundErrorResponse(w, "Domain")
+	default:
+		h.logger.Error(err, "Error applying manifest")
+		writeUnknownErrorResponse(w)
+	}
 }
 
 func (h *SpaceManifestHandler) diffManifestHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -68,7 +68,7 @@ func (h *SpaceManifestHandler) applyManifestHandler(authInfo authorization.Info,
 
 	err := h.applyManifestAction(r.Context(), authInfo, spaceGUID, h.defaultDomainName, manifest)
 	if err != nil {
-		h.handleApplyManifestErr(err, w)
+		h.handleApplyManifestErr(err, w, h.defaultDomainName)
 		return
 	}
 
@@ -76,11 +76,11 @@ func (h *SpaceManifestHandler) applyManifestHandler(authInfo authorization.Info,
 	w.WriteHeader(http.StatusAccepted)
 }
 
-func (h *SpaceManifestHandler) handleApplyManifestErr(err error, w http.ResponseWriter) {
+func (h *SpaceManifestHandler) handleApplyManifestErr(err error, w http.ResponseWriter, defaultDomainName string) {
 	switch err.(type) {
 	case repositories.NotFoundError:
 		h.logger.Info("Domain not found", "error: ", err.Error())
-		writeNotFoundErrorResponse(w, "Domain")
+		writeUnprocessableEntityError(w, "The configured default domain `"+defaultDomainName+"` was not found")
 	default:
 		h.logger.Error(err, "Error applying manifest")
 		writeUnknownErrorResponse(w)

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -310,6 +310,16 @@ var _ = Describe("SpaceManifestHandler", func() {
 				Expect(payload.Applications[0].DefaultRoute).To(BeTrue())
 			})
 		})
+
+		When("applying the manifest errors with NotFoundErr", func() {
+			BeforeEach(func() {
+				applyManifestAction.Returns(repositories.NotFoundError{})
+			})
+
+			It("respond with not found error", func() {
+				expectNotFoundError("Domain not found")
+			})
+		})
 	})
 
 	Describe("POST /v3/spaces/{spaceGUID}/manifest_diff", func() {

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -316,8 +316,8 @@ var _ = Describe("SpaceManifestHandler", func() {
 				applyManifestAction.Returns(repositories.NotFoundError{})
 			})
 
-			It("respond with not found error", func() {
-				expectNotFoundError("Domain not found")
+			It("respond with unprocessable entity error", func() {
+				expectUnprocessableEntityError("The configured default domain `" + defaultDomainName + "` was not found")
 			})
 		})
 	})


### PR DESCRIPTION

## Is there a related GitHub Issue?
#161 

## What is this change about?
Add missing edge case handling and documentation

- throws a HTTP 404 instead of a HTTP 500 when Domain is not found
- add documentation for setting default domains

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #161 

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
