### PR TITLE
GetProcessByAppTypeAndSpace now uses a user client

### DIFF
--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -227,6 +227,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	rootNamespace = mustHaveEnv("ROOT_NAMESPACE")
+	appFQDN = mustHaveEnv("APP_FQDN")
+
 	ensureServerIsUp()
 
 	serviceAccountName = generateGUID("token-user")

--- a/controllers/config/cf_roles/cf_admin.yaml
+++ b/controllers/config/cf_roles/cf_admin.yaml
@@ -37,6 +37,7 @@ rules:
   - cfprocesses
   verbs:
   - get
+  - list
 
 - apiGroups:
   - workloads.cloudfoundry.org

--- a/controllers/config/cf_roles/cf_space_developer.yaml
+++ b/controllers/config/cf_roles/cf_space_developer.yaml
@@ -37,6 +37,7 @@ rules:
   - cfprocesses
   verbs:
   - get
+  - list
 
 - apiGroups:
   - workloads.cloudfoundry.org

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1636,6 +1636,7 @@ rules:
   - cfprocesses
   verbs:
   - get
+  - list
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:
@@ -2153,6 +2154,7 @@ rules:
   - cfprocesses
   verbs:
   - get
+  - list
 - apiGroups:
   - workloads.cloudfoundry.org
   resources:


### PR DESCRIPTION
## Is there a related GitHub Issue?
#734

## What is this change about?
This PR updates the `GetProcessByAppTypeAndSpace` function in the process repository to use a user client instead of the privileged client.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #734

## Tag your pair, your PM, and/or team
@acosta11 