### PR TITLE
Add external domain and port api configuration

### DIFF
--- a/api/config/base/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/base/apiconfig/cf_k8s_api_config.yaml
@@ -1,5 +1,6 @@
-serverURL: "https://api.example.org"
-serverPort: 9000
+externalFQDN: "api.example.org"
+internalPort: 9000
+
 rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack

--- a/api/config/base/ingress.yaml
+++ b/api/config/base/ingress.yaml
@@ -14,6 +14,6 @@ spec:
     - prefix: /
     services:
     - name: cf-k8s-api-svc
-      port: 80
+      port: 443
     timeoutPolicy:
       response: "5m"

--- a/api/config/base/service.yaml
+++ b/api/config/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
+  - port: 443
     protocol: TCP
     targetPort: web
     name: web

--- a/api/config/overlays/kind-auth-enabled/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind-auth-enabled/apiconfig/cf_k8s_api_config.yaml
@@ -1,5 +1,6 @@
-serverURL: http://localhost
-serverPort: 9000
+externalFQDN: localhost
+internalPort: 9000
+
 rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack

--- a/api/config/overlays/kind-local-registry/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind-local-registry/apiconfig/cf_k8s_api_config.yaml
@@ -1,5 +1,6 @@
-serverURL: http://localhost
-serverPort: 9000
+externalFQDN: localhost
+internalPort: 9000
+
 rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack

--- a/api/config/overlays/kind-local-registry/kustomization.yaml
+++ b/api/config/overlays/kind-local-registry/kustomization.yaml
@@ -20,5 +20,3 @@ patches:
     - op: replace
       path: /spec/virtualhost/fqdn
       value: "localhost"
-    - op: remove
-      path: /spec/virtualhost/tls

--- a/api/config/overlays/kind/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/overlays/kind/apiconfig/cf_k8s_api_config.yaml
@@ -1,5 +1,6 @@
-serverURL: http://localhost
-serverPort: 9000
+externalFQDN: localhost
+internalPort: 9000
+
 rootNamespace: cf
 defaultLifecycleConfig:
   type: buildpack

--- a/api/config/overlays/kind/kustomization.yaml
+++ b/api/config/overlays/kind/kustomization.yaml
@@ -20,5 +20,3 @@ patches:
     - op: replace
       path: /spec/virtualhost/fqdn
       value: "localhost"
-    - op: remove
-      path: /spec/virtualhost/tls

--- a/api/main.go
+++ b/api/main.go
@@ -284,7 +284,7 @@ func main() {
 		cachingIdentityProvider,
 	).Middleware)
 
-	portString := fmt.Sprintf(":%v", config.ServerPort)
+	portString := fmt.Sprintf(":%v", config.InternalPort)
 	log.Println("Listening on ", portString)
 	log.Fatal(http.ListenAndServe(portString, router))
 }

--- a/api/reference/cf-k8s-api.yaml
+++ b/api/reference/cf-k8s-api.yaml
@@ -257,8 +257,9 @@ subjects:
 apiVersion: v1
 data:
   cf_k8s_api_config.yaml: |
-    serverURL: "https://api.example.org"
-    serverPort: 9000
+    externalFQDN: "api.example.org"
+    internalPort: 9000
+
     rootNamespace: cf
     defaultLifecycleConfig:
       type: buildpack
@@ -306,7 +307,7 @@ data:
         propagate: false
 kind: ConfigMap
 metadata:
-  name: cf-k8s-api-config-bcfbt875g8
+  name: cf-k8s-api-config-g56hdg6d55
   namespace: cf-k8s-api-system
 ---
 apiVersion: v1
@@ -319,7 +320,7 @@ metadata:
 spec:
   ports:
   - name: web
-    port: 80
+    port: 443
     protocol: TCP
     targetPort: web
   selector:
@@ -361,7 +362,7 @@ spec:
       serviceAccountName: cf-k8s-api-cf-admin-serviceaccount
       volumes:
       - configMap:
-          name: cf-k8s-api-config-bcfbt875g8
+          name: cf-k8s-api-config-g56hdg6d55
         name: cf-k8s-api-config
 ---
 apiVersion: projectcontour.io/v1
@@ -377,7 +378,7 @@ spec:
     - prefix: /
     services:
     - name: cf-k8s-api-svc
