### PR TITLE
Common error handling in api handlers

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,6 +11,7 @@ COPY controllers/apis controllers/apis/
 COPY controllers/webhooks controllers/webhooks/
 COPY api/actions api/actions/
 COPY api/apis api/apis/
+COPY api/apierrors api/apierrors
 COPY api/authorization api/authorization/
 COPY api/payloads api/payloads/
 COPY api/presenter api/presenter/

--- a/api/apierrors/errors.go
+++ b/api/apierrors/errors.go
@@ -1,0 +1,229 @@
+package apierrors
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type ApiError interface {
+	Detail() string
+	Title() string
+	Code() int
+	HttpStatus() int
+	Unwrap() error
+}
+
+type apiError struct {
+	cause      error
+	detail     string
+	title      string
+	code       int
+	httpStatus int
+}
+
+func (e apiError) Error() string {
+	return e.cause.Error()
+}
+
+func (e apiError) Unwrap() error {
+	return e.cause
+}
+
+func (e apiError) Detail() string {
+	return e.detail
+}
+
+func (e apiError) Title() string {
+	return e.title
+}
+
+func (e apiError) Code() int {
+	return e.code
+}
+
+func (e apiError) HttpStatus() int {
+	return e.httpStatus
+}
+
+type UnprocessableEntityError struct {
+	apiError
+}
+
+func NewUnprocessableEntityError(cause error, detail string) UnprocessableEntityError {
+	return UnprocessableEntityError{
+		apiError{
+			cause:      cause,
+			title:      "CF-UnprocessableEntity",
+			detail:     detail,
+			code:       10008,
+			httpStatus: http.StatusUnprocessableEntity,
+		},
+	}
+}
+
+type MessageParseError struct {
+	apiError
+}
+
+func NewMessageParseError(cause error) MessageParseError {
+	return MessageParseError{
+		apiError{
+			cause:      cause,
+			title:      "CF-MessageParseError",
+			detail:     "Request invalid due to parse error: invalid request body",
+			code:       1001,
+			httpStatus: http.StatusBadRequest,
+		},
+	}
+}
+
+type UnknownError struct {
+	apiError
+}
+
+func NewUnknownError(cause error) UnknownError {
+	return UnknownError{
+		apiError{
+			cause:      cause,
+			title:      "UnknownError",
+			detail:     "An unknown error occurred.",
+			code:       10001,
+			httpStatus: http.StatusInternalServerError,
+		},
+	}
+}
+
+type NotFoundError struct {
+	apiError
+}
+
+func NewNotFoundError(cause error, resourceType string) NotFoundError {
+	return NotFoundError{
+		apiError{
+			cause:      cause,
+			title:      "CF-ResourceNotFound",
+			detail:     fmt.Sprintf("%s not found. Ensure it exists and you have access to it.", resourceType),
+			code:       10010,
+			httpStatus: http.StatusNotFound,
+		},
+	}
+}
+
+type InvalidAuthError struct {
+	apiError
+}
+
+func NewInvalidAuthError(cause error) InvalidAuthError {
+	return InvalidAuthError{
+		apiError{
+			cause:      cause,
+			title:      "CF-InvalidAuthToken",
+			detail:     "Invalid Auth Token",
+			code:       1000,
+			httpStatus: http.StatusUnauthorized,
+		},
+	}
+}
+
+type NotAuthenticatedError struct {
+	apiError
+}
+
+func NewNotAuthenticatedError(cause error) NotAuthenticatedError {
+	return NotAuthenticatedError{
+		apiError{
+			cause:      cause,
+			title:      "CF-NotAuthenticated",
+			detail:     "Authentication error",
+			code:       10002,
+			httpStatus: http.StatusUnauthorized,
+		},
+	}
+}
+
+type ForbiddenError struct {
+	apiError
+	resourceType string
+}
+
+func (e ForbiddenError) ResourceType() string {
+	return e.resourceType
+}
+
+func NewForbiddenError(cause error, resourceType string) ForbiddenError {
+	return ForbiddenError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-NotAuthorized",
+			detail:     "You are not authorized to perform the requested action",
+			code:       10003,
+			httpStatus: http.StatusForbidden,
+		},
+		resourceType: resourceType,
+	}
+}
+
+type UnknownKeyError struct {
+	apiError
+}
+
+func NewUnknownKeyError(cause error, validKeys []string) UnknownKeyError {
+	return UnknownKeyError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-BadQueryParameter",
+			detail:     fmt.Sprintf("The query parameter is invalid: Valid parameters are: '%s'", strings.Join(validKeys, ", ")),
+			code:       10005,
+			httpStatus: http.StatusBadRequest,
+		},
+	}
+}
+
+type UniquenessError struct {
+	apiError
+}
+
+func NewUniquenessError(cause error, detail string) UniquenessError {
+	return UniquenessError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-UniquenessError",
+			detail:     detail,
+			code:       10016,
+			httpStatus: http.StatusUnprocessableEntity,
+		},
+	}
+}
+
+type InvalidRequestError struct {
+	apiError
+}
+
+func NewInvalidRequestError(cause error, detail string) InvalidRequestError {
+	return InvalidRequestError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-InvalidRequest",
+			detail:     detail,
+			code:       10004,
+			httpStatus: http.StatusBadRequest,
+		},
+	}
+}
+
+type PackageBitsAlreadyUploadedError struct {
+	apiError
+}
+
+func NewPackageBitsAlreadyUploadedError(cause error) PackageBitsAlreadyUploadedError {
+	return PackageBitsAlreadyUploadedError{
+		apiError: apiError{
+			cause:      cause,
+			title:      "CF-PackageBitsAlreadyUploaded",
+			detail:     "Bits may be uploaded only once. Create a new package to upload different bits.",
+			code:       150004,
+			httpStatus: http.StatusBadRequest,
+		},
+	}
+}

