### PR TITLE
Routes on shared domains must have a hostname specified

### DIFF
--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Spaces", func() {
 			spaceGUID = createSpace(generateGUID("space"), orgGUID)
 			resultErr = cfErrs{}
 
-			route := "https://manifested-app.vcap.me"
+			route := "manifested-app.vcap.me"
 			command := "whatever"
 			var err error
 			manifestBytes, err = yaml.Marshal(manifestResource{

--- a/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
+++ b/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
@@ -43,6 +43,7 @@ var _ = Describe("CFRouteMutatingWebhook Integration Tests", func() {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.CFRouteSpec{
+					Host: "my-host",
 					DomainRef: v1.ObjectReference{
 						Name:      cfDomainGUID,
 						Namespace: namespace,

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -22,6 +22,7 @@ const (
 	DuplicateRouteError
 	DuplicateDomainError
 	DuplicateServiceInstanceNameError
+	HostNameIsInvalidError
 )
 
 func (w ValidationErrorCode) Marshal() string {
@@ -58,6 +59,8 @@ func (w ValidationErrorCode) GetMessage() string {
 		return "Overlapping domain exists"
 	case DuplicateServiceInstanceNameError:
 		return "CFServiceInstance with same spec.name exists"
+	case HostNameIsInvalidError:
+		return "Missing or Invalid host. Routes in shared domains must have a valid host defined."
 	default:
 		return "An unknown error has occurred"
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/eirini-controller v0.2.0
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/buildpacks/lifecycle v0.13.4
 	github.com/buildpacks/pack v0.24.0
 	github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=


### PR DESCRIPTION
## Is there a related GitHub Issue?
#664 

## What is this change about?
Hostname validation on routes
- validation on the api side was already in place.
- used `govalidator - IsDNSName()`  to validate hostnames on controllers via webhooks

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Follow acceptance on #664 

## Tag your pair, your PM, and/or team
@Birdrock @clintyoshimura @acosta11 
