### PR TITLE
Fix flaky processes e2e tests

### DIFF
--- a/api/tests/e2e/processes_test.go
+++ b/api/tests/e2e/processes_test.go
@@ -88,10 +88,7 @@ var _ = Describe("Processes", func() {
 
 		It("succeeds", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
-
 			Expect(processStats.Resources).To(HaveLen(1))
-			Expect(processStats.Resources[0].State).To(Equal("RUNNING"))
-			Expect(processStats.Resources[0].Type).To(Equal("web"))
 		})
 
 		When("we wait for the metrics to be ready", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
* Tests no longer assume that processes are immediately created after
  app droplet has been set
* Tests no longer assume that processes status is immediately RUNNING

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green e2e

