### PR TITLE
Validate CFRoute path

### DIFF
--- a/api/apis/shared.go
+++ b/api/apis/shared.go
@@ -11,13 +11,15 @@ import (
 	"code.cloudfoundry.org/bytefmt"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-http-utils/headers"
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -51,8 +53,9 @@ func (dv *DecoderValidator) DecodeAndValidateJSONPayload(r *http.Request, object
 		var unmarshalTypeError *json.UnmarshalTypeError
 		switch {
 		case errors.As(err, &unmarshalTypeError):
-			Logger.Error(err, fmt.Sprintf("Request body contains an invalid value for the %q field (should be of type %v)", strings.Title(unmarshalTypeError.Field), unmarshalTypeError.Type))
-			return apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("%v must be a %v", strings.Title(unmarshalTypeError.Field), unmarshalTypeError.Type))
+			titler := cases.Title(language.AmericanEnglish)
+			Logger.Error(err, fmt.Sprintf("Request body contains an invalid value for the %q field (should be of type %v)", titler.String(unmarshalTypeError.Field), unmarshalTypeError.Type))
+			return apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("%v must be a %v", titler.String(unmarshalTypeError.Field), unmarshalTypeError.Type))
 		case strings.HasPrefix(err.Error(), "json: unknown field"):
 			// check whether the message matches an "unknown field" error. If so, 422. Else, 400
 			Logger.Error(err, fmt.Sprintf("Unknown field in JSON body: %T: %q", err, err.Error()))

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -313,14 +313,8 @@ func (f *RouteRepo) CreateRoute(ctx context.Context, authInfo authorization.Info
 
 	err = userClient.Create(ctx, &cfRoute)
 	if err != nil {
-		if webhooks.HasErrorCode(err, webhooks.DuplicateRouteError) {
-			pathDetails := ""
-			if message.Path != "" {
-				pathDetails = fmt.Sprintf(" and path '%s'", message.Path)
-			}
-			errorDetail := fmt.Sprintf("Route already exists with host '%s'%s for domain '%s'.",
-				message.Host, pathDetails, message.DomainName)
-			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, errorDetail)
+		if webhooks.IsValidationError(err) {
+			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, webhooks.GetErrorMessage(err))
 		}
 		return RouteRecord{}, apierrors.FromK8sError(err, RouteResourceType)
 	}

--- a/controllers/config/samples/cfroute.yaml
+++ b/controllers/config/samples/cfroute.yaml
@@ -9,6 +9,7 @@ spec:
   protocol: http
   domainRef:
     name: 5b5032ab-7fc8-4da5-b853-821fd1879201
+    namespace: cf
   # This array of destinations starts empty and is filled by CF Shim endpoints for /v3/routes/:guid/destinations
   destinations:
     - guid: 8ad77ef4-53d5-117a-b640-0ae227a13f35

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -53,43 +53,43 @@ controllers_debug=""
 while [[ $# -gt 0 ]]; do
   i=$1
   case $i in
-    -l | --use-local-registry)
-      use_local_registry="true"
-      shift
-      ;;
-    -c | --controllers-only)
-      controllers_only="true"
-      shift
-      ;;
-    -a | --api-only)
-      api_only="true"
-      shift
-      ;;
-    -d | --default-domain)
-      default_domain="true"
-      shift
-      ;;
-    -D | --debug)
-      controllers_debug="true"
-      shift
-      ;;
-    -v | --verbose)
-      set -x
-      shift
-      ;;
-    -h | --help | help)
+  -l | --use-local-registry)
+    use_local_registry="true"
+    shift
+    ;;
+  -c | --controllers-only)
+    controllers_only="true"
+    shift
+    ;;
+  -a | --api-only)
+    api_only="true"
+    shift
+    ;;
+  -d | --default-domain)
+    default_domain="true"
+    shift
+    ;;
+  -D | --debug)
+    controllers_debug="true"
+    shift
+    ;;
+  -v | --verbose)
+    set -x
+    shift
+    ;;
+  -h | --help | help)
+    usage_text >&2
+    exit 0
+    ;;
+  *)
+    if [[ -n "${cluster}" ]]; then
+      echo -e "Error: Unexpected argument: ${i/=*/}\n" >&2
       usage_text >&2
-      exit 0
-      ;;
-    *)
-      if [[ -n "${cluster}" ]]; then
-        echo -e "Error: Unexpected argument: ${i/=*/}\n" >&2
-        usage_text >&2
-        exit 1
-      fi
-      cluster=$1
-      shift
-      ;;
+      exit 1
+    fi
+    cluster=$1
+    shift
+    ;;
   esac
 done
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -24,20 +24,20 @@ EOF
 while [[ $# -gt 0 ]]; do
   i=$1
   case $i in
-    -g=* | --gcr-service-account-json=*)
-      GCP_SERVICE_ACCOUNT_JSON_FILE="${i#*=}"
-      shift
-      ;;
-    -g | --gcr-service-account-json)
-      GCP_SERVICE_ACCOUNT_JSON_FILE="${2}"
-      shift
-      shift
-      ;;
-    *)
-      echo -e "Error: Unknown flag: ${i/=*/}\n" >&2
-      usage_text >&2
-      exit 1
-      ;;
+  -g=* | --gcr-service-account-json=*)
+    GCP_SERVICE_ACCOUNT_JSON_FILE="${i#*=}"
+    shift
+    ;;
+  -g | --gcr-service-account-json)
+    GCP_SERVICE_ACCOUNT_JSON_FILE="${2}"
+    shift
+    shift
+    ;;
+  *)
+    echo -e "Error: Unknown flag: ${i/=*/}\n" >&2
+    usage_text >&2
+    exit 1
+    ;;
   esac
 done
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
#755 

## What is this change about?
Validates routes according to Cloud Controller rules.

## Does this PR introduce a breaking change?
It should not break anything currently existing. Previously valid routes may fail validation on update; this would require updating to a valid route.

## Acceptance Steps
* Run tests as normal.
* `cf create-route ... --path <some path>`
* `kubectl apply -f <some CFRoute>`

## Tag your pair, your PM, and/or team
@tcdowney @acosta11 @davewalter 