--- a/api/apis/apis_suite_test.go
+++ b/api/apis/apis_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
+	"github.com/go-http-utils/headers"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	. "github.com/onsi/ginkgo/v2"
@@ -83,7 +84,7 @@ func expectNotAuthorizedError() {
 
 func expectNotFoundError(detail string) {
 	ExpectWithOffset(1, rr).To(HaveHTTPStatus(http.StatusNotFound))
-	ExpectWithOffset(1, rr).To(HaveHTTPHeaderWithValue("Content-Type", jsonHeader))
+	ExpectWithOffset(1, rr).To(HaveHTTPHeaderWithValue(headers.ContentType, jsonHeader))
 	var bodyJSON map[string]interface{}
 	Expect(json.Unmarshal(rr.Body.Bytes(), &bodyJSON)).To(Succeed())
 	Expect(bodyJSON).To(HaveKey("errors"))

--- a/api/apis/auth_aware_handler.go
+++ b/api/apis/auth_aware_handler.go
@@ -1,16 +1,44 @@
 package apis
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"github.com/go-http-utils/headers"
 	"github.com/go-logr/logr"
 )
 
+// TODO: Maybe move to its own package so that users cannot access HandlerResponse.writeTo()
+type HandlerResponse struct {
+	httpStatus int
+	body       interface{}
+	headers    map[string]string
+}
+
+func NewHandlerResponse(httpStatus int) *HandlerResponse {
+	return &HandlerResponse{
+		httpStatus: httpStatus,
+		headers:    map[string]string{},
+	}
+}
+
+func (r *HandlerResponse) WithHeader(key, value string) *HandlerResponse {
+	r.headers[key] = value
+	return r
+}
+
+func (r *HandlerResponse) WithBody(body interface{}) *HandlerResponse {
+	r.body = body
+	return r
+}
+
 //counterfeiter:generate -o fake -fake-name AuthAwareHandlerFunc . AuthAwareHandlerFunc
 
-type AuthAwareHandlerFunc func(authInfo authorization.Info, w http.ResponseWriter, r *http.Request)
+type AuthAwareHandlerFunc func(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error)
 
 type AuthAwareHandlerFuncWrapper struct {
 	logger logr.Logger
@@ -25,11 +53,59 @@ func (wrapper *AuthAwareHandlerFuncWrapper) Wrap(delegate AuthAwareHandlerFunc) 
 		authInfo, ok := authorization.InfoFromContext(r.Context())
 		if !ok {
 			wrapper.logger.Error(nil, "unable to get auth info")
-			w.Header().Add(headers.ContentType, "application/json")
-			writeUnknownErrorResponse(w)
+			presentError(w, nil)
 			return
 		}
 
-		delegate(authInfo, w, r)
+		handlerResponse, err := delegate(authInfo, r)
+		if err != nil {
+			wrapper.logger.Info("handler returned error", "error", err)
+			presentError(w, err)
+			return
+		}
+
+		handlerResponse.writeTo(w)
+	}
+}
+
+func presentError(w http.ResponseWriter, err error) {
+	var apiError apierrors.ApiError
+	if errors.As(err, &apiError) {
+		NewHandlerResponse(apiError.HttpStatus()).
+			WithBody(presenter.ErrorsResponse{
+				Errors: []presenter.PresentedError{
+					{
+						Detail: apiError.Detail(),
+						Title:  apiError.Title(),
+						Code:   apiError.Code(),
+					},
+				},
+			}).
+			writeTo(w)
+		return
+	}
+
+	presentError(w, apierrors.NewUnknownError(err))
+}
+
+func (response *HandlerResponse) writeTo(w http.ResponseWriter) {
+	for k, v := range response.headers {
+		w.Header().Set(k, v)
+	}
+
+	if response.body == nil {
+		w.WriteHeader(response.httpStatus)
+		return
+	}
+
+	w.Header().Set(headers.ContentType, "application/json")
+	w.WriteHeader(response.httpStatus)
+
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(response.body)
+	if err != nil {
+		Logger.Error(err, "failed to encode and write response")
 	}
 }

