### PR TITLE
Reduce flakes in space list e2e tests

### DIFF
--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -114,6 +114,12 @@ var _ = Describe("Spaces", func() {
 		)
 
 		BeforeEach(func() {
+			org1GUID, org2GUID, org3GUID = "", "", ""
+			space11GUID, space12GUID, space13GUID = "", "", ""
+			space21GUID, space22GUID, space23GUID = "", "", ""
+			space31GUID, space32GUID, space33GUID = "", "", ""
+			result = resourceList{}
+
 			var orgWG sync.WaitGroup
 			orgErrChan := make(chan error, 3)
 			query = make(map[string]string)
@@ -193,11 +199,9 @@ var _ = Describe("Spaces", func() {
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(space31Name)}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal(space32Name)}),
 			))
-			Expect(result.Resources).ToNot(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal(space13Name)}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal(space23Name)}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal(space33Name)}),
-			))
+			Expect(result.Resources).ToNot(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(space13Name)})))
+			Expect(result.Resources).ToNot(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(space23Name)})))
+			Expect(result.Resources).ToNot(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(space33Name)})))
 		})
 
 		When("filtering by organization GUIDs", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
no

## What is this change about?
We see a frequent errors in the space list tests that suggest either uninitialized variables in beforeEach or cross-contamination of the environment in parallel tests or both.

This PR attempts to clean those up by making the "list all spaces" test more resilient to extra spaces and by initializing a lot of local variables that could be leaking results from one test to the next in a single thread.

## Does this PR introduce a breaking change?
no

## Acceptance Steps
run e2e in the CI a bunch of times. There shouldn't be flakes in the space list tests anymore.
