### PR TITLE
Endpoints are not paths

### DIFF
--- a/api/apis/app_handler.go
+++ b/api/apis/app_handler.go
@@ -24,22 +24,20 @@ import (
 )
 
 const (
-	AppCreateEndpoint            = "/v3/apps"
-	AppGetEndpoint               = "/v3/apps/{guid}"
-	AppListEndpoint              = "/v3/apps"
-	AppSetCurrentDropletEndpoint = "/v3/apps/{guid}/relationships/current_droplet"
-	AppGetCurrentDropletEndpoint = "/v3/apps/{guid}/droplets/current"
-	AppGetProcessesEndpoint      = "/v3/apps/{guid}/processes"
-	AppGetProcessByTypeEndpoint  = "/v3/apps/{guid}/processes/{type}"
-	AppProcessScaleEndpoint      = "/v3/apps/{guid}/processes/{processType}/actions/scale"
-	AppGetRoutesEndpoint         = "/v3/apps/{guid}/routes"
-	AppStartEndpoint             = "/v3/apps/{guid}/actions/start"
-	AppStopEndpoint              = "/v3/apps/{guid}/actions/stop"
-	AppRestartEndpoint           = "/v3/apps/{guid}/actions/restart"
-	AppDeleteEndpoint            = "/v3/apps/{guid}"
-	AppPatchEnvVarsEndpoint      = "/v3/apps/{guid}/environment_variables"
-	AppGetEnvEndpoint            = "/v3/apps/{guid}/env"
-	invalidDropletMsg            = "Unable to assign current droplet. Ensure the droplet exists and belongs to this app."
+	AppsPath                          = "/v3/apps"
+	AppPath                           = "/v3/apps/{guid}"
+	AppCurrentDropletRelationshipPath = "/v3/apps/{guid}/relationships/current_droplet"
+	AppCurrentDropletPath             = "/v3/apps/{guid}/droplets/current"
+	AppProcessesPath                  = "/v3/apps/{guid}/processes"
+	AppProcessByTypePath              = "/v3/apps/{guid}/processes/{type}"
+	AppProcessScalePath               = "/v3/apps/{guid}/processes/{processType}/actions/scale"
+	AppRoutesPath                     = "/v3/apps/{guid}/routes"
+	AppStartPath                      = "/v3/apps/{guid}/actions/start"
+	AppStopPath                       = "/v3/apps/{guid}/actions/stop"
+	AppRestartPath                    = "/v3/apps/{guid}/actions/restart"
+	AppEnvVarsPath                    = "/v3/apps/{guid}/environment_variables"
+	AppEnvPath                        = "/v3/apps/{guid}/env"
+	invalidDropletMsg                 = "Unable to assign current droplet. Ensure the droplet exists and belongs to this app."
 
 	AppStartedState = "STARTED"
 	AppStoppedState = "STOPPED"
@@ -606,19 +604,19 @@ func (h *AppHandler) handleUpdateAppErr(err error, appGUID string) error {
 
 func (h *AppHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(AppGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.appGetHandler))
-	router.Path(AppListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.appListHandler))
-	router.Path(AppCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.appCreateHandler))
-	router.Path(AppSetCurrentDropletEndpoint).Methods("PATCH").HandlerFunc(w.Wrap(h.appSetCurrentDropletHandler))
-	router.Path(AppGetCurrentDropletEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.appGetCurrentDropletHandler))
-	router.Path(AppStartEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.appStartHandler))
-	router.Path(AppStopEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.appStopHandler))
-	router.Path(AppRestartEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.appRestartHandler))
-	router.Path(AppProcessScaleEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.appScaleProcessHandler))
-	router.Path(AppGetProcessesEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.getProcessesForAppHandler))
-	router.Path(AppGetProcessByTypeEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.getProcessByTypeForAppHander))
-	router.Path(AppGetRoutesEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.getRoutesForAppHandler))
-	router.Path(AppDeleteEndpoint).Methods("DELETE").HandlerFunc(w.Wrap(h.appDeleteHandler))
-	router.Path(AppPatchEnvVarsEndpoint).Methods("PATCH").HandlerFunc(w.Wrap(h.appPatchEnvVarsHandler))
-	router.Path(AppGetEnvEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.appGetEnvHandler))
+	router.Path(AppPath).Methods("GET").HandlerFunc(w.Wrap(h.appGetHandler))
+	router.Path(AppsPath).Methods("GET").HandlerFunc(w.Wrap(h.appListHandler))
+	router.Path(AppsPath).Methods("POST").HandlerFunc(w.Wrap(h.appCreateHandler))
+	router.Path(AppCurrentDropletRelationshipPath).Methods("PATCH").HandlerFunc(w.Wrap(h.appSetCurrentDropletHandler))
+	router.Path(AppCurrentDropletPath).Methods("GET").HandlerFunc(w.Wrap(h.appGetCurrentDropletHandler))
+	router.Path(AppStartPath).Methods("POST").HandlerFunc(w.Wrap(h.appStartHandler))
+	router.Path(AppStopPath).Methods("POST").HandlerFunc(w.Wrap(h.appStopHandler))
+	router.Path(AppRestartPath).Methods("POST").HandlerFunc(w.Wrap(h.appRestartHandler))
+	router.Path(AppProcessScalePath).Methods("POST").HandlerFunc(w.Wrap(h.appScaleProcessHandler))
+	router.Path(AppProcessesPath).Methods("GET").HandlerFunc(w.Wrap(h.getProcessesForAppHandler))
+	router.Path(AppProcessByTypePath).Methods("GET").HandlerFunc(w.Wrap(h.getProcessByTypeForAppHander))
+	router.Path(AppRoutesPath).Methods("GET").HandlerFunc(w.Wrap(h.getRoutesForAppHandler))
+	router.Path(AppPath).Methods("DELETE").HandlerFunc(w.Wrap(h.appDeleteHandler))
+	router.Path(AppEnvVarsPath).Methods("PATCH").HandlerFunc(w.Wrap(h.appPatchEnvVarsHandler))
+	router.Path(AppEnvPath).Methods("GET").HandlerFunc(w.Wrap(h.appGetEnvHandler))
 }

