### PR TITLE
Rename default admin user to `cf-admin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ kubectl create secret tls \
 ```
 
 **NOTE**: If you choose to generate a self-signed certificate, you will need to
-skip TLS validation when connecting to the your workload.
+skip TLS validation when connecting to the workload.
 
 # Development Workflows
 
@@ -296,6 +296,22 @@ or
 ./scripts/deploy-on-kind --help
 ```
 for usage notes.
+
+### User Permissions Disclaimer
+When using the deploy-on-kind script, you will get a separate `cf-admin` user by default with which to interact with the cf api.
+
+So when prompted to select a user by the cli you may see something like:
+```
+$ cf login
+API endpoint: http://localhost
+Warning: Insecure http API endpoint detected: secure https API endpoints are recommended
+
+1. cf-admin
+2. kind-test
+```
+
+Of these options, `cf-admin` is the user with permissions set up by default. Selecting the other use may allow you to login and
+successfully create resources, but you may notice that the user lacks the permissions to list those resources once created.
 
 ---
 ## Install all dependencies with script

--- a/dependencies/cf-setup.yaml
+++ b/dependencies/cf-setup.yaml
@@ -17,4 +17,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: admin
+  name: cf-admin

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -39,17 +39,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "*********************************************"
-echo "Creating CF Namespace and admin RoleBinding"
-echo "*********************************************"
+echo "************************************************"
+echo "Creating CF Namespace and cf-admin RoleBinding"
+echo "************************************************"
 
 kubectl apply -f "${DEP_DIR}/cf-setup.yaml"
 
-echo "***********************"
-echo "Creating user 'admin'"
-echo "***********************"
+echo "**************************"
+echo "Creating user 'cf-admin'"
+echo "**************************"
 
-"$SCRIPT_DIR/create-new-user.sh" admin
+"$SCRIPT_DIR/create-new-user.sh" cf-admin
 
 echo "*************************"
 echo "Installing Cert Manager"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -22,8 +22,8 @@ else
 
   export API_SERVER_ROOT=http://localhost
   export ROOT_NAMESPACE=cf
-  export CF_ADMIN_CERT=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-certificate-data}')
-  export CF_ADMIN_KEY=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "admin")].user.client-key-data}')
+  export CF_ADMIN_CERT=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "cf-admin")].user.client-certificate-data}')
+  export CF_ADMIN_KEY=$(kubectl config view --raw -o jsonpath='{.users[?(@.name == "cf-admin")].user.client-key-data}')
 
   extra_args+=("--slow-spec-threshold=30s")
 fi


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#607](https://github.com/cloudfoundry/cf-k8s-controllers/issues/607)

## What is this change about?
See #607 

## Does this PR introduce a breaking change?
Not to the api, but potentially to the end to end tests and to scripts that rely on the user's name.

## Acceptance
cc @julian-hj to confirm that the proposed changes maintain the spirit of the chore issue

## Tag your pair, your PM, and/or team
paired w/ @matt-royal 
