### PR TITLE
Use a shared rest mapper to client

### DIFF
--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -23,7 +23,6 @@ var _ = Describe("ServiceBindingRepo", func() {
 	var (
 		repo                *repositories.ServiceBindingRepo
 		testCtx             context.Context
-		clientFactory       repositories.UnprivilegedClientFactory
 		org                 *hnsv1alpha2.SubnamespaceAnchor
 		space               *hnsv1alpha2.SubnamespaceAnchor
 		appGUID             string
@@ -32,8 +31,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 
 	BeforeEach(func() {
 		testCtx = context.Background()
-		clientFactory = repositories.NewUnprivilegedClientFactory(k8sConfig)
-		repo = repositories.NewServiceBindingRepo(clientFactory, nsPerms)
+		repo = repositories.NewServiceBindingRepo(userClientFactory, nsPerms)
 
 		org = createOrgAnchorAndNamespace(testCtx, rootNamespace, prefixedGUID("org"))
 		space = createSpaceAnchorAndNamespace(testCtx, org.Name, prefixedGUID("space1"))


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/572

## What is this change about?
Use a shared REST mapper in user client creation which utilises the mapper cache

## Does this PR introduce a breaking change?
No

## Acceptance Steps
green tests