--- a/api/apis/build_handler.go
+++ b/api/apis/build_handler.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	BuildGetEndpoint    = "/v3/builds/{guid}"
-	BuildCreateEndpoint = "/v3/builds"
+	BuildPath  = "/v3/builds/{guid}"
+	BuildsPath = "/v3/builds"
 )
 
 //counterfeiter:generate -o fake -fake-name CFBuildRepository . CFBuildRepository
@@ -105,6 +105,6 @@ func (h *BuildHandler) buildCreateHandler(authInfo authorization.Info, r *http.R
 
 func (h *BuildHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(BuildGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.buildGetHandler))
-	router.Path(BuildCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.buildCreateHandler))
+	router.Path(BuildPath).Methods("GET").HandlerFunc(w.Wrap(h.buildGetHandler))
+	router.Path(BuildsPath).Methods("POST").HandlerFunc(w.Wrap(h.buildCreateHandler))
 }

--- a/api/apis/buildpack_handler.go
+++ b/api/apis/buildpack_handler.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	BuildpackListEndpoint = "/v3/buildpacks"
+	BuildpacksPath = "/v3/buildpacks"
 )
 
 //counterfeiter:generate -o fake -fake-name BuildpackRepository . BuildpackRepository
@@ -87,5 +87,5 @@ func (h *BuildpackHandler) buildpackListHandler(authInfo authorization.Info, r *
 
 func (h *BuildpackHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(BuildpackListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.buildpackListHandler))
+	router.Path(BuildpacksPath).Methods("GET").HandlerFunc(w.Wrap(h.buildpackListHandler))
 }

--- a/api/apis/domain_handler.go
+++ b/api/apis/domain_handler.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	DomainListEndpoint = "/v3/domains"
+	DomainsPath = "/v3/domains"
 )
 
 //counterfeiter:generate -o fake -fake-name CFDomainRepository . CFDomainRepository
@@ -87,5 +87,5 @@ func (h *DomainHandler) DomainListHandler(authInfo authorization.Info, r *http.R
 
 func (h *DomainHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(DomainListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.DomainListHandler))
+	router.Path(DomainsPath).Methods("GET").HandlerFunc(w.Wrap(h.DomainListHandler))
 }

