### PR TITLE
Update smoke tests to use https for kind

### DIFF
--- a/tests/smoke/run-smoke-tests-kind.sh
+++ b/tests/smoke/run-smoke-tests-kind.sh
@@ -8,10 +8,10 @@ pushd "${SCRIPT_DIR}"
 {
   cf api https://localhost --skip-ssl-validation
   cf login << EOF
-1
-1
-1
+2
+2
+2
 EOF
-  SMOKE_TEST_APP_ROUTE_PROTOCOL="http" SMOKE_TEST_APPS_DOMAIN="vcap.me" go test
+  SMOKE_TEST_APP_ROUTE_PROTOCOL="https" SMOKE_TEST_APPS_DOMAIN="vcap.me" go test
 }
 popd

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Smoke Tests", func() {
 
 			Eventually(func() int {
 				var err error
+				http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 				resp, err = http.Get(fmt.Sprintf("%s://%s.%s", appRouteProtocol, appName, appsDomain))
 				Expect(err).NotTo(HaveOccurred())
 				return resp.StatusCode


### PR DESCRIPTION
## Is there a related GitHub Issue?
No. Consider this as a follow up to #751 

## What is this change about?
This PR updates the smoke tests to use HTTPS for apps endpoints. It also fixes the `run-smoke-test-kind.sh` to use the new `cf-admin` user.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
deploy and run smoke tests

## Tag your pair, your PM, and/or team
@clintyoshimura 
