### PR TITLE
Change gh chore template id

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -11,7 +11,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: action
+    id: action-to-take
     attributes:
       label: Action to take
       description: This section is optional, but if it is clear what steps should be taken, we should note them. For example, if there is already an agreed upon solution or next step(s).


### PR DESCRIPTION
## What is this change about?
Change template textarea id to `action-to-take`. There is a bug in GitHub's implementation of their templates, which will fill in the textarea with `new` if the id is `action`.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Not much to accept - it's an issue template change.

## Tag your pair, your PM, and/or team
@davewalter 