--- a/api/apis/droplet_handler.go
+++ b/api/apis/droplet_handler.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	DropletGetEndpoint = "/v3/droplets/{guid}"
+	DropletPath = "/v3/droplets/{guid}"
 )
 
 //counterfeiter:generate -o fake -fake-name CFDropletRepository . CFDropletRepository
@@ -57,5 +57,5 @@ func (h *DropletHandler) dropletGetHandler(authInfo authorization.Info, r *http.
 
 func (h *DropletHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(DropletGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.dropletGetHandler))
+	router.Path(DropletPath).Methods("GET").HandlerFunc(w.Wrap(h.dropletGetHandler))
 }

--- a/api/apis/job_handler.go
+++ b/api/apis/job_handler.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	JobGetEndpoint    = "/v3/jobs/{guid}"
+	JobPath           = "/v3/jobs/{guid}"
 	syncSpacePrefix   = "space.apply_manifest"
 	appDeletePrefix   = "app.delete"
 	orgDeletePrefix   = "org.delete"
@@ -65,7 +65,7 @@ func (h *JobHandler) jobGetHandler(_ authorization.Info, r *http.Request) (*Hand
 
 func (h *JobHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(JobGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.jobGetHandler))
+	router.Path(JobPath).Methods("GET").HandlerFunc(w.Wrap(h.jobGetHandler))
 }
 
 func parseJobGUID(jobGUID string) (string, string, bool) {

--- a/api/apis/log_cache_handler.go
+++ b/api/apis/log_cache_handler.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	LogCacheInfoEndpoint = "/api/v1/info"
-	LogCacheReadEndpoint = "/api/v1/read/{guid}"
-	logCacheVersion      = "2.11.4+cf-k8s"
+	LogCacheInfoPath = "/api/v1/info"
+	LogCacheReadPath = "/api/v1/read/{guid}"
+	logCacheVersion  = "2.11.4+cf-k8s"
 )
 
 // LogCacheHandler implements the minimal set of log-cache API endpoints/features necessary
@@ -40,6 +40,6 @@ func (h *LogCacheHandler) logCacheEmptyReadHandler(w http.ResponseWriter, r *htt
 }
 
 func (h *LogCacheHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(LogCacheInfoEndpoint).Methods("GET").HandlerFunc(h.logCacheInfoHandler)
-	router.Path(LogCacheReadEndpoint).Methods("GET").HandlerFunc(h.logCacheEmptyReadHandler)
+	router.Path(LogCacheInfoPath).Methods("GET").HandlerFunc(h.logCacheInfoHandler)
+	router.Path(LogCacheReadPath).Methods("GET").HandlerFunc(h.logCacheEmptyReadHandler)
 }

--- a/api/apis/org_handler.go
+++ b/api/apis/org_handler.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	OrgsEndpoint           = "/v3/organizations"
-	OrgDeleteEndpoint      = "/v3/organizations/{guid}"
-	OrgListDomainsEndpoint = "/v3/organizations/{guid}/domains"
+	OrgsPath       = "/v3/organizations"
+	OrgPath        = "/v3/organizations/{guid}"
+	OrgDomainsPath = "/v3/organizations/{guid}/domains"
 )
 
 //counterfeiter:generate -o fake -fake-name OrgRepository . CFOrgRepository
@@ -196,8 +196,8 @@ func (h *OrgHandler) orgListDomainHandler(info authorization.Info, r *http.Reque
 
 func (h *OrgHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(OrgsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.orgListHandler))
-	router.Path(OrgDeleteEndpoint).Methods("DELETE").HandlerFunc(w.Wrap(h.orgDeleteHandler))
-	router.Path(OrgsEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.orgCreateHandler))
-	router.Path(OrgListDomainsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.orgListDomainHandler))
+	router.Path(OrgsPath).Methods("GET").HandlerFunc(w.Wrap(h.orgListHandler))
+	router.Path(OrgPath).Methods("DELETE").HandlerFunc(w.Wrap(h.orgDeleteHandler))
+	router.Path(OrgsPath).Methods("POST").HandlerFunc(w.Wrap(h.orgCreateHandler))
+	router.Path(OrgDomainsPath).Methods("GET").HandlerFunc(w.Wrap(h.orgListDomainHandler))
 }

