### PR TITLE
Added DELETE /v3/service_credential_bindings/:guid

### DIFF
--- a/api/apis/fake/cfservice_binding_repository.go
+++ b/api/apis/fake/cfservice_binding_repository.go
@@ -26,12 +26,12 @@ type CFServiceBindingRepository struct {
 		result1 repositories.ServiceBindingRecord
 		result2 error
 	}
-	DeleteServiceBindingStub        func(context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) error
+	DeleteServiceBindingStub        func(context.Context, authorization.Info, string) error
 	deleteServiceBindingMutex       sync.RWMutex
 	deleteServiceBindingArgsForCall []struct {
 		arg1 context.Context
 		arg2 authorization.Info
-		arg3 repositories.DeleteServiceBindingMessage
+		arg3 string
 	}
 	deleteServiceBindingReturns struct {
 		result1 error
@@ -141,13 +141,13 @@ func (fake *CFServiceBindingRepository) CreateServiceBindingReturnsOnCall(i int,
 	}{result1, result2}
 }
 
-func (fake *CFServiceBindingRepository) DeleteServiceBinding(arg1 context.Context, arg2 authorization.Info, arg3 repositories.DeleteServiceBindingMessage) error {
+func (fake *CFServiceBindingRepository) DeleteServiceBinding(arg1 context.Context, arg2 authorization.Info, arg3 string) error {
 	fake.deleteServiceBindingMutex.Lock()
 	ret, specificReturn := fake.deleteServiceBindingReturnsOnCall[len(fake.deleteServiceBindingArgsForCall)]
 	fake.deleteServiceBindingArgsForCall = append(fake.deleteServiceBindingArgsForCall, struct {
 		arg1 context.Context
 		arg2 authorization.Info
-		arg3 repositories.DeleteServiceBindingMessage
+		arg3 string
 	}{arg1, arg2, arg3})
 	stub := fake.DeleteServiceBindingStub
 	fakeReturns := fake.deleteServiceBindingReturns
@@ -168,13 +168,13 @@ func (fake *CFServiceBindingRepository) DeleteServiceBindingCallCount() int {
 	return len(fake.deleteServiceBindingArgsForCall)
 }
 
-func (fake *CFServiceBindingRepository) DeleteServiceBindingCalls(stub func(context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) error) {
+func (fake *CFServiceBindingRepository) DeleteServiceBindingCalls(stub func(context.Context, authorization.Info, string) error) {
 	fake.deleteServiceBindingMutex.Lock()
 	defer fake.deleteServiceBindingMutex.Unlock()
 	fake.DeleteServiceBindingStub = stub
 }
 
-func (fake *CFServiceBindingRepository) DeleteServiceBindingArgsForCall(i int) (context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) {
+func (fake *CFServiceBindingRepository) DeleteServiceBindingArgsForCall(i int) (context.Context, authorization.Info, string) {
 	fake.deleteServiceBindingMutex.RLock()
 	defer fake.deleteServiceBindingMutex.RUnlock()
 	argsForCall := fake.deleteServiceBindingArgsForCall[i]

--- a/api/apis/fake/cfservice_binding_repository.go
+++ b/api/apis/fake/cfservice_binding_repository.go
@@ -26,6 +26,19 @@ type CFServiceBindingRepository struct {
 		result1 repositories.ServiceBindingRecord
 		result2 error
 	}
+	DeleteServiceBindingStub        func(context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) error
+	deleteServiceBindingMutex       sync.RWMutex
+	deleteServiceBindingArgsForCall []struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.DeleteServiceBindingMessage
+	}
+	deleteServiceBindingReturns struct {
+		result1 error
+	}
+	deleteServiceBindingReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ListServiceBindingsStub        func(context.Context, authorization.Info, repositories.ListServiceBindingsMessage) ([]repositories.ServiceBindingRecord, error)
 	listServiceBindingsMutex       sync.RWMutex
 	listServiceBindingsArgsForCall []struct {
@@ -126,6 +139,69 @@ func (fake *CFServiceBindingRepository) CreateServiceBindingReturnsOnCall(i int,
 		result1 repositories.ServiceBindingRecord
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBinding(arg1 context.Context, arg2 authorization.Info, arg3 repositories.DeleteServiceBindingMessage) error {
+	fake.deleteServiceBindingMutex.Lock()
+	ret, specificReturn := fake.deleteServiceBindingReturnsOnCall[len(fake.deleteServiceBindingArgsForCall)]
+	fake.deleteServiceBindingArgsForCall = append(fake.deleteServiceBindingArgsForCall, struct {
+		arg1 context.Context
+		arg2 authorization.Info
+		arg3 repositories.DeleteServiceBindingMessage
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteServiceBindingStub
+	fakeReturns := fake.deleteServiceBindingReturns
+	fake.recordInvocation("DeleteServiceBinding", []interface{}{arg1, arg2, arg3})
+	fake.deleteServiceBindingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBindingCallCount() int {
+	fake.deleteServiceBindingMutex.RLock()
+	defer fake.deleteServiceBindingMutex.RUnlock()
+	return len(fake.deleteServiceBindingArgsForCall)
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBindingCalls(stub func(context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) error) {
+	fake.deleteServiceBindingMutex.Lock()
+	defer fake.deleteServiceBindingMutex.Unlock()
+	fake.DeleteServiceBindingStub = stub
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBindingArgsForCall(i int) (context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) {
+	fake.deleteServiceBindingMutex.RLock()
+	defer fake.deleteServiceBindingMutex.RUnlock()
+	argsForCall := fake.deleteServiceBindingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBindingReturns(result1 error) {
+	fake.deleteServiceBindingMutex.Lock()
+	defer fake.deleteServiceBindingMutex.Unlock()
+	fake.DeleteServiceBindingStub = nil
+	fake.deleteServiceBindingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CFServiceBindingRepository) DeleteServiceBindingReturnsOnCall(i int, result1 error) {
+	fake.deleteServiceBindingMutex.Lock()
+	defer fake.deleteServiceBindingMutex.Unlock()
+	fake.DeleteServiceBindingStub = nil
+	if fake.deleteServiceBindingReturnsOnCall == nil {
+		fake.deleteServiceBindingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteServiceBindingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *CFServiceBindingRepository) ListServiceBindings(arg1 context.Context, arg2 authorization.Info, arg3 repositories.ListServiceBindingsMessage) ([]repositories.ServiceBindingRecord, error) {
@@ -267,6 +343,8 @@ func (fake *CFServiceBindingRepository) Invocations() map[string][][]interface{}
 	defer fake.invocationsMutex.RUnlock()
 	fake.createServiceBindingMutex.RLock()
 	defer fake.createServiceBindingMutex.RUnlock()
+	fake.deleteServiceBindingMutex.RLock()
+	defer fake.deleteServiceBindingMutex.RUnlock()
 	fake.listServiceBindingsMutex.RLock()
 	defer fake.listServiceBindingsMutex.RUnlock()
 	fake.serviceBindingExistsMutex.RLock()

--- a/api/apis/integration/service_binding_test.go
+++ b/api/apis/integration/service_binding_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ServiceBinding Handler", func() {
 	BeforeEach(func() {
 		appRepo := repositories.NewAppRepo(k8sClient, namespaceRetriever, clientFactory, nsPermissions)
 		serviceInstanceRepo := repositories.NewServiceInstanceRepo(namespaceRetriever, clientFactory, nsPermissions)
-		serviceBindingRepo := repositories.NewServiceBindingRepo(clientFactory, nsPermissions)
+		serviceBindingRepo := repositories.NewServiceBindingRepo(namespaceRetriever, clientFactory, nsPermissions)
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/api/apis/service_binding_handler.go
+++ b/api/apis/service_binding_handler.go
@@ -33,7 +33,7 @@ type ServiceBindingHandler struct {
 //counterfeiter:generate -o fake -fake-name CFServiceBindingRepository . CFServiceBindingRepository
 type CFServiceBindingRepository interface {
 	CreateServiceBinding(context.Context, authorization.Info, repositories.CreateServiceBindingMessage) (repositories.ServiceBindingRecord, error)
-	DeleteServiceBinding(context.Context, authorization.Info, repositories.DeleteServiceBindingMessage) error
+	DeleteServiceBinding(context.Context, authorization.Info, string) error
 	ServiceBindingExists(ctx context.Context, info authorization.Info, spaceGUID, appGUID, serviceInsanceGUID string) (bool, error)
 	ListServiceBindings(context.Context, authorization.Info, repositories.ListServiceBindingsMessage) ([]repositories.ServiceBindingRecord, error)
 }
@@ -103,8 +103,7 @@ func (h *ServiceBindingHandler) deleteHandler(authInfo authorization.Info, w htt
 	vars := mux.Vars(r)
 	serviceBindingGUID := vars["guid"]
 
-	err := h.serviceBindingRepo.DeleteServiceBinding(ctx, authInfo, repositories.DeleteServiceBindingMessage{GUID: serviceBindingGUID})
-
+	err := h.serviceBindingRepo.DeleteServiceBinding(ctx, authInfo, serviceBindingGUID)
 	if err != nil {
 		h.logger.Error(err, "error when deleting service binding", "guid", serviceBindingGUID)
 		handleRepoErrorsOnWrite(h.logger, err, repositories.ServiceBindingResourceType, serviceBindingGUID, w)

--- a/api/apis/service_binding_handler_test.go
+++ b/api/apis/service_binding_handler_test.go
@@ -27,6 +27,7 @@ var _ = Describe("ServiceBindingHandler", func() {
 		serviceInstanceGUID                 = "test-service-instance-guid"
 		spaceGUID                           = "test-space-guid"
 		listServiceBindingsUrl              = "/v3/service_credential_bindings"
+		deleteServiceBindingUrl             = "/v3/service_credential_bindings/test-service-instance-guid"
 	)
 
 	var (
@@ -517,6 +518,23 @@ var _ = Describe("ServiceBindingHandler", func() {
 			It("returns an Unknown key error", func() {
 				expectUnknownKeyError("The query parameter is invalid: Valid parameters are: 'app_guids, service_instance_guids, include, type'")
 			})
+		})
+	})
+
+	Describe("the DELETE /v3/service_credential_bindings/:guid endpoint", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequestWithContext(ctx, "DELETE", deleteServiceBindingUrl, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns a NoContent status", func() {
+			Expect(rr.Code).To(Equal(http.StatusNoContent))
+			Expect(rr.Body.String()).To(ContainSubstring(`{}`))
+		})
+
+		It("invokes DeleteServiceBinding on the repository", func() {
+			Expect(serviceBindingRepo.DeleteServiceBindingCallCount()).To(Equal(1))
 		})
 	})
 })

--- a/api/apis/service_binding_handler_test.go
+++ b/api/apis/service_binding_handler_test.go
@@ -23,11 +23,10 @@ var _ = Describe("ServiceBindingHandler", func() {
 	const (
 		testServiceBindingHandlerLoggerName = "TestServiceBindingHandler"
 		appGUID                             = "test-app-guid"
-		serviceBindingGuid                  = "some-generated-guid"
+		serviceBindingGUID                  = "some-generated-guid"
 		serviceInstanceGUID                 = "test-service-instance-guid"
 		spaceGUID                           = "test-space-guid"
 		listServiceBindingsUrl              = "/v3/service_credential_bindings"
-		deleteServiceBindingUrl             = "/v3/service_credential_bindings/test-service-instance-guid"
 	)
 
 	var (
@@ -355,7 +354,7 @@ var _ = Describe("ServiceBindingHandler", func() {
 	Describe("the GET /v3/service_credential_bindings endpoint", func() {
 		BeforeEach(func() {
 			serviceBindingRepo.ListServiceBindingsReturns([]repositories.ServiceBindingRecord{{
-				GUID:                serviceBindingGuid,
+				GUID:                serviceBindingGUID,
 				Type:                "app",
 				AppGUID:             appGUID,
 				ServiceInstanceGUID: serviceInstanceGUID,
@@ -372,7 +371,7 @@ var _ = Describe("ServiceBindingHandler", func() {
 
 		It("returns the ServiceBindings available to the user", func() {
 			Expect(rr.Code).To(Equal(http.StatusOK))
-			Expect(rr.Body.String()).To(ContainSubstring(serviceBindingGuid))
+			Expect(rr.Body.String()).To(ContainSubstring(serviceBindingGUID))
 		})
 
 		When("no service bindings can be found", func() {
@@ -522,9 +521,11 @@ var _ = Describe("ServiceBindingHandler", func() {
 	})
 
 	Describe("the DELETE /v3/service_credential_bindings/:guid endpoint", func() {
+		const serviceBindingGUID = "test-service-instance-guid"
+
 		BeforeEach(func() {
 			var err error
-			req, err = http.NewRequestWithContext(ctx, "DELETE", deleteServiceBindingUrl, nil)
+			req, err = http.NewRequestWithContext(ctx, "DELETE", "/v3/service_credential_bindings/"+serviceBindingGUID, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -535,6 +536,8 @@ var _ = Describe("ServiceBindingHandler", func() {
 
 		It("invokes DeleteServiceBinding on the repository", func() {
 			Expect(serviceBindingRepo.DeleteServiceBindingCallCount()).To(Equal(1))
+			_, _, guid := serviceBindingRepo.DeleteServiceBindingArgsForCall(0)
+			Expect(guid).To(Equal(serviceBindingGUID))
 		})
 	})
 })

--- a/api/main.go
+++ b/api/main.go
@@ -116,7 +116,7 @@ func main() {
 	buildRepo := repositories.NewBuildRepo(privilegedCRClient, namespaceRetriever, userClientFactory)
 	packageRepo := repositories.NewPackageRepo(privilegedCRClient, namespaceRetriever, userClientFactory)
 	serviceInstanceRepo := repositories.NewServiceInstanceRepo(namespaceRetriever, userClientFactory, nsPermissions)
-	serviceBindingRepo := repositories.NewServiceBindingRepo(userClientFactory, nsPermissions)
+	serviceBindingRepo := repositories.NewServiceBindingRepo(namespaceRetriever, userClientFactory, nsPermissions)
 	buildpackRepo := repositories.NewBuildpackRepository(userClientFactory)
 	roleRepo := repositories.NewRoleRepo(
 		privilegedCRClient,

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -401,7 +401,7 @@ var _ = Describe("AppRepository", func() {
 
 		It("creates a new app CR", func() {
 			createdAppRecord, err := appRepo.CreateApp(testCtx, authInfo, appCreateMessage)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(createdAppRecord).NotTo(BeNil())
 
 			cfAppLookupKey := types.NamespacedName{Name: createdAppRecord.GUID, Namespace: spaceGUID}
@@ -435,7 +435,7 @@ var _ = Describe("AppRepository", func() {
 
 			It("creates an empty secret and sets the environment variable secret ref on the App", func() {
 				createdAppRecord, err := appRepo.CreateApp(testCtx, authInfo, appCreateMessage)
-				Expect(err).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(createdAppRecord).NotTo(BeNil())
 
 				cfAppLookupKey := types.NamespacedName{Name: createdAppRecord.GUID, Namespace: spaceGUID}
@@ -466,7 +466,7 @@ var _ = Describe("AppRepository", func() {
 
 			It("creates an secret for the environment variables and sets the ref on the App", func() {
 				createdAppRecord, err := appRepo.CreateApp(testCtx, authInfo, appCreateMessage)
-				Expect(err).To(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(createdAppRecord).NotTo(BeNil())
 
 				cfAppLookupKey := types.NamespacedName{Name: createdAppRecord.GUID, Namespace: spaceGUID}

--- a/api/repositories/service_binding_repository.go
+++ b/api/repositories/service_binding_repository.go
@@ -114,20 +114,20 @@ func (r *ServiceBindingRepo) CreateServiceBinding(ctx context.Context, authInfo 
 	return cfServiceBindingToRecord(cfServiceBinding), err
 }
 
-func (r *ServiceBindingRepo) DeleteServiceBinding(ctx context.Context, authInfo authorization.Info, message DeleteServiceBindingMessage) error {
+func (r *ServiceBindingRepo) DeleteServiceBinding(ctx context.Context, authInfo authorization.Info, guid string) error {
 	userClient, err := r.userClientFactory.BuildClient(authInfo)
 	if err != nil {
 		return fmt.Errorf("failed to build user client: %w", err)
 	}
 
-	namespace, err := r.namespaceRetriever.NamespaceFor(ctx, message.GUID, ServiceBindingResourceType)
+	namespace, err := r.namespaceRetriever.NamespaceFor(ctx, guid, ServiceBindingResourceType)
 	if err != nil {
 		return NewNotFoundError(ServiceBindingResourceType, err)
 	}
 
 	binding := &servicesv1alpha1.CFServiceBinding{}
 
-	err = userClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: message.GUID}, binding)
+	err = userClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: guid}, binding)
 	if err != nil {
 		if k8serrors.IsForbidden(err) {
 			return NewNotFoundError(ServiceBindingResourceType, err)

--- a/api/repositories/service_binding_repository_test.go
+++ b/api/repositories/service_binding_repository_test.go
@@ -190,8 +190,7 @@ var _ = Describe("ServiceBindingRepo", func() {
 		})
 
 		JustBeforeEach(func() {
-			msg := repositories.DeleteServiceBindingMessage{GUID: serviceBindingGUID}
-			ret = repo.DeleteServiceBinding(testCtx, authInfo, msg)
+			ret = repo.DeleteServiceBinding(testCtx, authInfo, serviceBindingGUID)
 		})
 
 		It("returns a not-found error for users with no role in the space", func() {

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -650,7 +650,8 @@ func listServiceInstances() resourceList {
 	return serviceInstances
 }
 
-func createServiceBinding(appGUID, instanceGUID string) {
+func createServiceBinding(appGUID, instanceGUID string) string {
+	var pkg resource
 	resp, err := adminClient.R().
 		SetBody(typedResource{
 			Type: "app",
@@ -658,10 +659,13 @@ func createServiceBinding(appGUID, instanceGUID string) {
 				Relationships: relationships{"app": {Data: resource{GUID: appGUID}}, "service_instance": {Data: resource{GUID: instanceGUID}}},
 			},
 		}).
+		SetResult(&pkg).
 		Post("/v3/service_credential_bindings")
 
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+
+	return pkg.GUID
 }
 
 func createPackage(appGUID string) string {

--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Service Bindings", func() {
 			httpResp, httpError = certClient.R().Delete("/v3/service_credential_bindings/" + bindingGUID)
 		})
 
-		It("returns a not found error", func() {
+		It("returns a not found error when the user has no role in the space", func() {
 			Expect(httpError).NotTo(HaveOccurred())
 			Expect(httpResp).To(HaveRestyStatusCode(http.StatusNotFound))
 		})

--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -12,38 +12,77 @@ import (
 )
 
 var _ = Describe("Service Bindings", func() {
+	var (
+		appGUID      string
+		orgGUID      string
+		spaceGUID    string
+		bindingGUID  string
+		instanceGUID string
+		httpResp     *resty.Response
+		httpError    error
+	)
+
+	BeforeEach(func() {
+		orgGUID = createOrg(generateGUID("org"))
+		time.Sleep(time.Second) // this appears to reduce flakes, but should be removed once we have better logic to determine org/space readiness
+		spaceGUID = createSpace(generateGUID("space1"), orgGUID)
+		time.Sleep(time.Second)
+		createOrgRole("organization_user", rbacv1.UserKind, certUserName, orgGUID)
+		instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"))
+		appGUID = createApp(spaceGUID, generateGUID("app"))
+		bindingGUID = createServiceBinding(appGUID, instanceGUID)
+	})
+
+	AfterEach(func() {
+		deleteOrg(orgGUID)
+	})
+
+	Describe("Delete", func() {
+		JustBeforeEach(func() {
+			httpResp, httpError = certClient.R().Delete("/v3/service_credential_bindings/" + bindingGUID)
+		})
+
+		It("returns a not found error", func() {
+			Expect(httpError).NotTo(HaveOccurred())
+			Expect(httpResp).To(HaveRestyStatusCode(http.StatusNotFound))
+		})
+
+		When("the user has space manager role", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_manager", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("returns a forbidden error", func() {
+				Expect(httpError).NotTo(HaveOccurred())
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusForbidden))
+			})
+		})
+
+		When("the user has space developer role", func() {
+			BeforeEach(func() {
+				createSpaceRole("space_developer", rbacv1.UserKind, certUserName, spaceGUID)
+			})
+
+			It("succeeds", func() {
+				Expect(httpError).NotTo(HaveOccurred())
+				Expect(httpResp).To(HaveRestyStatusCode(http.StatusNoContent))
+			})
+		})
+	})
+
 	Describe("List", func() {
 		var (
-			appGUID      string
-			orgGUID      string
-			spaceGUID    string
-			instanceGUID string
-			httpResp     *resty.Response
-			httpError    error
-			queryString  string
-			result       resourceListWithInclusion
+			queryString string
+			result      resourceListWithInclusion
 		)
 
 		BeforeEach(func() {
-			orgGUID = createOrg(generateGUID("org"))
-			time.Sleep(time.Second) // this appears to reduce flakes, but should be removed once we have better logic to determine org/space readiness
-			spaceGUID = createSpace(generateGUID("space1"), orgGUID)
-			time.Sleep(time.Second)
-			createOrgRole("organization_user", rbacv1.UserKind, certUserName, orgGUID)
-			instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"))
-			appGUID = createApp(spaceGUID, generateGUID("app"))
-			createServiceBinding(appGUID, instanceGUID)
-
 			queryString = ""
 			result = resourceListWithInclusion{}
 		})
 
 		JustBeforeEach(func() {
 			httpResp, httpError = certClient.R().SetResult(&result).Get("/v3/service_credential_bindings" + queryString)
-		})
-
-		AfterEach(func() {
-			deleteOrg(orgGUID)
 		})
 
 		It("Returns an empty list", func() {

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -70,8 +70,10 @@ rules:
   resources:
     - cfservicebindings
   verbs:
+    - get
     - list
     - create
+    - delete
 
 - apiGroups:
   - networking.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -70,8 +70,10 @@ rules:
   resources:
     - cfservicebindings
   verbs:
+    - get
     - list
     - create
+    - delete
 
 - apiGroups:
   - networking.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_manager.yaml
+++ b/controllers/config/cf_roles/cf_space_manager.yaml
@@ -46,4 +46,5 @@ rules:
   resources:
     - cfservicebindings
   verbs:
+    - get
     - list

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1665,8 +1665,10 @@ rules:
   resources:
   - cfservicebindings
   verbs:
+  - get
   - list
   - create
+  - delete
 - apiGroups:
   - networking.cloudfoundry.org
   resources:
@@ -2180,8 +2182,10 @@ rules:
   resources:
   - cfservicebindings
   verbs:
+  - get
   - list
   - create
+  - delete
 - apiGroups:
   - networking.cloudfoundry.org
   resources:
@@ -2241,6 +2245,7 @@ rules:
   resources:
   - cfservicebindings
   verbs:
+  - get
   - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/api.md
+++ b/docs/api.md
@@ -418,6 +418,29 @@ curl "https://localhost:9000/v3/service_instances" \
 `names` and `space_guids` and ordering by `name`, `created_at` or `updated_at`.
 The `fields` and `per_page` parameters will be silently ignored.
 
+### Service Credential Bindings
+
+Docs: https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#service-credential-binding
+
+| Resource                          | Endpoint                                     |
+|-----------------------------------|----------------------------------------------|
+| List Service Credential Binding   | GET /v3/service_credential_bindings          |
+| Create Service Credential Binding | POST /v3/service_credential_bindings         |
+| Delete Service Credential Binding | DELETE /v3/service_credential_bindings/:guid |
+
+#### [List Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#list-service-credential-bindings)
+
+**Query Parameters:** Currently supports filtering by `service_instance_guids`, `app_guids`, and `type`. `include` is
+supported, but only for the value `app`.
+
+#### [Create Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#create-a-service-credential-binding)
+
+The only supported value for the `type` is `app`. 
+
+#### [Delete Service Credential Binding](https://v3-apidocs.cloudfoundry.org/version/3.115.0/index.html#delete-a-service-credential-binding)
+
+This endpoint is fully supported.
+
 ### User Identity
 
 _This is not part of the published CF API, and is not supported on CF on VMs._


### PR DESCRIPTION
This is a draft PR--we still need to update the API docs to add the totally missing service_credential_bindings endpoint
## Is there a related GitHub Issue?
[#718]

## What is this change about?
Adds DELETE handling for service bindings

## Does this PR introduce a breaking change?
no

## Acceptance Steps
#718 

## Tag your pair, your PM, and/or team
@clintyoshimura 