--- a/api/apis/auth_aware_handler_test.go
+++ b/api/apis/auth_aware_handler_test.go
@@ -2,8 +2,10 @@ package apis_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
@@ -17,13 +19,14 @@ var _ = Describe("AuthAwareHandlerFuncWrapper", func() {
 	var (
 		delegate    *fake.AuthAwareHandlerFunc
 		wrappedFunc http.HandlerFunc
+		response    *apis.HandlerResponse
 	)
 
 	BeforeEach(func() {
+		response = apis.NewHandlerResponse(http.StatusTeapot)
 		delegate = new(fake.AuthAwareHandlerFunc)
-		delegate.Stub = func(_ authorization.Info, w http.ResponseWriter, _ *http.Request) {
-			w.Header().Add(headers.ContentType, "application/json")
-			w.WriteHeader(http.StatusTeapot)
+		delegate.Stub = func(_ authorization.Info, _ *http.Request) (*apis.HandlerResponse, error) {
+			return response, nil
 		}
 		wrapper := apis.NewAuthAwareHandlerFuncWrapper(logf.Log.WithName("test"))
 		wrappedFunc = wrapper.Wrap(delegate.Spy)
@@ -37,13 +40,17 @@ var _ = Describe("AuthAwareHandlerFuncWrapper", func() {
 
 	It("passes the authorization.Info from the context to the auth aware delegate", func() {
 		Expect(delegate.CallCount()).To(Equal(1))
-		actualAuthInfo, _, actualReq := delegate.ArgsForCall(0)
+		actualAuthInfo, actualReq := delegate.ArgsForCall(0)
 		Expect(actualAuthInfo).To(Equal(authInfo))
 		Expect(actualReq.URL.Path).To(Equal("/foo"))
 	})
 
 	It("returns whatever the delegate returns", func() {
 		Expect(rr).To(HaveHTTPStatus(http.StatusTeapot))
+	})
+
+	It("does not set content type header on the response", func() {
+		Expect(rr.Header()).NotTo(HaveKey(headers.ContentType))
 	})
 
 	When("the authorization.Info object is not available in the context", func() {
@@ -57,6 +64,56 @@ var _ = Describe("AuthAwareHandlerFuncWrapper", func() {
 
 		It("does not call the delegate", func() {
 			Expect(delegate.CallCount()).To(BeZero())
+		})
+	})
+
+	When("the response body is not nil", func() {
+		BeforeEach(func() {
+			response = response.WithBody("some-response-content")
+		})
+
+		It("sets the application/json content type in the response", func() {
+			Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, "application/json"))
+		})
+
+		It("sets the body into the response", func() {
+			Expect(rr).To(HaveHTTPBody(ContainSubstring("some-response-content")))
+		})
+	})
+
+	When("the response sets header values", func() {
+		BeforeEach(func() {
+			response = response.WithHeader(headers.Location, "/home")
+			response = response.WithHeader(headers.Link, "link")
+		})
+
+		It("sets the header on the response", func() {
+			Expect(rr).To(HaveHTTPHeaderWithValue(headers.Location, "/home"))
+			Expect(rr).To(HaveHTTPHeaderWithValue(headers.Link, "link"))
+		})
+	})
+
+	When("the delegate returns an unknown error", func() {
+		BeforeEach(func() {
+			delegate.Stub = func(_ authorization.Info, _ *http.Request) (*apis.HandlerResponse, error) {
+				return nil, errors.New("delegateErr")
+			}
+		})
+
+		It("returns an unknown error response", func() {
+			expectUnknownError()
+		})
+	})
+
+	When("the delegate returns an api error", func() {
+		BeforeEach(func() {
+			delegate.Stub = func(_ authorization.Info, _ *http.Request) (*apis.HandlerResponse, error) {
+				return nil, apierrors.NewUnprocessableEntityError(errors.New("foo"), "bar")
+			}
+		})
+
+		It("presents the error", func() {
+			expectUnprocessableEntityError("bar")
 		})
 	})
 })

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 
@@ -50,30 +51,24 @@ func NewBuildHandler(
 	}
 }
 
-func (h *BuildHandler) buildGetHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {
+func (h *BuildHandler) buildGetHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	ctx := r.Context()
-	w.Header().Set("Content-Type", "application/json")
 
 	vars := mux.Vars(r)
 	buildGUID := vars["guid"]
 
 	build, err := h.buildRepo.GetBuild(ctx, authInfo, buildGUID)
 	if err != nil {
-		handleRepoErrors(h.logger, err, "build", buildGUID, w)
-		return
+		return nil, handleRepoErrors(h.logger, err, repositories.BuildResourceType, buildGUID)
 	}
 
-	writeResponse(w, http.StatusOK, presenter.ForBuild(build, h.serverURL))
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForBuild(build, h.serverURL)), nil
 }
 
-func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
+func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	var payload payloads.BuildCreate
-	rme := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload)
-	if rme != nil {
-		writeRequestMalformedErrorResponse(w, rme)
-		return
+	if err := h.decoderValidator.DecodeAndValidateJSONPayload(r, &payload); err != nil {
+		return nil, err
 	}
 
 	packageRecord, err := h.packageRepo.GetPackage(r.Context(), authInfo, payload.Package.GUID)
@@ -81,15 +76,14 @@ func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, w http.Re
 		switch err.(type) {
 		case repositories.ForbiddenError:
 			h.logger.Info("Package forbidden", "Package GUID", payload.Package.GUID)
-			writeUnprocessableEntityError(w, "Unable to use package. Ensure that the package exists and you have access to it.")
+			return nil, apierrors.NewUnprocessableEntityError(err, "Unable to use package. Ensure that the package exists and you have access to it.")
 		case repositories.NotFoundError:
 			h.logger.Info("Package not found", "Package GUID", payload.Package.GUID)
-			writeUnprocessableEntityError(w, "Unable to use package. Ensure that the package exists and you have access to it.")
+			return nil, apierrors.NewUnprocessableEntityError(err, "Unable to use package. Ensure that the package exists and you have access to it.")
 		default:
 			h.logger.Info("Error finding Package", "Package GUID", payload.Package.GUID)
-			writeUnknownErrorResponse(w)
+			return nil, err
 		}
-		return
 	}
 
 	buildCreateMessage := payload.ToMessage(packageRecord)
@@ -99,15 +93,14 @@ func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, w http.Re
 		switch err.(type) {
 		case repositories.ForbiddenError:
 			h.logger.Info("Create build is forbidden to user")
-			writeNotAuthorizedErrorResponse(w)
+			return nil, apierrors.NewForbiddenError(err, repositories.BuildResourceType)
 		default:
 			h.logger.Info("Error creating build with repository", "error", err.Error())
-			writeUnknownErrorResponse(w)
+			return nil, err
 		}
-		return
 	}
 
-	writeResponse(w, http.StatusCreated, presenter.ForBuild(record, h.serverURL))
+	return NewHandlerResponse(http.StatusCreated).WithBody(presenter.ForBuild(record, h.serverURL)), nil
 }
 
 func (h *BuildHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -41,20 +41,18 @@ func NewDropletHandler(
 	}
 }
 