--- a/api/apis/package_handler.go
+++ b/api/apis/package_handler.go
@@ -20,11 +20,10 @@ import (
 )
 
 const (
-	PackageGetEndpoint          = "/v3/packages/{guid}"
-	PackageListEndpoint         = "/v3/packages"
-	PackageCreateEndpoint       = "/v3/packages"
-	PackageUploadEndpoint       = "/v3/packages/{guid}/upload"
-	PackageListDropletsEndpoint = "/v3/packages/{guid}/droplets"
+	PackagePath         = "/v3/packages/{guid}"
+	PackagesPath        = "/v3/packages"
+	PackageUploadPath   = "/v3/packages/{guid}/upload"
+	PackageDropletsPath = "/v3/packages/{guid}/droplets"
 )
 
 //counterfeiter:generate -o fake -fake-name CFPackageRepository . CFPackageRepository
@@ -281,9 +280,9 @@ func (h PackageHandler) packageListDropletsHandler(authInfo authorization.Info, 
 
 func (h *PackageHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(PackageGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.packageGetHandler))
-	router.Path(PackageListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.packageListHandler))
-	router.Path(PackageCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.packageCreateHandler))
-	router.Path(PackageUploadEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.packageUploadHandler))
-	router.Path(PackageListDropletsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.packageListDropletsHandler))
+	router.Path(PackagePath).Methods("GET").HandlerFunc(w.Wrap(h.packageGetHandler))
+	router.Path(PackagesPath).Methods("GET").HandlerFunc(w.Wrap(h.packageListHandler))
+	router.Path(PackagesPath).Methods("POST").HandlerFunc(w.Wrap(h.packageCreateHandler))
+	router.Path(PackageUploadPath).Methods("POST").HandlerFunc(w.Wrap(h.packageUploadHandler))
+	router.Path(PackageDropletsPath).Methods("GET").HandlerFunc(w.Wrap(h.packageListDropletsHandler))
 }

--- a/api/apis/process_handler.go
+++ b/api/apis/process_handler.go
@@ -19,12 +19,11 @@ import (
 )
 
 const (
-	ProcessGetEndpoint         = "/v3/processes/{guid}"
-	ProcessGetSidecarsEndpoint = "/v3/processes/{guid}/sidecars"
-	ProcessScaleEndpoint       = "/v3/processes/{guid}/actions/scale"
-	ProcessGetStatsEndpoint    = "/v3/processes/{guid}/stats"
-	ProcessListEndpoint        = "/v3/processes"
-	ProcessPatchEndpoint       = "/v3/processes/{guid}"
+	ProcessPath         = "/v3/processes/{guid}"
+	ProcessSidecarsPath = "/v3/processes/{guid}/sidecars"
+	ProcessScalePath    = "/v3/processes/{guid}/actions/scale"
+	ProcessStatsPath    = "/v3/processes/{guid}/stats"
+	ProcessesPath       = "/v3/processes"
 )
 
 //counterfeiter:generate -o fake -fake-name CFProcessRepository . CFProcessRepository
@@ -235,10 +234,10 @@ func (h *ProcessHandler) writeErrorResponse(processGUID string, err error) error
 
 func (h *ProcessHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(ProcessGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.processGetHandler))
-	router.Path(ProcessGetSidecarsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.processGetSidecarsHandler))
-	router.Path(ProcessScaleEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.processScaleHandler))
-	router.Path(ProcessGetStatsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.processGetStatsHandler))
-	router.Path(ProcessListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.processListHandler))
-	router.Path(ProcessPatchEndpoint).Methods("PATCH").HandlerFunc(w.Wrap(h.processPatchHandler))
+	router.Path(ProcessPath).Methods("GET").HandlerFunc(w.Wrap(h.processGetHandler))
+	router.Path(ProcessSidecarsPath).Methods("GET").HandlerFunc(w.Wrap(h.processGetSidecarsHandler))
+	router.Path(ProcessScalePath).Methods("POST").HandlerFunc(w.Wrap(h.processScaleHandler))
+	router.Path(ProcessStatsPath).Methods("GET").HandlerFunc(w.Wrap(h.processGetStatsHandler))
+	router.Path(ProcessesPath).Methods("GET").HandlerFunc(w.Wrap(h.processListHandler))
+	router.Path(ProcessPath).Methods("PATCH").HandlerFunc(w.Wrap(h.processPatchHandler))
 }

