### PR TITLE
Fix CLI errors during space creation

### DIFF
--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -109,9 +109,10 @@ func (r *RoleRepo) CreateRole(ctx context.Context, authInfo authorization.Info, 
 	err = userClient.Create(ctx, &roleBinding)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
+			errorDetail := fmt.Sprintf("User '%s' already has '%s' role", role.User, role.Type)
 			return RoleRecord{}, apierrors.NewUnprocessableEntityError(
-				fmt.Errorf("rolebinging %s:%s already exists", roleBinding.Namespace, roleBinding.Name),
-				"RoleBinding with that name already exists",
+				fmt.Errorf("rolebinding %s:%s already exists", roleBinding.Namespace, roleBinding.Name),
+				errorDetail,
 			)
 		}
 		return RoleRecord{}, fmt.Errorf("failed to assign user %q to role %q: %w", role.User, role.Type, apierrors.FromK8sError(err, RoleResourceType))

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -194,10 +194,10 @@ var _ = Describe("RoleRepository", func() {
 						Org:  roleCreateMessage.Org,
 					}
 					_, createErr = roleRepo.CreateRole(ctx, authInfo, anotherRoleCreateMessage)
-					Expect(createErr).To(SatisfyAll(
-						BeAssignableToTypeOf(apierrors.UnprocessableEntityError{}),
-						MatchError(ContainSubstring("already exists")),
-					))
+					var apiErr apierrors.UnprocessableEntityError
+					Expect(errors.As(createErr, &apiErr)).To(BeTrue())
+					// Note: the cf cli expects this specific format and ignores the error if it matches it.
+					Expect(apiErr.Detail()).To(Equal("User 'myuser@example.com' already has 'organization_manager' role"))
 				})
 			})
 		})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#819 

## What is this change about?
The CF CLI expects a specific error detail when adding a user to a role they are already a member of and will not ignore the error otherwise. This commit restores the expected error detail format so that the CLI will ignore the error.
[#819]

## Does this PR introduce a breaking change?
no, but it does introduce a **fixing** change

## Acceptance Steps
#819 

## Tag your pair, your PM, and/or team
@clintyoshimura @danail-branekov @kieron-dev @georgethebeatle PTAL
