### PR TITLE
Fix incorrect conversion of an integer

### DIFF
--- a/controllers/controllers/workloads/imageprocessfetcher/image_process_fetcher.go
+++ b/controllers/controllers/workloads/imageprocessfetcher/image_process_fetcher.go
@@ -3,7 +3,6 @@ package imageprocessfetcher
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
@@ -14,6 +13,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"k8s.io/utils/net"
 )
 
 type ImageProcessFetcher struct {
@@ -74,12 +74,11 @@ func extractExposedPorts(imageConfig *v1.Config) ([]int32, error) {
 	// Drop the protocol since we only use TCP (the default) and only store the port number
 	ports := []int32{}
 	for port := range imageConfig.ExposedPorts {
-		portInt, err := strconv.Atoi(port)
+		parsed, err := net.ParsePort(port, false)
 		if err != nil {
 			return []int32{}, err
 		}
-		ports = append(ports, int32(portInt))
+		ports = append(ports, int32(parsed))
 	}
-
 	return ports, nil
 }


### PR DESCRIPTION
## Is there a related GitHub Issue?
No.

## What is this change about?
Use `k8s.io/utils/net` `ParsePort` to  correctly parse and convert port numbers in `image_process_fetcher.go`

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
Run tests as normal.

## Tag your pair, your PM, and/or team
@tcdowney @gnovv @davewalter 