### PR TITLE
Check for route destinations outside the space

### DIFF
--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -373,6 +373,9 @@ func (f *RouteRepo) AddDestinationsToRoute(ctx context.Context, authInfo authori
 
 	err = userClient.Patch(ctx, cfRoute, client.MergeFrom(baseCFRoute))
 	if err != nil {
+		if webhooks.HasErrorCode(err, webhooks.RouteDestinationNotInSpace) {
+			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, "Routes cannot be mapped to destinations in different spaces.")
+		}
 		return RouteRecord{}, fmt.Errorf("failed to add destination to route %q: %w", message.RouteGUID, apierrors.FromK8sError(err, RouteResourceType))
 	}
 

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -852,3 +852,14 @@ func expectForbiddenError(resp *resty.Response, errResp cfErrs) {
 		},
 	))
 }
+
+func expectUnprocessableEntityError(resp *resty.Response, errResp cfErrs, detail string) {
+	Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
+	Expect(errResp.Errors).To(ConsistOf(
+		cfErr{
+			Detail: detail,
+			Title:  "CF-UnprocessableEntity",
+			Code:   10008,
+		},
+	))
+}

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -22,6 +22,7 @@ const (
 	DuplicateRouteError
 	DuplicateDomainError
 	DuplicateServiceInstanceNameError
+	RouteDestinationNotInSpace
 )
 
 func (w ValidationErrorCode) Marshal() string {
@@ -58,6 +59,8 @@ func (w ValidationErrorCode) GetMessage() string {
 		return "Overlapping domain exists"
 	case DuplicateServiceInstanceNameError:
 		return "CFServiceInstance with same spec.name exists"
+	case RouteDestinationNotInSpace:
+		return "Route destination app not found in space"
 	default:
 		return "An unknown error has occurred"
 	}


### PR DESCRIPTION
## Is there a related GitHub Issue?
#837 

## What is this change about?

In the route validating webhhook, check that all apps in the
destinations list are in the route's namespace.

Where an app is not found in the namespace, translate that to an API
unprocessable entity error

## Does this PR introduce a breaking change?
No

## Acceptance Steps
See #837

## Tag your pair, your PM, and/or team

## Things to remember
