### PR TITLE
Add a controller debug option to deploy-on-kind script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ docker-build: docker-build-controllers docker-build-api
 docker-build-controllers:
 	docker buildx build --load -f controllers/Dockerfile -t ${IMG_CONTROLLERS} .
 
+docker-build-controllers-debug:
+	docker buildx build --load -f controllers/remote-debug/Dockerfile -t ${IMG_CONTROLLERS} .
+
 docker-build-api:
 	docker buildx build --load -f api/Dockerfile -t ${IMG_API} .
 
@@ -141,6 +144,9 @@ deploy-controllers: install-kustomize build-reference-controllers
 
 deploy-controllers-kind-local: install-kustomize build-reference-controllers
 	$(KUSTOMIZE) build controllers/config/overlays/kind-local-registry | kubectl apply -f -
+
+deploy-controllers-kind-local-debug: install-kustomize build-reference-controllers
+	$(KUSTOMIZE) build controllers/config/overlays/kind-controller-debug | kubectl apply -f -
 
 deploy-api: install-kustomize build-reference-api
 	$(KUSTOMIZE) build api/config/base | kubectl apply -f -

--- a/controllers/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/config/default/manager_auth_proxy_patch.yaml
@@ -19,8 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"

--- a/controllers/config/manager/manager.yaml
+++ b/controllers/config/manager/manager.yaml
@@ -26,7 +26,9 @@ spec:
         runAsNonRoot: true
       containers:
       - args:
-        - --leader-elect
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         image: cloudfoundry/cf-k8s-controllers:latest
         name: manager
         securityContext:
@@ -63,3 +65,4 @@ spec:
           name: cf-k8s-controllers-config
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+

--- a/controllers/config/overlays/kind-controller-debug/kustomization.yaml
+++ b/controllers/config/overlays/kind-controller-debug/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../kind-local-registry
+  - manager_debug_nodeport.yaml
+
+patchesStrategicMerge:
+  - manager_debug_container.yaml

--- a/controllers/config/overlays/kind-controller-debug/manager_debug_container.yaml
+++ b/controllers/config/overlays/kind-controller-debug/manager_debug_container.yaml
@@ -1,0 +1,41 @@
+---
+# This patch sets up the manger container to run Delve and exposes the debug port at
+# :40000
+# It requires the `remote-debug` controller container built with ubuntu and Delve
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: cf-k8s-controllers-system
+  labels:
+    app: cf-k8s-controller-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: cf-k8s-controller-manager
+    spec:
+      securityContext:
+        runAsNonRoot: false
+      containers:
+      - name: manager
+        args:
+        - "/dlv"
+        - "--listen=:40000"
+        - "--headless=true"
+        - "--api-version=2"
+        - "exec"
+        - "/manager"
+        - "--continue"
+        - "--accept-multiclient"
+        - "--"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        securityContext:
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+              - SYS_PTRACE
+

--- a/controllers/config/overlays/kind-controller-debug/manager_debug_nodeport.yaml
+++ b/controllers/config/overlays/kind-controller-debug/manager_debug_nodeport.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-debug-port
+  namespace: cf-k8s-controllers-system
+spec:
+  ports:
+    - name: debug-30051
+      nodePort: 30051
+      port: 30051
+      protocol: TCP
+      targetPort: 40000
+  selector:
+    app: cf-k8s-controller-manager
+  type: NodePort

--- a/controllers/remote-debug/Dockerfile
+++ b/controllers/remote-debug/Dockerfile
@@ -1,0 +1,31 @@
+# syntax = docker/dockerfile:experimental
+FROM golang:1.17.8 as builder
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY controllers/apis controllers/apis/
+COPY controllers/controllers controllers/controllers/
+COPY controllers/coordination controllers/coordination/
+COPY controllers/webhooks controllers/webhooks/
+COPY controllers/config/config.go controllers/config/
+COPY controllers/main.go controllers/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager controllers/main.go
+
+# Get Delve from a GOPATH not from a Go Modules project
+WORKDIR /go/src/
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM ubuntu
+WORKDIR /
+COPY --from=builder /workspace/manager .
+COPY --from=builder /go/bin/dlv .
+
+EXPOSE 8080 8081 9443 40000
+
+CMD ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/manager", '--continue', "--accept-multiclient"]


### PR DESCRIPTION
- the new option is -D or --debug
- when selected, this will rebuild the docker container with Delve and
  deploy it with a port open on 40000
- this change also adds a NodePort for the debug channel, and exposes it
  through Kind on localhost:30051

## Is there a related GitHub Issue?
No, this was a dev-day project last Friday

## What is this change about?
This change adds a remote-debug option to the script that enables developers to debug controllers in-situ

There are a few parts involved:
- a new Dockerfile that builds the controller image on top of Ubuntu instead of distroless, and includes the Delve (`dlv`) executable.
- a Kustomize patch to change the options and command for the controller-manager deployment so that it runs Delve instead of running the controller manager directly.
- a NodePort service that maps the debug port from Delve
- a new port mapping in the Kind cluster to map that port out to the desktop

## Does this PR introduce a breaking change?
Not so far as I am aware

## Acceptance Steps
- run `scripts/deploy-on-kind.sh kind -l -D`
- create a new "Go Remote" debug configuration in VSCode or GoLand that connects to `localhost:30051`
- observe that you can set breakpoints in your controller reconcile loops

## Tag your pair, your PM, and/or team
Anyone interested, PTAL
