### PR TITLE
RBAC logic for scale process endpoint

### DIFF
--- a/api/actions/scale_process.go
+++ b/api/actions/scale_process.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"context"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
@@ -20,7 +21,7 @@ func NewScaleProcess(processRepo CFProcessRepository) *ScaleProcess {
 func (a *ScaleProcess) Invoke(ctx context.Context, authInfo authorization.Info, processGUID string, scale repositories.ProcessScaleValues) (repositories.ProcessRecord, error) {
 	process, err := a.processRepo.GetProcess(ctx, authInfo, processGUID)
 	if err != nil {
-		return repositories.ProcessRecord{}, err
+		return repositories.ProcessRecord{}, apierrors.ForbiddenAsNotFound(err)
 	}
 	scaleMessage := repositories.ScaleProcessMessage{
 		GUID:               process.GUID,

--- a/api/actions/scale_process_test.go
+++ b/api/actions/scale_process_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"code.cloudfoundry.org/cf-k8s-controllers/tests/matchers"
 	"context"
 	"errors"
 
@@ -124,6 +125,19 @@ var _ = Describe("ScaleProcessAction", func() {
 			})
 			It("passes through the error", func() {
 				Expect(responseErr).To(Equal(toReturnErr))
+			})
+		})
+
+		When(`the error is "Forbidden"`, func() {
+			BeforeEach(func() {
+				toReturnErr := apierrors.NewForbiddenError(nil, repositories.ProcessResourceType)
+				processRepo.GetProcessReturns(repositories.ProcessRecord{}, toReturnErr)
+			})
+			It("returns an empty record", func() {
+				Expect(responseRecord).To(Equal(repositories.ProcessRecord{}))
+			})
+			It("wraps the error as NotFound", func() {
+				Expect(responseErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
 			})
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
[#625]

## What is this change about?
- this is primarily a testing change, since the scale and get methods
  for the process repository already use the user client.
- the exception is in the handler code where we were missing a 403->404
  translation.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
[#625]

## Tag your pair, your PM, and/or team
soloing at EOD... @gcapizzi @kieron-dev PTAL if you get a chance
