### PR TITLE
Fix flaky service instance delete e2e test

### DIFF
--- a/api/tests/e2e/service_instances_test.go
+++ b/api/tests/e2e/service_instances_test.go
@@ -123,13 +123,14 @@ var _ = Describe("Service Instances", func() {
 			})
 
 			It("deletes the service instance", func() {
-				serviceInstances := listServiceInstances()
-				Expect(serviceInstances.Resources).NotTo(ContainElement(
+				Eventually(func() []resource {
+					return listServiceInstances().Resources
+				}).ShouldNot(ContainElement(
 					MatchFields(IgnoreExtras, Fields{
 						"Name": Equal(existingInstanceName),
 						"GUID": Equal(existingInstanceGUID),
-					})),
-				)
+					}),
+				))
 			})
 		})
 


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Fix service instance delete e2e test to use eventually to reduce the number of flakes

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
The e2e service instance delete test passes consistently

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@matt-royal 