--- a/api/apis/resource_matches_handler.go
+++ b/api/apis/resource_matches_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ResourceMatchesEndpoint = "/v3/resource_matches"
+	ResourceMatchesPath = "/v3/resource_matches"
 )
 
 type ResourceMatchesHandler struct {
@@ -30,5 +30,5 @@ func (h *ResourceMatchesHandler) resourceMatchesPostHandler(_ authorization.Info
 
 func (h *ResourceMatchesHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(ResourceMatchesEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.resourceMatchesPostHandler))
+	router.Path(ResourceMatchesPath).Methods("POST").HandlerFunc(w.Wrap(h.resourceMatchesPostHandler))
 }

--- a/api/apis/role_handler.go
+++ b/api/apis/role_handler.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	RolesEndpoint = "/v3/roles"
+	RolesPath = "/v3/roles"
 )
 
 type RoleName string
@@ -94,5 +94,5 @@ func (h *RoleHandler) roleCreateHandler(authInfo authorization.Info, r *http.Req
 
 func (h *RoleHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(RolesEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.roleCreateHandler))
+	router.Path(RolesPath).Methods("POST").HandlerFunc(w.Wrap(h.roleCreateHandler))
 }

--- a/api/apis/root_handler.go
+++ b/api/apis/root_handler.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	RootGetEndpoint = "/"
+	RootPath = "/"
 )
 
 type RootHandler struct {
@@ -25,5 +25,5 @@ func (h *RootHandler) rootGetHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RootHandler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootGetEndpoint).Methods("GET").HandlerFunc(h.rootGetHandler)
+	router.Path(RootPath).Methods("GET").HandlerFunc(h.rootGetHandler)
 }

--- a/api/apis/root_v3_handler.go
+++ b/api/apis/root_v3_handler.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	RootV3GetEndpoint = "/v3"
+	RootV3Path = "/v3"
 )
 
 type RootV3Handler struct {
@@ -29,5 +29,5 @@ func (h *RootV3Handler) rootV3GetHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *RootV3Handler) RegisterRoutes(router *mux.Router) {
-	router.Path(RootV3GetEndpoint).Methods("GET").HandlerFunc(h.rootV3GetHandler)
+	router.Path(RootV3Path).Methods("GET").HandlerFunc(h.rootV3GetHandler)
 }

--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -18,12 +18,9 @@ import (
 )
 
 const (
-	RouteGetEndpoint             = "/v3/routes/{guid}"
-	RouteGetListEndpoint         = "/v3/routes"
-	RouteGetDestinationsEndpoint = "/v3/routes/{guid}/destinations"
-	RouteCreateEndpoint          = "/v3/routes"
-	RouteDeleteEndpoint          = "/v3/routes/{guid}"
-	RouteAddDestinationsEndpoint = "/v3/routes/{guid}/destinations"
+	RoutePath             = "/v3/routes/{guid}"
+	RoutesPath            = "/v3/routes"
+	RouteDestinationsPath = "/v3/routes/{guid}/destinations"
 )
 
 //counterfeiter:generate -o fake -fake-name CFRouteRepository . CFRouteRepository
@@ -291,12 +288,12 @@ func (h *RouteHandler) routeDeleteHandler(authInfo authorization.Info, r *http.R
 
 func (h *RouteHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(RouteGetEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.routeGetHandler))
-	router.Path(RouteGetListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.routeGetListHandler))
-	router.Path(RouteGetDestinationsEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.routeGetDestinationsHandler))
-	router.Path(RouteCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.routeCreateHandler))
-	router.Path(RouteDeleteEndpoint).Methods("DELETE").HandlerFunc(w.Wrap(h.routeDeleteHandler))
-	router.Path(RouteAddDestinationsEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.routeAddDestinationsHandler))
+	router.Path(RoutePath).Methods("GET").HandlerFunc(w.Wrap(h.routeGetHandler))
+	router.Path(RoutesPath).Methods("GET").HandlerFunc(w.Wrap(h.routeGetListHandler))
+	router.Path(RouteDestinationsPath).Methods("GET").HandlerFunc(w.Wrap(h.routeGetDestinationsHandler))
+	router.Path(RoutesPath).Methods("POST").HandlerFunc(w.Wrap(h.routeCreateHandler))
+	router.Path(RoutePath).Methods("DELETE").HandlerFunc(w.Wrap(h.routeDeleteHandler))
+	router.Path(RouteDestinationsPath).Methods("POST").HandlerFunc(w.Wrap(h.routeAddDestinationsHandler))
 }
 
 // Fetch Route and compose related Domain information within

