### PR TITLE
Retry domain installation in `deploy-on-kind.sh`

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+retry() {
+  until $@; do
+    echo -n .
+    sleep 1
+  done
+  echo
+}

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -10,6 +10,8 @@ export PATH="${PATH}:${API_DIR}/bin"
 
 OPENSSL_VERSION="$(openssl version | awk '{ print $1 }')"
 
+source "$SCRIPT_DIR/common.sh"
+
 function usage_text() {
   cat <<EOF
 Usage:
@@ -251,7 +253,7 @@ function deploy_cf_k8s_controllers() {
   popd >/dev/null
 
   if [[ -n "${default_domain}" ]]; then
-    kubectl apply -f "${CONTROLLER_DIR}/config/samples/cfdomain.yaml"
+    retry kubectl apply -f "${CONTROLLER_DIR}/config/samples/cfdomain.yaml"
   fi
 }
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEP_DIR="$(cd "${SCRIPT_DIR}/../dependencies" && pwd)"
 
+source "$SCRIPT_DIR/common.sh"
+
 function usage_text() {
   cat <<EOF
 Usage:
@@ -122,14 +124,6 @@ chmod +x "${HNC_BIN}/kubectl-hns"
 
 kubectl apply -f "https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/${HNC_VERSION}/hnc-manager.yaml"
 kubectl rollout status deployment/hnc-controller-manager -w -n hnc-system
-
-retry() {
-  until $@; do
-    echo -n .
-    sleep 1
-  done
-  echo
-}
 
 # Hierarchical namespace controller is quite asynchronous. There is no
 # guarantee that the operations below would succeed on first invocation,

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -24,20 +24,20 @@ EOF
 while [[ $# -gt 0 ]]; do
   i=$1
   case $i in
-  -g=* | --gcr-service-account-json=*)
-    GCP_SERVICE_ACCOUNT_JSON_FILE="${i#*=}"
-    shift
-    ;;
-  -g | --gcr-service-account-json)
-    GCP_SERVICE_ACCOUNT_JSON_FILE="${2}"
-    shift
-    shift
-    ;;
-  *)
-    echo -e "Error: Unknown flag: ${i/=*/}\n" >&2
-    usage_text >&2
-    exit 1
-    ;;
+    -g=* | --gcr-service-account-json=*)
+      GCP_SERVICE_ACCOUNT_JSON_FILE="${i#*=}"
+      shift
+      ;;
+    -g | --gcr-service-account-json)
+      GCP_SERVICE_ACCOUNT_JSON_FILE="${2}"
+      shift
+      shift
+      ;;
+    *)
+      echo -e "Error: Unknown flag: ${i/=*/}\n" >&2
+      usage_text >&2
+      exit 1
+      ;;
   esac
 done
 


### PR DESCRIPTION
This uses the `retry` utility function to retry the installation of the default `vcap.me` domain when `deploy-on-kind.sh` is invoked with `-d`.

Given `retry` was defined in `install-dependencies.sh`, I extracted it to a `common.sh` file and `source`d it in both scripts.