### PR TITLE
Make scripts work with the default OSX openssl

### DIFF
--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -17,7 +17,11 @@ csr_file="$(mktemp)"
 cert_file="$(mktemp)"
 csr_name="$(echo ${RANDOM} | shasum | head -c 40)"
 
-openssl req -new -newkey rsa:4096 -keyout "${priv_key_file}" -nodes -out "${csr_file}" -subj "/CN=${username}"
+openssl req -new -newkey rsa:4096 \
+  -keyout "${priv_key_file}" \
+  -out "${csr_file}" \
+  -nodes \
+  -subj "/CN=${username}"
 
 cat <<EOF | kubectl create -f -
 apiVersion: certificates.k8s.io/v1

--- a/scripts/generate-eirini-certs-secret.sh
+++ b/scripts/generate-eirini-certs-secret.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-echo "Will now generate tls.ca tls.crt and tls.key files"
+set -euo pipefail
+
+echo "Will now generate tls.ca tls.crt and tls.key files..."
 
 keys="$(mktemp -d)"
 trap 'rm -rf "${keys}"' EXIT
@@ -8,22 +10,38 @@ trap 'rm -rf "${keys}"' EXIT
 readonly EIRINI_NAMESPACE=eirini-controller
 otherDNS="$1"
 
-pushd "${keys}"
-{
-  kubectl create namespace "${EIRINI_NAMESPACE}" || true
+kubectl create namespace "${EIRINI_NAMESPACE}" || true
 
-  openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -addext "subjectAltName = DNS:${otherDNS}, DNS:${otherDNS}.cluster.local" -days 365 ||
-    openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -nodes -subj '/CN=localhost' -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${otherDNS}, DNS:${otherDNS}.cluster.local'")) -days 365
+if [[ "$(openssl version | awk '{ print $1 }')" == "OpenSSL" ]]; then
+  openssl req -x509 -newkey rsa:4096 \
+    -keyout "${keys}/tls.key" \
+    -out "${keys}/tls.crt" \
+    -nodes \
+    -subj '/CN=localhost' \
+    -addext "subjectAltName = DNS:${otherDNS}, DNS:${otherDNS}.cluster.local" \
+    -days 365
+else
+  openssl req -x509 -newkey rsa:4096 \
+    -keyout "${keys}/tls.key" \
+    -out "${keys}/tls.crt" \
+    -nodes \
+    -subj '/CN=localhost' \
+    -extensions SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[ SAN ]\nsubjectAltName='DNS:${otherDNS}, DNS:${otherDNS}.cluster.local'")) \
+    -days 365
+fi
 
-  for secret_name in eirini-webhooks-certs; do
-    if kubectl -n "${EIRINI_NAMESPACE}" get secret "${secret_name}" >/dev/null 2>&1; then
-      kubectl delete secret -n "${EIRINI_NAMESPACE}" "${secret_name}"
-    fi
+for secret_name in eirini-webhooks-certs; do
+  if kubectl -n "${EIRINI_NAMESPACE}" get secret "${secret_name}" >/dev/null 2>&1; then
+    kubectl delete secret "${secret_name}" \
+      -n "${EIRINI_NAMESPACE}"
+  fi
 
-    echo "Creating the ${secret_name} secret in your kubernetes cluster..."
-    kubectl create secret -n "${EIRINI_NAMESPACE}" generic "${secret_name}" --from-file=tls.crt=./tls.crt --from-file=tls.ca=./tls.crt --from-file=tls.key=./tls.key
-  done
+  echo "Creating the ${secret_name} secret in your kubernetes cluster..."
+  kubectl create secret generic "${secret_name}" \
+    -n "${EIRINI_NAMESPACE}" \
+    --from-file=tls.crt="${keys}/tls.crt" \
+    --from-file=tls.ca="${keys}/tls.crt" \
+    --from-file=tls.key="${keys}/tls.key"
+done
 
-  echo "Done!"
-}
-popd
+echo "Done!"


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
We recently introduced more `openssl` commands into our scripts, but they only work on Linux, or if you have installed the `openssl@3` brew recipe on OSX. This PR introduces a check to see which version of `openssl` is available and adds alternative commands that are compatible with the default OSX version.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Make sure that the scripts work with both versions of `openssl` on OSX, and still work on Linux.

## Tag your pair, your PM, and/or team
@clintyoshimura 