--- a/api/apis/service_binding_handler.go
+++ b/api/apis/service_binding_handler.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	ServiceBindingCreateEndpoint  = "/v3/service_credential_bindings"
-	ServiceBindingsListEndpoint   = "/v3/service_credential_bindings"
-	ServiceBindingsDeleteEndpoint = "/v3/service_credential_bindings/{guid}"
+	ServiceBindingsPath = "/v3/service_credential_bindings"
+	ServiceBindingPath  = "/v3/service_credential_bindings/{guid}"
 )
 
 type ServiceBindingHandler struct {
@@ -167,9 +166,9 @@ func (h *ServiceBindingHandler) writeErrorResponse(err error, action, resourceTy
 
 func (h *ServiceBindingHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(ServiceBindingCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.createHandler))
-	router.Path(ServiceBindingsListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.listHandler))
-	router.Path(ServiceBindingsDeleteEndpoint).Methods("DELETE").HandlerFunc(w.Wrap(h.deleteHandler))
+	router.Path(ServiceBindingsPath).Methods("POST").HandlerFunc(w.Wrap(h.createHandler))
+	router.Path(ServiceBindingsPath).Methods("GET").HandlerFunc(w.Wrap(h.listHandler))
+	router.Path(ServiceBindingPath).Methods("DELETE").HandlerFunc(w.Wrap(h.deleteHandler))
 }
 
 // TODO: Separate commit/PR to move this function into shared.go and refactor all the handlers

--- a/api/apis/service_instance_handler.go
+++ b/api/apis/service_instance_handler.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	ServiceInstanceCreateEndpoint = "/v3/service_instances"
-	ServiceInstanceListEndpoint   = "/v3/service_instances"
-	ServiceInstanceDeleteEndpoint = "/v3/service_instances/{guid}"
+	ServiceInstancesPath = "/v3/service_instances"
+	ServiceInstancePath  = "/v3/service_instances/{guid}"
 )
 
 //counterfeiter:generate -o fake -fake-name CFServiceInstanceRepository . CFServiceInstanceRepository
@@ -204,7 +203,7 @@ func (h *ServiceInstanceHandler) serviceInstanceDeleteHandler(authInfo authoriza
 
 func (h *ServiceInstanceHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(ServiceInstanceCreateEndpoint).Methods(http.MethodPost).HandlerFunc(w.Wrap(h.serviceInstanceCreateHandler))
-	router.Path(ServiceInstanceListEndpoint).Methods(http.MethodGet).HandlerFunc(w.Wrap(h.serviceInstanceListHandler))
-	router.Path(ServiceInstanceDeleteEndpoint).Methods(http.MethodDelete).HandlerFunc(w.Wrap(h.serviceInstanceDeleteHandler))
+	router.Path(ServiceInstancesPath).Methods(http.MethodPost).HandlerFunc(w.Wrap(h.serviceInstanceCreateHandler))
+	router.Path(ServiceInstancesPath).Methods(http.MethodGet).HandlerFunc(w.Wrap(h.serviceInstanceListHandler))
+	router.Path(ServiceInstancePath).Methods(http.MethodDelete).HandlerFunc(w.Wrap(h.serviceInstanceDeleteHandler))
 }

--- a/api/apis/service_route_binding_handler.go
+++ b/api/apis/service_route_binding_handler.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ServiceRouteBindingsListEndpoint = "/v3/service_route_bindings"
+	ServiceRouteBindingsPath = "/v3/service_route_bindings"
 )
 
 type ServiceRouteBindingHandler struct {
@@ -36,5 +36,5 @@ func (h *ServiceRouteBindingHandler) serviceRouteBindingsListHandler(authInfo au
 
 func (h *ServiceRouteBindingHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(ServiceRouteBindingsListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.serviceRouteBindingsListHandler))
+	router.Path(ServiceRouteBindingsPath).Methods("GET").HandlerFunc(w.Wrap(h.serviceRouteBindingsListHandler))
 }

--- a/api/apis/space_handler.go
+++ b/api/apis/space_handler.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	SpaceCreateEndpoint = "/v3/spaces"
-	SpaceDeleteEnpoint  = "/v3/spaces/{guid}"
-	SpaceListEndpoint   = "/v3/spaces"
+	SpacesPath = "/v3/spaces"
+	SpacePath  = "/v3/spaces/{guid}"
 )
 
 //counterfeiter:generate -o fake -fake-name SpaceRepository . SpaceRepository
