### PR TITLE
Add FQDN validation on routes to api and webhook

### DIFF
--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/networking"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
@@ -158,6 +159,12 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, r *http.R
 			"Invalid domain. Ensure that the domain exists and you have access to it.",
 			apierrors.NotFoundError{},
 		)
+	}
+
+	_, err = networking.IsFQDN(payload.Host, domain.Name)
+	if err != nil {
+		h.logger.Info(err.Error(), "HostName", payload.Host, "Domain Name", domain.Name)
+		return nil, apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("Invalid Route, %v", err.Error()))
 	}
 
 	createRouteMessage := payload.ToMessage(domain.Namespace, domain.Name)

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -806,6 +806,34 @@ var _ = Describe("RouteHandler", func() {
 			})
 		})
 
+		When("the FQDN is invalid with invalid characters", func() {
+			BeforeEach(func() {
+				domainRepo.GetDomainReturns(repositories.DomainRecord{
+					GUID: testDomainGUID,
+					Name: "this-is-@n-inv@lid-dom@in-n@me",
+				}, nil)
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError("Invalid Route, FQDN does not comply with RFC 1035 standards")
+			})
+
+		})
+
+		When("the FQDN is invalid with invalid length", func() {
+			BeforeEach(func() {
+				domainRepo.GetDomainReturns(repositories.DomainRecord{
+					GUID: testDomainGUID,
+					Name: "a-very-looooooooooooong-invalid-domain-name-that-should-fail-validation",
+				}, nil)
+			})
+
+			It("returns an error", func() {
+				expectUnprocessableEntityError("Invalid Route, subdomains must each be at most 63 characters")
+			})
+
+		})
+
 		When("the path is missing a leading /", func() {
 			BeforeEach(func() {
 				requestBody = `{

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Routes", func() {
 
 		spaceGUID = createSpace(generateGUID("space"), orgGUID)
 
-		domainName = generateGUID("domain-name")
+		domainName = generateGUID("domain.name")
 		domainGUID = createDomain(domainName)
 
 		host = generateGUID("myapp")
@@ -227,6 +227,22 @@ var _ = Describe("Routes", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(createErr.Errors).To(ConsistOf(cfErr{
 					Detail: fmt.Sprintf("Route already exists with host '%s' for domain '%s'.", host, domainName),
+					Title:  "CF-UnprocessableEntity",
+					Code:   10008,
+				}))
+			})
+		})
+
+		When("the FQDN on the route is invalid", func() {
+			BeforeEach(func() {
+				domainName = generateGUID("inv@lid.dom@in.n@me")
+				domainGUID = createDomain(domainName)
+			})
+
+			It("fails with a invalid route error", func() {
+				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
+				Expect(createErr.Errors).To(ConsistOf(cfErr{
+					Detail: "Invalid Route, FQDN does not comply with RFC 1035 standards",
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))

--- a/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
+++ b/controllers/apis/networking/v1alpha1/integration/cfroute_webhook_integration_test.go
@@ -33,6 +33,17 @@ var _ = Describe("CFRouteMutatingWebhook Integration Tests", func() {
 			cfDomainGUID = GenerateGUID()
 			cfRouteGUID = GenerateGUID()
 
+			cfDomain := &v1alpha1.CFDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfDomainGUID,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.CFDomainSpec{
+					Name: "example.com",
+				},
+			}
+			Expect(k8sClient.Create(testCtx, cfDomain)).To(Succeed())
+
 			cfRoute := &v1alpha1.CFRoute{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CFRoute",

--- a/controllers/apis/networking/v1alpha1/integration/webhook_suite_integration_test.go
+++ b/controllers/apis/networking/v1alpha1/integration/webhook_suite_integration_test.go
@@ -95,11 +95,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect((&networkingv1alpha1.CFRoute{}).SetupWebhookWithManager(mgr)).To(Succeed())
+	Expect(networking.NewCFDomainValidation(mgr.GetClient()).SetupWebhookWithManager(mgr)).To(Succeed())
 
 	cfRootNamespace = "default"
 	Expect(networking.NewCFRouteValidation(
 		webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), networking.RouteEntityType)),
 		cfRootNamespace,
+		mgr.GetClient(),
 	).SetupWebhookWithManager(mgr)).To(Succeed())
 
 	//+kubebuilder:scaffold:webhook

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -240,6 +240,7 @@ func main() {
 		if err = networking.NewCFRouteValidation(
 			webhooks.NewDuplicateValidator(coordination.NewNameRegistry(mgr.GetClient(), networking.RouteEntityType)),
 			controllerConfig.CFRootNamespace,
+			mgr.GetClient(),
 		).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CFRoute")
 			os.Exit(1)

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -22,7 +22,6 @@ const (
 	DuplicateRouteError
 	DuplicateDomainError
 	DuplicateServiceInstanceNameError
-	HostNameIsInvalidError
 )
 
 func (w ValidationErrorCode) Marshal() string {
@@ -59,8 +58,6 @@ func (w ValidationErrorCode) GetMessage() string {
 		return "Overlapping domain exists"
 	case DuplicateServiceInstanceNameError:
 		return "CFServiceInstance with same spec.name exists"
-	case HostNameIsInvalidError:
-		return "Missing or Invalid host. Routes in shared domains must have a valid host defined."
 	default:
 		return "An unknown error has occurred"
 	}

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -3,15 +3,17 @@ package networking
 import (
 	"context"
 	"errors"
+	"regexp"
 	"strings"
 
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
 
-	. "github.com/asaskevich/govalidator"
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -38,12 +40,14 @@ type CFRouteValidation struct {
 	decoder            *admission.Decoder
 	rootNamespace      string
 	duplicateValidator NameValidator
+	Client             client.Client
 }
 
-func NewCFRouteValidation(nameValidator NameValidator, rootNamespace string) *CFRouteValidation {
+func NewCFRouteValidation(nameValidator NameValidator, rootNamespace string, client client.Client) *CFRouteValidation {
 	return &CFRouteValidation{
 		duplicateValidator: nameValidator,
 		rootNamespace:      rootNamespace,
+		Client:             client,
 	}
 }
 
@@ -77,14 +81,24 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 	var validatorErr error
 	switch req.Operation {
 	case admissionv1.Create:
-		if !IsDNSName(route.Spec.Host) {
-			return admission.Denied(webhooks.HostNameIsInvalidError.Marshal())
+		_, err := isHost(route.Spec.Host)
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+		_, err = v.isFQDN(route)
+		if err != nil {
+			return admission.Denied(err.Error())
 		}
 		validatorErr = v.duplicateValidator.ValidateCreate(ctx, logger, v.rootNamespace, uniqueName(route))
 
 	case admissionv1.Update:
-		if !IsDNSName(route.Spec.Host) {
-			return admission.Denied(webhooks.HostNameIsInvalidError.Marshal())
+		_, err := isHost(route.Spec.Host)
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+		_, err = v.isFQDN(route)
+		if err != nil {
+			return admission.Denied(err.Error())
 		}
 		validatorErr = v.duplicateValidator.ValidateUpdate(ctx, logger, v.rootNamespace, uniqueName(oldRoute), uniqueName(route))
 
@@ -112,4 +126,70 @@ func uniqueName(route networkingv1alpha1.CFRoute) string {
 func (v *CFRouteValidation) InjectDecoder(d *admission.Decoder) error {
 	v.decoder = d
 	return nil
+}
+
+func (v *CFRouteValidation) isFQDN(cfRoute networkingv1alpha1.CFRoute) (bool, error) {
+	var cfDomain networkingv1alpha1.CFDomain
+	ctx := context.Background()
+	err := v.Client.Get(ctx, types.NamespacedName{Name: cfRoute.Spec.DomainRef.Name, Namespace: cfRoute.Spec.DomainRef.Namespace}, &cfDomain)
+	if err != nil {
+		return false, err
+	}
+
+	return IsFQDN(cfRoute.Spec.Host, cfDomain.Spec.Name)
+}
+
+func isHost(hostname string) (bool, error) {
+	const (
+		// HOST_REGEX - Must be either "*" or contain only alphanumeric characters, "_", or "-"
+		HOST_REGEX                  = "^([\\w\\-]+|\\*)?$"
+		MAXIMUM_DOMAIN_LABEL_LENGTH = 63
+	)
+
+	rxHost := regexp.MustCompile(HOST_REGEX)
+
+	if len(hostname) == 0 {
+		return false, errors.New("host cannot be empty")
+	}
+
+	if len(hostname) > MAXIMUM_DOMAIN_LABEL_LENGTH {
+		return false, errors.New("host is too long (maximum is 63 characters)")
+	}
+
+	if !rxHost.MatchString(hostname) {
+		return false, errors.New("host must be either \"*\" or contain only alphanumeric characters, \"_\", or \"-\"")
+	}
+
+	return true, nil
+}
+
+func IsFQDN(host, domain string) (bool, error) {
+	const (
+		// MAXIMUM_FQDN_DOMAIN_LENGTH - The maximum fully-qualified domain length is 255 including separators, but this includes two "invisible"
+		// characters at the beginning and end of the domain, so for string comparisons, the correct length is 253.
+		//
+		// The first character denotes the length of the first label, and the last character denotes the termination
+		// of the domain.
+		MAXIMUM_FQDN_DOMAIN_LENGTH = 253
+		MINIMUM_FQDN_DOMAIN_LENGTH = 3
+		DOMAIN_REGEX               = "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])\\.)+([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])$"
+		SUBDOMAIN_REGEX            = "^([^\\.]{0,63}\\.)*[^\\.]{0,63}$"
+	)
+
+	fqdn := host + "." + domain
+
+	rxSubdomain := regexp.MustCompile(SUBDOMAIN_REGEX)
+
+	if !rxSubdomain.MatchString(fqdn) {
+		return false, errors.New("subdomains must each be at most 63 characters")
+	}
+
+	rxDomain := regexp.MustCompile(DOMAIN_REGEX)
+	fqdnLength := len(fqdn)
+
+	if fqdnLength < MINIMUM_FQDN_DOMAIN_LENGTH || fqdnLength > MAXIMUM_FQDN_DOMAIN_LENGTH || !rxDomain.MatchString(fqdn) {
+		return false, errors.New("FQDN does not comply with RFC 1035 standards")
+	}
+
+	return true, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	code.cloudfoundry.org/eirini-controller v0.2.0
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/buildpacks/lifecycle v0.13.5
 	github.com/buildpacks/pack v0.24.0
 	github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -283,7 +283,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#754 

## What is this change about?
Validates FQDN on routes and also improves existing Hostname validation on routes

- added IsFQDN() for validating `host + "." + domain` value.
- IsHost() checks for validity of hostnames on routes
- removed the `HostNameIsInvalidError` as it is not being used by api repositories.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Follow acceptance steps on #754 

## Tag your pair, your PM, and/or team