-func (h *DropletHandler) dropletGetHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {
+func (h *DropletHandler) dropletGetHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	ctx := r.Context()
-	w.Header().Set("Content-Type", "application/json")
 
 	vars := mux.Vars(r)
 	dropletGUID := vars["guid"]
 
 	droplet, err := h.dropletRepo.GetDroplet(ctx, authInfo, dropletGUID)
 	if err != nil {
-		handleRepoErrors(h.logger, err, "droplet", dropletGUID, w)
-		return
+		return nil, handleRepoErrors(h.logger, err, repositories.DropletResourceType, dropletGUID)
 	}
 
-	writeResponse(w, http.StatusOK, presenter.ForDroplet(droplet, h.serverURL))
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForDroplet(droplet, h.serverURL)), nil
 }
 
 func (h *DropletHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/fake/auth_aware_handler_func.go
+++ b/api/apis/fake/auth_aware_handler_func.go
@@ -10,30 +10,42 @@ import (
 )
 
 type AuthAwareHandlerFunc struct {
-	Stub        func(authorization.Info, http.ResponseWriter, *http.Request)
+	Stub        func(authorization.Info, *http.Request) (*apis.HandlerResponse, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 authorization.Info
-		arg2 http.ResponseWriter
-		arg3 *http.Request
+		arg2 *http.Request
+	}
+	returns struct {
+		result1 *apis.HandlerResponse
+		result2 error
+	}
+	returnsOnCall map[int]struct {
+		result1 *apis.HandlerResponse
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *AuthAwareHandlerFunc) Spy(arg1 authorization.Info, arg2 http.ResponseWriter, arg3 *http.Request) {
+func (fake *AuthAwareHandlerFunc) Spy(arg1 authorization.Info, arg2 *http.Request) (*apis.HandlerResponse, error) {
 	fake.mutex.Lock()
+	ret, specificReturn := fake.returnsOnCall[len(fake.argsForCall)]
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 authorization.Info
-		arg2 http.ResponseWriter
-		arg3 *http.Request
-	}{arg1, arg2, arg3})
+		arg2 *http.Request
+	}{arg1, arg2})
 	stub := fake.Stub
-	fake.recordInvocation("AuthAwareHandlerFunc", []interface{}{arg1, arg2, arg3})
+	returns := fake.returns
+	fake.recordInvocation("AuthAwareHandlerFunc", []interface{}{arg1, arg2})
 	fake.mutex.Unlock()
 	if stub != nil {
-		fake.Stub(arg1, arg2, arg3)
+		return stub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return returns.result1, returns.result2
 }
 
 func (fake *AuthAwareHandlerFunc) CallCount() int {
@@ -42,16 +54,42 @@ func (fake *AuthAwareHandlerFunc) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *AuthAwareHandlerFunc) Calls(stub func(authorization.Info, http.ResponseWriter, *http.Request)) {
+func (fake *AuthAwareHandlerFunc) Calls(stub func(authorization.Info, *http.Request) (*apis.HandlerResponse, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *AuthAwareHandlerFunc) ArgsForCall(i int) (authorization.Info, http.ResponseWriter, *http.Request) {
+func (fake *AuthAwareHandlerFunc) ArgsForCall(i int) (authorization.Info, *http.Request) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
-	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3
+	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2
+}
+
+func (fake *AuthAwareHandlerFunc) Returns(result1 *apis.HandlerResponse, result2 error) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
+	fake.Stub = nil
+	fake.returns = struct {
+		result1 *apis.HandlerResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *AuthAwareHandlerFunc) ReturnsOnCall(i int, result1 *apis.HandlerResponse, result2 error) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
+	fake.Stub = nil
+	if fake.returnsOnCall == nil {
+		fake.returnsOnCall = make(map[int]struct {
+			result1 *apis.HandlerResponse
+			result2 error
+		})
+	}
+	fake.returnsOnCall[i] = struct {
+		result1 *apis.HandlerResponse
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *AuthAwareHandlerFunc) Invocations() map[string][][]interface{} {

--- a/api/apis/job_handler.go
+++ b/api/apis/job_handler.go
@@ -1,10 +1,13 @@
 package apis
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
+	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
 	"github.com/go-logr/logr"
@@ -20,6 +23,8 @@ const (
 	spaceDeletePrefix = "space.delete"
 )
 
+const JobResourceType = "Job"
+
 type JobHandler struct {
 	logger    logr.Logger
 	serverURL url.URL
@@ -32,9 +37,7 @@ func NewJobHandler(logger logr.Logger, serverURL url.URL) *JobHandler {
 	}
 }
 
-func (h *JobHandler) jobGetHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
+func (h *JobHandler) jobGetHandler(_ authorization.Info, r *http.Request) (*HandlerResponse, error) {
 	vars := mux.Vars(r)
 	jobGUID := vars["guid"]
 
@@ -42,8 +45,7 @@ func (h *JobHandler) jobGetHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !match {
 		h.logger.Info("Invalid Job GUID")
-		writeNotFoundErrorResponse(w, "Job")
-		return
+		return nil, apierrors.NewNotFoundError(fmt.Errorf("invalid job guid: %s", jobGUID), JobResourceType)
 	}
 
 	var jobResponse presenter.JobResponse
@@ -55,15 +57,15 @@ func (h *JobHandler) jobGetHandler(w http.ResponseWriter, r *http.Request) {
 		jobResponse = presenter.ForDeleteJob(jobGUID, jobType, h.serverURL)
 	default:
 		h.logger.Info("Invalid Job type: %s", jobType)
-		writeNotFoundErrorResponse(w, "Job")
-		return
+		return nil, apierrors.NewNotFoundError(fmt.Errorf("invalid job type: %s", jobType), JobResourceType)
 	}
 
-	writeResponse(w, http.StatusOK, jobResponse)
+	return NewHandlerResponse(http.StatusOK).WithBody(jobResponse), nil
 }
 
 func (h *JobHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(JobGetEndpoint).Methods("GET").HandlerFunc(h.jobGetHandler)
+	w := NewAuthAwareHandlerFuncWrapper(h.logger)
+	router.Path(JobGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.jobGetHandler))
 }
 
 func parseJobGUID(jobGUID string) (string, string, bool) {

--- a/api/apis/job_handler_test.go
+++ b/api/apis/job_handler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 
+	"github.com/go-http-utils/headers"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,21 +18,23 @@ var _ = Describe("JobHandler", func() {
 		var (
 			resourceGUID string
 			jobGUID      string
+			req          *http.Request
 		)
 
 		BeforeEach(func() {
 			resourceGUID = uuid.NewString()
-		})
-
-		JustBeforeEach(func() {
 			jobsHandler := apis.NewJobHandler(
-				logf.Log.WithName("TestRootHandler"),
+				logf.Log.WithName("TestJobsHandler"),
 				*serverURL,
 			)
 			jobsHandler.RegisterRoutes(router)
+		})
 
-			req, err := http.NewRequest("GET", "/v3/jobs/"+jobGUID, nil)
+		JustBeforeEach(func() {
+			var err error
+			req, err = http.NewRequestWithContext(ctx, "GET", "/v3/jobs/"+jobGUID, nil)
 			Expect(err).NotTo(HaveOccurred())
+
 			router.ServeHTTP(rr, req)
 		})
 
@@ -41,20 +44,16 @@ var _ = Describe("JobHandler", func() {
 			})
 
 			It("returns status 200 OK", func() {
-				Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+				Expect(rr.Code).To(Equal(http.StatusOK))
 			})
 
 			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+				Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, jsonHeader))
 			})
 
 			When("the existing job operation is space.apply-manifest", func() {
-				BeforeEach(func() {
-				})
-
 				It("returns the job", func() {
-					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+					Expect(rr.Body).To(MatchJSON(fmt.Sprintf(`{
 						"created_at": "",
 						"errors": null,
 						"guid": "%[2]s",
@@ -70,7 +69,7 @@ var _ = Describe("JobHandler", func() {
 						"state": "COMPLETE",
 						"updated_at": "",
 						"warnings": null
-						}`, defaultServerURL, jobGUID, resourceGUID)), "Response body matches response:")
+						}`, defaultServerURL, jobGUID, resourceGUID)))
 				})
 			})
 
@@ -80,7 +79,7 @@ var _ = Describe("JobHandler", func() {
 				})
 
 				It("returns the job", func() {
-					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+					Expect(rr.Body).To(MatchJSON(fmt.Sprintf(`{
 						"created_at": "",
 						"errors": null,
 						"guid": "%[2]s",
@@ -93,7 +92,7 @@ var _ = Describe("JobHandler", func() {
 						"state": "COMPLETE",
 						"updated_at": "",
 						"warnings": null
-					}`, defaultServerURL, jobGUID)), "Response body matches response:")
+					}`, defaultServerURL, jobGUID)))
 				})
 			})
 