@@ -181,9 +180,9 @@ func (h *SpaceHandler) spaceDeleteHandler(info authorization.Info, r *http.Reque
 
 func (h *SpaceHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(SpaceListEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.spaceListHandler))
-	router.Path(SpaceCreateEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.spaceCreateHandler))
-	router.Path(SpaceDeleteEnpoint).Methods("DELETE").HandlerFunc(w.Wrap(h.spaceDeleteHandler))
+	router.Path(SpacesPath).Methods("GET").HandlerFunc(w.Wrap(h.spaceListHandler))
+	router.Path(SpacesPath).Methods("POST").HandlerFunc(w.Wrap(h.spaceCreateHandler))
+	router.Path(SpacePath).Methods("DELETE").HandlerFunc(w.Wrap(h.spaceDeleteHandler))
 }
 
 func parseCommaSeparatedList(list string) []string {

--- a/api/apis/space_manifest_handler.go
+++ b/api/apis/space_manifest_handler.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	SpaceManifestApplyEndpoint = "/v3/spaces/{spaceGUID}/actions/apply_manifest"
-	SpaceManifestDiffEndpoint  = "/v3/spaces/{spaceGUID}/manifest_diff"
+	SpaceManifestApplyPath = "/v3/spaces/{spaceGUID}/actions/apply_manifest"
+	SpaceManifestDiffPath  = "/v3/spaces/{spaceGUID}/manifest_diff"
 )
 
 type SpaceManifestHandler struct {
@@ -54,8 +54,8 @@ func NewSpaceManifestHandler(
 
 func (h *SpaceManifestHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(SpaceManifestApplyEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.applyManifestHandler))
-	router.Path(SpaceManifestDiffEndpoint).Methods("POST").HandlerFunc(w.Wrap(h.diffManifestHandler))
+	router.Path(SpaceManifestApplyPath).Methods("POST").HandlerFunc(w.Wrap(h.applyManifestHandler))
+	router.Path(SpaceManifestDiffPath).Methods("POST").HandlerFunc(w.Wrap(h.diffManifestHandler))
 }
 
 func (h *SpaceManifestHandler) applyManifestHandler(authInfo authorization.Info, r *http.Request) (*HandlerResponse, error) {

--- a/api/apis/whoami_handler.go
+++ b/api/apis/whoami_handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	WhoAmIEndpoint = "/whoami"
+	WhoAmIPath = "/whoami"
 )
 
 //counterfeiter:generate -o fake -fake-name IdentityProvider . IdentityProvider
@@ -47,5 +47,5 @@ func (h *WhoAmIHandler) whoAmIHandler(authInfo authorization.Info, r *http.Reque
 
 func (h *WhoAmIHandler) RegisterRoutes(router *mux.Router) {
 	w := NewAuthAwareHandlerFuncWrapper(h.logger)
-	router.Path(WhoAmIEndpoint).Methods("GET").HandlerFunc(w.Wrap(h.whoAmIHandler))
+	router.Path(WhoAmIPath).Methods("GET").HandlerFunc(w.Wrap(h.whoAmIHandler))
 }

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -422,7 +422,7 @@ func asyncCreateSpace(spaceName, orgGUID string, createdSpaceGUID *string, wg *s
 // createRole creates an org or space role
 // You should probably invoke this via createOrgRole or createSpaceRole
 func createRole(roleName, kind, orgSpaceType, userName, orgSpaceGUID string) {
-	rolesURL := apiServerRoot + apis.RolesEndpoint
+	rolesURL := apiServerRoot + apis.RolesPath
 
 	userOrServiceAccount := "user"
 	if kind == rbacv1.ServiceAccountKind {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
An endpoint is defined by a path and a method, we used endpoint constants for paths and duplicated them for operations using different methods on the same path (e.g. `GET` and `DELETE` on the same resource).
This removes the duplication and fixes the constant names.

## Does this PR introduce a breaking change?
No.