### PR TITLE
Backfill tests for /v3/apps/:guid/processes/:type

### DIFF
--- a/api/apis/app_handler_test.go
+++ b/api/apis/app_handler_test.go
@@ -1846,6 +1846,17 @@ var _ = Describe("AppHandler", func() {
 			})
 		})
 
+		When("the user lacks access in the app namespace", func() {
+			BeforeEach(func() {
+				appRepo.GetAppReturns(repositories.AppRecord{}, repositories.NewForbiddenError(repositories.AppResourceType, nil))
+				makeGetRequest(processTypeWeb)
+			})
+
+			It("returns an not found error", func() {
+				expectNotFoundError("App not found")
+			})
+		})
+
 		When("the app doesn't have a process of the given type", func() {
 			BeforeEach(func() {
 				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, repositories.NewNotFoundError(repositories.ProcessResourceType, nil))


### PR DESCRIPTION
**Note:** There is a slight discrepancy between the product behavior and the stated A/C in #734 

The story expects an error like `"detail": "Process not found"`
The product is currently returning `"detail": "App not found. Ensure it exists and you have access to it."`

We believe that the product behavior is more correct, and doesn't leak any information that the user shouldn't have access to.

We also noticed that the app routes endpoint returns the `"App not found"` error message when the app cannot be found, so this behavior is more consistent.

Having said that, please feel free to reject the story if there is some nuance we missed.

## Is there a related GitHub Issue?
#734

## What is this change about?
- implementation was already correct, but tests were missing
- this commit adds handler unit and e2e tests.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
#734 (see note above)

## Tag your pair, your PM, and/or team
@acosta11 