@@ -103,7 +102,7 @@ var _ = Describe("JobHandler", func() {
 				})
 
 				It("returns the job", func() {
-					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+					Expect(rr.Body).To(MatchJSON(fmt.Sprintf(`{
 						"created_at": "",
 						"errors": null,
 						"guid": "%[2]s",
@@ -116,7 +115,7 @@ var _ = Describe("JobHandler", func() {
 						"state": "COMPLETE",
 						"updated_at": "",
 						"warnings": null
-					}`, defaultServerURL, jobGUID)), "Response body matches response:")
+					}`, defaultServerURL, jobGUID)))
 				})
 			})
 
@@ -126,7 +125,7 @@ var _ = Describe("JobHandler", func() {
 				})
 
 				It("returns the job", func() {
-					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+					Expect(rr.Body).To(MatchJSON(fmt.Sprintf(`{
 						"created_at": "",
 						"errors": null,
 						"guid": "%[2]s",
@@ -139,7 +138,7 @@ var _ = Describe("JobHandler", func() {
 						"state": "COMPLETE",
 						"updated_at": "",
 						"warnings": null
-					}`, defaultServerURL, jobGUID)), "Response body matches response:")
+					}`, defaultServerURL, jobGUID)))
 				})
 			})
 
@@ -149,7 +148,7 @@ var _ = Describe("JobHandler", func() {
 				})
 
 				It("returns the job", func() {
-					Expect(rr.Body.String()).To(MatchJSON(fmt.Sprintf(`{
+					Expect(rr.Body).To(MatchJSON(fmt.Sprintf(`{
 						"created_at": "",
 						"errors": null,
 						"guid": "%[2]s",
@@ -162,7 +161,7 @@ var _ = Describe("JobHandler", func() {
 						"state": "COMPLETE",
 						"updated_at": "",
 						"warnings": null
-					}`, defaultServerURL, jobGUID)), "Response body matches response:")
+					}`, defaultServerURL, jobGUID)))
 				})
 			})
 		})

--- a/api/apis/log_cache_handler.go
+++ b/api/apis/log_cache_handler.go
@@ -22,16 +22,21 @@ func NewLogCacheHandler() *LogCacheHandler {
 }
 
 func (h *LogCacheHandler) logCacheInfoHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	writeStringResponse(w, http.StatusOK, `{"version":"`+logCacheVersion+`","vm_uptime":"0"}`)
