### PR TITLE
Only include app info for returned bindings

### DIFF
--- a/api/apis/service_binding_handler.go
+++ b/api/apis/service_binding_handler.go
@@ -131,7 +131,7 @@ func (h *ServiceBindingHandler) listHandler(authInfo authorization.Info, r *http
 	}
 
 	var appRecords []repositories.AppRecord
-	if listFilter.Include != nil {
+	if listFilter.Include != nil && len(serviceBindingList) > 0 {
 		listAppsMessage := repositories.ListAppsMessage{}
 
 		for _, serviceBinding := range serviceBindingList {

--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -1,12 +1,13 @@
 package e2e_test
 
 import (
+	"net/http"
+
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"net/http"
 )
 
 var _ = Describe("Service Bindings", func() {

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -106,7 +106,7 @@ function create_tls_secret() {
       -days 365
   fi
 
-  cat << EOF > ${tmp_dir}/kustomization.yml
+  cat <<EOF >${tmp_dir}/kustomization.yml
 secretGenerator:
 - name: ${secret_name}
   namespace: ${secret_namespace}

--- a/tests/smoke/run-smoke-tests-kind.sh
+++ b/tests/smoke/run-smoke-tests-kind.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 pushd "${SCRIPT_DIR}"
 {
   cf api https://localhost --skip-ssl-validation
-  cf login << EOF
+  cf login <<EOF
 1
 1
 1

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Smoke Tests", func() {
 
 			if doLogin != "" {
 				apiEndpoint := GetRequiredEnvVar("SMOKE_TEST_API_ENDPOINT")
-				//username := GetRequiredEnvVar("SMOKE_TEST_USERNAME")
-				//password := GetRequiredEnvVar("SMOKE_TEST_PASSWORD")
+				// username := GetRequiredEnvVar("SMOKE_TEST_USERNAME")
+				// password := GetRequiredEnvVar("SMOKE_TEST_PASSWORD")
 
 				apiArguments := []string{"api", apiEndpoint}
 				skip_ssl, _ := os.LookupEnv("SMOKE_TEST_SKIP_SSL")


### PR DESCRIPTION
## Is there a related GitHub Issue?
#627

## What is this change about?
Fix a bug where the `included` block of the list service bindings call would return apps even if no service bindings matched the service instance guid filter. Also includes some diffs from running `make fmt`.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Follow A/C for #627 and query for service bindings with a service instance guid filter of nonexistent instances. Expect no info returned in the `included` block of the response.

## Tag your pair, your PM, and/or team
paired w/ @julian-hj 
