### PR TITLE
Update create space exists error to match the cli

### DIFF
--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -212,7 +212,8 @@ func (r *OrgRepo) CreateSpace(ctx context.Context, info authorization.Info, mess
 	)
 	if err != nil {
 		if webhooks.HasErrorCode(err, webhooks.DuplicateSpaceNameError) {
-			errorDetail := fmt.Sprintf("Space '%s' already exists.", message.Name)
+			// Note: the cf cli expects the specific text 'Name must be unique per organization' in the error and ignores the error if it matches it.
+			errorDetail := fmt.Sprintf("Space '%s' already exists. Name must be unique per organization.", message.Name)
 			return SpaceRecord{}, apierrors.NewUnprocessableEntityError(err, errorDetail)
 		}
 		return SpaceRecord{}, err

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Spaces", func() {
 			It("returns an unprocessable entity error", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(resultErr.Errors).To(ConsistOf(cfErr{
-					Detail: fmt.Sprintf(`Space '%s' already exists.`, spaceName),
+					Detail: fmt.Sprintf(`Space '%s' already exists. Name must be unique per organization.`, spaceName),
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))


### PR DESCRIPTION
## Is there a related GitHub Issue?
#820 

## What is this change about?
Fixes an issue where the v3 cf client expects a different error message to indicate that a create space command failed because the space already exists. Because the error message didn't contain the expected substring, the cli no longer ignored the error and the command failed.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
See bug acceptance criteria

## Tag your pair, your PM, and/or team
@julian-hj 