+	writeResponse(w, http.StatusOK, map[string]interface{}{
+		"version":   logCacheVersion,
+		"vm_uptime": "0",
+	})
 }
 
 func (h *LogCacheHandler) logCacheEmptyReadHandler(w http.ResponseWriter, r *http.Request) {
 	// Since we're not currently returning an app logs there is no need to check the validity of the app guid
 	// provided in the request. A full implementation of this endpoint needs to have the appropriate
 	// validity and authorization checks in place.
-	w.Header().Set("Content-Type", "application/json")
-	writeStringResponse(w, http.StatusOK, `{"envelopes":{"batch":[]}}`)
+	writeResponse(w, http.StatusOK, map[string]interface{}{
+		"envelopes": map[string]interface{}{
+			"batch": []interface{}{},
+		},
+	})
 }
 
 func (h *LogCacheHandler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/log_cache_handler_test.go
+++ b/api/apis/log_cache_handler_test.go
@@ -9,55 +9,58 @@ import (
 )
 
 var _ = Describe("LogCacheHandler", func() {
+	var req *http.Request
+
+	BeforeEach(func() {
+		handler := apis.NewLogCacheHandler()
+		handler.RegisterRoutes(router)
+	})
+
+	JustBeforeEach(func() {
+		router.ServeHTTP(rr, req)
+	})
+
 	Describe("the GET /api/v1/info endpoint", func() {
 		BeforeEach(func() {
-			req, err := http.NewRequest("GET", "/api/v1/info", nil)
+			var err error
+			req, err = http.NewRequest("GET", "/api/v1/info", nil)
 			Expect(err).NotTo(HaveOccurred())
-
-			apiHandler := apis.NewLogCacheHandler()
-			apiHandler.RegisterRoutes(router)
-
-			router.ServeHTTP(rr, req)
 		})
 
 		It("returns status 200 OK", func() {
-			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 
 		It("returns Content-Type as JSON in header", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
-			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+			Expect(contentTypeHeader).To(Equal(jsonHeader))
 		})
 
 		It("matches the expected response body format", func() {
 			expectedBody := `{"version":"2.11.4+cf-k8s","vm_uptime":"0"}`
-			Expect(rr.Body.String()).To(Equal(expectedBody), "Response body matches LogCacheHandler response:")
+			Expect(rr.Body).To(MatchJSON(expectedBody))
 		})
 	})
 
 	Describe("the GET /api/v1/read/<app-guid> endpoint", func() {
 		BeforeEach(func() {
-			req, err := http.NewRequest("GET", "/api/v1/read/unused-app-guid", nil)
+			var err error
+			req, err = http.NewRequest("GET", "/api/v1/read/unused-app-guid", nil)
 			Expect(err).NotTo(HaveOccurred())
-
-			apiHandler := apis.NewLogCacheHandler()
-			apiHandler.RegisterRoutes(router)
-
-			router.ServeHTTP(rr, req)
 		})
 
 		It("returns status 200 OK", func() {
-			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 
 		It("returns Content-Type as JSON in header", func() {
 			contentTypeHeader := rr.Header().Get("Content-Type")
-			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+			Expect(contentTypeHeader).To(Equal(jsonHeader))
 		})
 
 		It("returns a hardcoded list of empty log envelopes", func() {
 			expectedBody := `{"envelopes":{"batch":[]}}`
-			Expect(rr.Body.String()).To(Equal(expectedBody), "Response body matches LogCacheHandler response:")
+			Expect(rr.Body).To(MatchJSON(expectedBody))
 		})
 	})
 })

--- a/api/apis/org_handler_test.go
+++ b/api/apis/org_handler_test.go
@@ -673,7 +673,7 @@ var _ = Describe("OrgHandler", func() {
 			})
 
 			It("returns a not found error", func() {
-				expectNotFoundError("Organization not found. Ensure it exists and you have access to it.")
+				expectNotFoundError("Org not found")
 			})
 		})
 

--- a/api/apis/resource_matches_handler_test.go
+++ b/api/apis/resource_matches_handler_test.go
@@ -5,44 +5,44 @@ import (
 	"strings"
 
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ResourceMatchesHandler", func() {
+	var req *http.Request
+
+	BeforeEach(func() {
+		handler := NewResourceMatchesHandler(logf.Log.WithName("TestResourceMatchesHandler"))
+		handler.RegisterRoutes(router)
+	})
+
+	JustBeforeEach(func() {
+		router.ServeHTTP(rr, req)
+	})
+
 	Describe("Get Resource Match Endpoint", func() {
-		makePostRequest := func(body string) {
-			req, err := http.NewRequest("POST", "/v3/resource_matches", strings.NewReader(body))
-			Expect(err).NotTo(HaveOccurred())
-
-			router.ServeHTTP(rr, req)
-		}
-
 		BeforeEach(func() {
-			apiHandler := NewResourceMatchesHandler("foo://my-server")
-			apiHandler.RegisterRoutes(router)
+			var err error
+			req, err = http.NewRequestWithContext(ctx, "POST", "/v3/resource_matches", strings.NewReader("{}"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		When("ResourceMatchesHandler is called", func() {
-			BeforeEach(func() {
-				makePostRequest(`{}`)
-			})
+		It("returns status 201 Created", func() {
+			Expect(rr.Code).To(Equal(http.StatusCreated), "Matching HTTP response code:")
+		})
 
-			It("returns status 201 Created", func() {
-				Expect(rr.Code).To(Equal(http.StatusCreated), "Matching HTTP response code:")
-			})
+		It("returns Content-Type as JSON in header", func() {
+			contentTypeHeader := rr.Header().Get("Content-Type")
+			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+		})
 
-			It("returns Content-Type as JSON in header", func() {
-				contentTypeHeader := rr.Header().Get("Content-Type")
-				Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
-			})
-
-			It("returns a CF API formatted Error response", func() {
-				Expect(rr.Body.String()).To(MatchJSON(`{
+		It("returns a CF API formatted Error response", func() {
+			Expect(rr.Body.String()).To(MatchJSON(`{
 				"resources": []
 			  }`), "Response body matches response:")
-			})
 		})
 	})
 })

--- a/api/apis/root_handler_test.go
+++ b/api/apis/root_handler_test.go
@@ -12,17 +12,24 @@ import (
 )
 
 var _ = Describe("RootHandler", func() {
+	var req *http.Request
+
+	BeforeEach(func() {
+		apiHandler := apis.NewRootHandler(
+			defaultServerURL,
+		)
+		apiHandler.RegisterRoutes(router)
+	})
+
+	JustBeforeEach(func() {
+		router.ServeHTTP(rr, req)
+	})
+
 	Describe("GET / endpoint", func() {
 		BeforeEach(func() {
-			req, err := http.NewRequest("GET", "/", nil)
+			var err error
+			req, err = http.NewRequest("GET", "/", nil)
 			Expect(err).NotTo(HaveOccurred())
-
-			apiHandler := apis.NewRootHandler(
-				defaultServerURL,
-			)
-			apiHandler.RegisterRoutes(router)
-
-			router.ServeHTTP(rr, req)
 		})
 
 		It("returns status 200 OK", func() {

--- a/api/apis/root_v3_handler.go
+++ b/api/apis/root_v3_handler.go
@@ -19,8 +19,13 @@ func NewRootV3Handler(serverURL string) *RootV3Handler {
 }
 
 func (h *RootV3Handler) rootV3GetHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	writeStringResponse(w, http.StatusOK, `{"links":{"self":{"href":"`+h.serverURL+`/v3"}}}`)
+	writeResponse(w, http.StatusOK, map[string]interface{}{
+		"links": map[string]interface{}{
+			"self": map[string]interface{}{
+				"href": h.serverURL + "/v3",
+			},
+		},
+	})
 }
 
 func (h *RootV3Handler) RegisterRoutes(router *mux.Router) {

--- a/api/apis/root_v3_handler_test.go
+++ b/api/apis/root_v3_handler_test.go
@@ -4,34 +4,41 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis"
+	"github.com/go-http-utils/headers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("RootV3Handler", func() {
+	var req *http.Request
+
+	BeforeEach(func() {
+		handler := apis.NewRootV3Handler(defaultServerURL)
+		handler.RegisterRoutes(router)
+	})
+
+	JustBeforeEach(func() {
+		router.ServeHTTP(rr, req)
+	})
+
 	Describe("the GET /v3 endpoint", func() {
 		BeforeEach(func() {
-			req, err := http.NewRequest("GET", "/v3", nil)
+			var err error
+			req, err = http.NewRequest("GET", "/v3", nil)
 			Expect(err).NotTo(HaveOccurred())
-
-			apiHandler := apis.NewRootV3Handler(defaultServerURL)
-			apiHandler.RegisterRoutes(router)
-
-			router.ServeHTTP(rr, req)
 		})
 
 		It("returns status 200 OK", func() {
-			Expect(rr.Code).To(Equal(http.StatusOK), "Matching HTTP response code:")
+			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 
 		It("returns Content-Type as JSON in header", func() {
-			contentTypeHeader := rr.Header().Get("Content-Type")
-			Expect(contentTypeHeader).To(Equal(jsonHeader), "Matching Content-Type header:")
+			Expect(rr).To(HaveHTTPHeaderWithValue(headers.ContentType, jsonHeader))
 		})
 
 		It("matches the expected response body format", func() {
 			expectedBody := `{"links":{"self":{"href":"` + defaultServerURL + `/v3"}}}`
-			Expect(rr.Body.String()).To(Equal(expectedBody), "Response body matches RootV3GetHandler response:")
+			Expect(rr.Body).To(MatchJSON(expectedBody))
 		})
 	})
 })

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -173,7 +173,7 @@ var _ = Describe("RouteHandler", func() {
 			})
 
 			It("returns an error", func() {
-				expectNotFoundError("Route not found. Ensure it exists and you have access to it.")
+				expectNotFoundError("Route not found")
 			})
 		})
 
@@ -1739,7 +1739,7 @@ var _ = Describe("RouteHandler", func() {
 
 		When("deleting the route is not authorized", func() {
 			BeforeEach(func() {
-				routeRepo.DeleteRouteReturns(authorization.InvalidAuthError{Err: errors.New("boom")})
+				routeRepo.DeleteRouteReturns(repositories.NewForbiddenError(repositories.RouteResourceType, errors.New("boom")))
 			})
 
 			It("returns a 403 error", func() {

--- a/api/apis/service_route_binding_handler.go
+++ b/api/apis/service_route_binding_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 
 	"github.com/go-logr/logr"
@@ -29,12 +30,11 @@ func NewServiceRouteBindingHandler(
 	}
 }
 
-func (h *ServiceRouteBindingHandler) serviceRouteBindingsListHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
-	writeResponse(w, http.StatusOK, presenter.ForServiceRouteBindingsList(h.serverURL, *r.URL))
+func (h *ServiceRouteBindingHandler) serviceRouteBindingsListHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForServiceRouteBindingsList(h.serverURL, *r.URL)), nil
 }
 
 func (h *ServiceRouteBindingHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(ServiceRouteBindingsListEndpoint).Methods("GET").HandlerFunc(h.serviceRouteBindingsListHandler)
+	w := NewAuthAwareHandlerFuncWrapper(h.logger)
+	router.Path(ServiceRouteBindingsListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.serviceRouteBindingsListHandler))
 }

--- a/api/apis/service_route_binding_handler_test.go
+++ b/api/apis/service_route_binding_handler_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("ServiceRouteBinding", func() {
 	Describe("the GET /v3/service_route_binding endpoint", func() {
 		BeforeEach(func() {
-			req, err := http.NewRequest("GET", "/v3/service_route_bindings", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "/v3/service_route_bindings", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			apiHandler := apis.NewServiceRouteBindingHandler(

--- a/api/apis/space_handler_test.go
+++ b/api/apis/space_handler_test.go
@@ -529,7 +529,7 @@ var _ = Describe("Spaces", func() {
 
 		When("deleting the space is not authorized", func() {
 			BeforeEach(func() {
-				spaceRepo.DeleteSpaceReturns(authorization.InvalidAuthError{Err: errors.New("boom")})
+				spaceRepo.DeleteSpaceReturns(repositories.NewForbiddenError(repositories.SpaceResourceType, errors.New("boom")))
 			})
 
 			It("returns a 403 error", func() {

--- a/api/apis/space_manifest_handler_test.go
+++ b/api/apis/space_manifest_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"time"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	repositoriesfake "code.cloudfoundry.org/cf-k8s-controllers/api/repositories/fake"
@@ -29,24 +28,6 @@ var _ = Describe("SpaceManifestHandler", func() {
 		applyManifestAction = new(fake.ApplyManifestAction)
 		spaceRepo = new(repositoriesfake.CFSpaceRepository)
 		defaultDomainName = "apps.example.org"
-
-		now := time.Unix(1631892190, 0)
-		spaceRepo.ListSpacesReturns([]repositories.SpaceRecord{
-			{
-				Name:             "my-test-space",
-				GUID:             spaceGUID,
-				OrganizationGUID: "org-guid-1",
-				CreatedAt:        now,
-				UpdatedAt:        now,
-			},
-			{
-				Name:             "bob",
-				GUID:             "b-o-b",
-				OrganizationGUID: "org-guid-2",
-				CreatedAt:        now,
-				UpdatedAt:        now,
-			},
-		}, nil)
 
 		decoderValidator, err := NewDefaultDecoderValidator()
 		Expect(err).NotTo(HaveOccurred())
@@ -350,6 +331,7 @@ var _ = Describe("SpaceManifestHandler", func() {
 
 		When("the space is not found", func() {
 			BeforeEach(func() {
+				spaceRepo.GetSpaceReturns(repositories.SpaceRecord{}, repositories.NewNotFoundError(repositories.SpaceResourceType, errors.New("foo")))
 				var err error
 				req, err = http.NewRequestWithContext(ctx, "POST", "/v3/spaces/"+"fake-space-guid"+"/manifest_diff", strings.NewReader(`---
 				version: 1

--- a/api/apis/whoami_handler.go
+++ b/api/apis/whoami_handler.go
@@ -36,17 +36,13 @@ func NewWhoAmI(identityProvider IdentityProvider, apiBaseURL url.URL) *WhoAmIHan
 	}
 }
 
-func (h *WhoAmIHandler) whoAmIHandler(authInfo authorization.Info, w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	w.Header().Set("Content-Type", "application/json")
-
-	identity, err := h.identityProvider.GetIdentity(ctx, authInfo)
+func (h *WhoAmIHandler) whoAmIHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {
+	identity, err := h.identityProvider.GetIdentity(r.Context(), authInfo)
 	if err != nil {
-		writeUnknownErrorResponse(w)
-		return
+		return nil, err
 	}
 
-	writeResponse(w, http.StatusOK, presenter.ForWhoAmI(identity))
+	return NewHandlerResponse(http.StatusOK).WithBody(presenter.ForWhoAmI(identity)), nil
 }
 
 func (h *WhoAmIHandler) RegisterRoutes(router *mux.Router) {

--- a/api/main.go
+++ b/api/main.go
@@ -157,7 +157,7 @@ func main() {
 		apis.NewRootHandler(
 			config.ServerURL,
 		),
-		apis.NewResourceMatchesHandler(config.ServerURL),
+		apis.NewResourceMatchesHandler(ctrl.Log.WithName("ResourceMatchesHandler")),
 		apis.NewAppHandler(
 			ctrl.Log.WithName("AppHandler"),
 			*serverURL,

--- a/api/repositories/image_repository.go
+++ b/api/repositories/image_repository.go
@@ -16,6 +16,8 @@ import (
 	k8sclient "k8s.io/client-go/kubernetes"
 )
 
+const SourceImageResourceType = "SourceImage"
+
 //counterfeiter:generate -o fake -fake-name ImageBuilder . ImageBuilder
 //counterfeiter:generate -o fake -fake-name ImagePusher . ImagePusher
 

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Orgs", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusNotFound))
 				Expect(errResp.Errors).To(ConsistOf(
 					cfErr{
-						Detail: "Organization not found. Ensure it exists and you have access to it.",
+						Detail: "Org not found. Ensure it exists and you have access to it.",
 						Title:  "CF-ResourceNotFound",
 						Code:   10010,
 					},


### PR DESCRIPTION
## Is there a related GitHub Issue?
https://github.com/cloudfoundry/cf-k8s-controllers/issues/288


## What is this change about?
* Extend the handler functions interface to return a `HandlerResponse`
  and an error (that should usually be on the of errors from the
  `apierrors` package; generic errors are alos supported but would be
  presented as unknown errors)
* Handler functions no longer have access to the `http.ResponseWriter`.
  Instead, the interaction with the writer is carried out by the
  `AuthAwareHandler` wrapper which presents the errors returned by
  handlers in a generic manner.
* Misc improvements
  * All handlers that (except the ones that do not required
    authentication according to the CF API spec) are wrapped by
    `AuthAwareHandler` in order to make use of the common error
    handling.
  * Deprecated `writeStringResponse` utility function is deleted
  * Improvements in handlers unit tests

With this change repositories still return repository errors and
therefore handlers need to translate them to `apierrors`. Next steps
would be to make repositories return `apierrors` so that handlers would
no longer need to do that.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Green tests

## Tag your pair, your PM, and/or team
@kieron-dev 