-      port: 80
+      port: 443
     timeoutPolicy:
       response: 5m
   virtualhost:

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
@@ -53,6 +54,7 @@ var (
 	clientset           *kubernetes.Clientset
 	rootNamespace       string
 	apiServerRoot       string
+	appFQDN             string
 	serviceAccountName  string
 	serviceAccountToken string
 	tokenAuthHeader     string
@@ -192,6 +194,7 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 	apiServerRoot = mustHaveEnv("API_SERVER_ROOT")
+	appFQDN = mustHaveEnv("APP_FQDN")
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -243,9 +246,9 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	tokenAuthHeader = fmt.Sprintf("Bearer %s", serviceAccountToken)
-	adminClient = resty.New().SetBaseURL(apiServerRoot).SetAuthScheme("ClientCert").SetAuthToken(obtainAdminUserCert())
-	certClient = resty.New().SetBaseURL(apiServerRoot).SetAuthScheme("ClientCert").SetAuthToken(certPEM)
-	tokenClient = resty.New().SetBaseURL(apiServerRoot).SetAuthToken(serviceAccountToken)
+	adminClient = resty.New().SetBaseURL(apiServerRoot).SetAuthScheme("ClientCert").SetAuthToken(obtainAdminUserCert()).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	certClient = resty.New().SetBaseURL(apiServerRoot).SetAuthScheme("ClientCert").SetAuthToken(certPEM).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	tokenClient = resty.New().SetBaseURL(apiServerRoot).SetAuthToken(serviceAccountToken).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 })
 
 var _ = AfterSuite(func() {
@@ -262,6 +265,7 @@ func mustHaveEnv(key string) string {
 
 func ensureServerIsUp() {
 	Eventually(func() (int, error) {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		resp, err := http.Get(apiServerRoot)
 		if err != nil {
 			return 0, err

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Routes", func() {
 				appClient := resty.New()
 				Eventually(func() int {
 					var err error
-					resp, err = appClient.R().Get(fmt.Sprintf("http://%s.%s", host, SamplesDomain))
+					resp, err = appClient.R().Get(fmt.Sprintf("http://%s.%s", host, appFQDN))
 					Expect(err).NotTo(HaveOccurred())
 					return resp.StatusCode()
 				}).Should(Equal(http.StatusOK))

--- a/api/tests/e2e/whoami_test.go
+++ b/api/tests/e2e/whoami_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"net/http"
 
@@ -24,7 +25,7 @@ var _ = Describe("WhoAmI", func() {
 	)
 
 	BeforeEach(func() {
-		client = resty.New().SetBaseURL(apiServerRoot)
+		client = resty.New().SetBaseURL(apiServerRoot).SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	})
 
 	JustBeforeEach(func() {

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -212,11 +212,16 @@ deploy_cf_k8s_api() {
       make docker-build-api
     fi
     kind load docker-image --name "$cluster" "$IMG_API"
+
     if [[ -n "$use_local_registry" ]]; then
       make deploy-api-kind-local
     else
       make deploy-api-kind-auth
     fi
+
+    openssl req -x509 -newkey rsa:4096 -keyout /tmp/api-tls.key -out /tmp/api-tls.crt -nodes -subj '/CN=localhost' -addext "subjectAltName = DNS:*.vcap.me" -days 365
+    kubectl create secret tls   cf-k8s-api-ingress-cert   --cert=/tmp/api-tls.crt --key=/tmp/api-tls.key -n cf-k8s-api-system
+
   }
   popd >/dev/null
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -20,7 +20,8 @@ else
     "${SCRIPT_DIR}/deploy-on-kind.sh" -l e2e
   fi
 
-  export API_SERVER_ROOT=http://localhost
+  export API_SERVER_ROOT=https://localhost
+  export APP_FQDN=vcap.me
   export ROOT_NAMESPACE=cf
   export CF_ADMIN_CERT=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-certificate-data}')
   export CF_ADMIN_KEY=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-key-data}')


### PR DESCRIPTION
Co-authored-by: Dave Walter <walterda@vmware.com>

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
Resolves #387 

## What is this change about?
<!-- _Please describe the change here._ -->
Add replaces serverURL in config.yaml and adds the ability to specify externalPort for api shim outputs.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No.

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@davewalter 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
