### PR TITLE
Use NewForConfig in CreateMetricsFetcher

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -102,7 +102,7 @@ func main() {
 		panic(fmt.Sprintf("could not parse server URL: %v", err))
 	}
 
-	metricsFetcherFunction, err := repositories.CreateMetricsFetcher()
+	metricsFetcherFunction, err := repositories.CreateMetricsFetcher(k8sClientConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/api/repositories/pod_repository.go
+++ b/api/repositories/pod_repository.go
@@ -298,13 +298,8 @@ func containersRunning(statuses []corev1.ContainerStatus) bool {
 	return true
 }
 
-func CreateMetricsFetcher() (MetricsFetcherFn, error) {
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := versioned.NewForConfig(restConfig)
+func CreateMetricsFetcher(k8sClientConfig *rest.Config) (MetricsFetcherFn, error) {
+	c, err := versioned.NewForConfig(k8sClientConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Uses the same `k8sClientConfig` as the `privilegedK8sClient` for `CreateMetricsFetcher`.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run tests as normal.

## Tag your pair, your PM, and/or team
@gnovv @clintyoshimura @tcdowney 

