### PR TITLE
[DRAFT] Remove sleeps from e2e and smoke tests

### DIFF
--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -1,14 +1,12 @@
 package e2e_test
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"net/http"
 )
 
 var _ = Describe("Service Bindings", func() {
@@ -24,9 +22,7 @@ var _ = Describe("Service Bindings", func() {
 
 	BeforeEach(func() {
 		orgGUID = createOrg(generateGUID("org"))
-		time.Sleep(time.Second) // this appears to reduce flakes, but should be removed once we have better logic to determine org/space readiness
 		spaceGUID = createSpace(generateGUID("space1"), orgGUID)
-		time.Sleep(time.Second)
 		createOrgRole("organization_user", rbacv1.UserKind, certUserName, orgGUID)
 		instanceGUID = createServiceInstance(spaceGUID, generateGUID("service-instance"))
 		appGUID = createApp(spaceGUID, generateGUID("app"))

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -74,7 +74,6 @@ var _ = Describe("Smoke Tests", func() {
 			spaceName := generator.PrefixedRandomName(NamePrefix, "space")
 
 			Eventually(cf.Cf("create-org", orgName)).Should(Exit(0))
-			time.Sleep(2 * time.Second) // TODO this stinks
 			Eventually(cf.Cf("create-space", "-o", orgName, spaceName)).Should(Exit(0))
 			Eventually(cf.Cf("target", "-o", orgName, "-s", spaceName)).Should(Exit(0))
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
no
## What is this change about?
- We had delays built into some tests to wait for HNC role propagation
- These delays are theoretically no longer necessary because the API shim waits for permissions to appear before sending the HTTP response

We've run this PR through CI a couple of times with no failures, so we think the change set doesn't introduce new flakiness.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
e2e tests should pass

## Tag your pair, your PM, and/or team
@akrishna90 

