### PR TITLE
Volume mount serviceBinding credentials onto workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ subnamespaces.
 kubectl hns config set-resource secrets --mode Propagate
 ```
 
+---
+## Optional: Install Service Bindings Controller
+
+Cloud Native Buildpacks and other app frameworks (such as [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings)) are adopting the [K8s ServiceBinding spec](https://github.com/servicebinding/spec#workload-projection) model of volume mounted secrets. 
+We currently are providing apps access to these via the `VCAP_SERVICES` environment variable ([see this issue](https://github.com/cloudfoundry/cf-k8s-controllers/issues/462)) for backwards compatibility reasons.
+We would also want to support the newer developments in the ServiceBinding ecosystem as well.
+
+We are not implementing this ourselves but allowing controller that adopts the [ServiceBinding Spec](https://github.com/servicebinding/spec) that volume mounts secrets to workload containers to be used. 
+We have tested with [this Service Binding reconciler](https://github.com/vmware-labs/service-bindings). Install it using 
+
+```sh
+kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
+```
+
+---
 # Installation
 ## Configure cf-k8s-controllers
 Configuration file for cf-k8s-controllers is at `controllers/config/base/controllersconfig/cf_k8s_controllers_config.yaml`

--- a/controllers/config/rbac/cfservicebinding_reconciler_role.yaml
+++ b/controllers/config/rbac/cfservicebinding_reconciler_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cfservicebinding-reconciler-role
+  labels:
+    servicebinding.io/controller: "true" # matches the aggregation rule selector
+rules:
+- apiGroups:
+  - services.cloudfoundry.org
+  resources:
+  - cfservicebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/controllers/config/rbac/kustomization.yaml
+++ b/controllers/config/rbac/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- cfservicebinding_reconciler_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -1724,6 +1724,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    servicebinding.io/controller: "true"
+  name: cf-k8s-controllers-cfservicebinding-reconciler-role
+rules:
+- apiGroups:
+  - services.cloudfoundry.org
+  resources:
+  - cfservicebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   creationTimestamp: null
   name: cf-k8s-controllers-manager-role
 rules:

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -166,6 +166,12 @@ helm template eirini-controller "${EIRINI_DIR}/deployment/helm" \
   --set "images.eirini_controller=eirini/eirini-controller@sha256:42e22b3222e9b3788782f5c141d260a5e163da4f4032e2926752ef2e5bae0685" \
   --namespace "eirini-controller" | kubectl apply -f -
 
+echo "**************************************"
+echo "Installing Service Binding Controller"
+echo "**************************************"
+
+kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
+
 echo "******"
 echo "Done"
 echo "******"


### PR DESCRIPTION




<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
closes #746 

## What is this change about?
Volume mount serviceBinding credentials onto workloads
- Add ClusterRole required by the ServiceBinding Controller to fetch the referenced CFServiceBinding object
- Add installation of ServiceBinding controller to `deploy-on-kind` script.
- Update README with manual installation instructions

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
no

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
see issue

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@gnovv 


