### PR TITLE
Fix FQDN Validation Bug

### DIFF
--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -11,8 +11,6 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/networking"
-
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
@@ -159,12 +157,6 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, r *http.R
 			"Invalid domain. Ensure that the domain exists and you have access to it.",
 			apierrors.NotFoundError{},
 		)
-	}
-
-	_, err = networking.IsFQDN(payload.Host, domain.Name)
-	if err != nil {
-		h.logger.Info(err.Error(), "HostName", payload.Host, "Domain Name", domain.Name)
-		return nil, apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("Invalid Route, %v", err.Error()))
 	}
 
 	createRouteMessage := payload.ToMessage(domain.Namespace, domain.Name)

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -806,32 +806,6 @@ var _ = Describe("RouteHandler", func() {
 			})
 		})
 
-		When("the FQDN is invalid with invalid characters", func() {
-			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{
-					GUID: testDomainGUID,
-					Name: "this-is-@n-inv@lid-dom@in-n@me",
-				}, nil)
-			})
-
-			It("returns an error", func() {
-				expectUnprocessableEntityError("Invalid Route, FQDN does not comply with RFC 1035 standards")
-			})
-		})
-
-		When("the FQDN is invalid with invalid length", func() {
-			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{
-					GUID: testDomainGUID,
-					Name: "a-very-looooooooooooong-invalid-domain-name-that-should-fail-validation",
-				}, nil)
-			})
-
-			It("returns an error", func() {
-				expectUnprocessableEntityError("Invalid Route, subdomains must each be at most 63 characters")
-			})
-		})
-
 		When("the path is missing a leading /", func() {
 			BeforeEach(func() {
 				requestBody = `{

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -316,6 +316,9 @@ func (f *RouteRepo) CreateRoute(ctx context.Context, authInfo authorization.Info
 		if webhooks.IsValidationError(err) {
 			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, webhooks.GetErrorMessage(err))
 		}
+		if webhooks.HasErrorCode(err, webhooks.RouteFQDNInvalidError) {
+			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("Invalid Route, %s", webhooks.RouteFQDNInvalidError.GetMessage()))
+		}
 		return RouteRecord{}, apierrors.FromK8sError(err, RouteResourceType)
 	}
 

--- a/api/repositories/route_repository.go
+++ b/api/repositories/route_repository.go
@@ -316,9 +316,6 @@ func (f *RouteRepo) CreateRoute(ctx context.Context, authInfo authorization.Info
 		if webhooks.IsValidationError(err) {
 			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, webhooks.GetErrorMessage(err))
 		}
-		if webhooks.HasErrorCode(err, webhooks.RouteFQDNInvalidError) {
-			return RouteRecord{}, apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("Invalid Route, %s", webhooks.RouteFQDNInvalidError.GetMessage()))
-		}
 		return RouteRecord{}, apierrors.FromK8sError(err, RouteResourceType)
 	}
 

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a invalid route error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: "Invalid Route, FQDN does not comply with RFC 1035 standards",
+						Detail: "Invalid Route, Route FQDN does not comply with RFC 1035 standards",
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -94,10 +94,9 @@ func IsValidationError(err error) bool {
 	if statusError := new(k8serrors.StatusError); errors.As(err, &statusError) {
 		reason := statusError.Status().Reason
 
-		val := new(ValidationErrorCode)
-		val.Unmarshall(string(reason))
+		errorCode := ExtractCodeFromErrorReason(string(reason))
 
-		if *val != UnknownError {
+		if errorCode != UnknownError {
 			return true
 		}
 	}

--- a/controllers/webhooks/cf_validation_errors_test.go
+++ b/controllers/webhooks/cf_validation_errors_test.go
@@ -18,24 +18,18 @@ var _ = Describe("CFWebhookValidationError", func() {
 	})
 
 	It("Unmarshals UnknownError", func() {
-		e := new(webhooks.ValidationErrorCode)
 		p := `{"code":0}`
-		e.Unmarshall(p)
-		Expect(*e).To(Equal(webhooks.UnknownError))
+		Expect(webhooks.ExtractCodeFromErrorReason(p)).To(Equal(webhooks.UnknownError))
 	})
 
 	It("Unmarshals DuplicateAppError", func() {
-		e := new(webhooks.ValidationErrorCode)
 		p := `{"code":1}`
-		e.Unmarshall(p)
-		Expect(*e).To(Equal(webhooks.DuplicateAppError))
+		Expect(webhooks.ExtractCodeFromErrorReason(p)).To(Equal(webhooks.DuplicateAppError))
 	})
 
 	It("Handles malformed json payloads", func() {
-		e := new(webhooks.ValidationErrorCode)
 		p := `{"code":1`
-		e.Unmarshall(p)
-		Expect(*e).To(Equal(webhooks.UnknownError))
+		Expect(webhooks.ExtractCodeFromErrorReason(p)).To(Equal(webhooks.UnknownError))
 	})
 })
 

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -131,7 +131,7 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 		}
 		err = validatePath(route)
 		if err != nil {
-			return admission.Denied(err.Error())
+			return admission.Denied(webhooks.RouteFQDNInvalidError.Marshal())
 		}
 
 		if err := v.checkDestinationsExistInNamespace(ctx, route); err != nil {
@@ -172,7 +172,7 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 }
 
 func uniqueName(route networkingv1alpha1.CFRoute) string {
-	return strings.Join([]string{strings.ToLower(route.Spec.Host), route.Spec.DomainRef.Namespace, route.Spec.DomainRef.Name, route.Spec.Path}, "::")
+	return strings.Join([]string{strings.ToLower(route.Spec.Host), route.Spec.DomainRef.Namespace, strings.ToLower(route.Spec.DomainRef.Name), route.Spec.Path}, "::")
 }
 
 func validatePath(route networkingv1alpha1.CFRoute) error {
@@ -249,8 +249,7 @@ func IsFQDN(host, domain string) (bool, error) {
 		MAXIMUM_FQDN_DOMAIN_LENGTH = 253
 		MINIMUM_FQDN_DOMAIN_LENGTH = 3
 		DOMAIN_REGEX               = "^[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$"
-		//DOMAIN_REGEX               = "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])\\.)+([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])$"
-		SUBDOMAIN_REGEX = "^([^\\.]{0,63}\\.)*[^\\.]{0,63}$"
+		SUBDOMAIN_REGEX            = "^([^\\.]{0,63}\\.)*[^\\.]{0,63}$"
 	)
 
 	fqdn := host + "." + domain

--- a/controllers/webhooks/networking/cfroute_validation_test.go
+++ b/controllers/webhooks/networking/cfroute_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"

--- a/controllers/webhooks/networking/cfroute_validation_test.go
+++ b/controllers/webhooks/networking/cfroute_validation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
@@ -376,7 +375,6 @@ var _ = Describe("CF Route Validation", func() {
 			})
 
 			It("denies the request", func() {
-				fmt.Println(response)
 				Expect(response.Allowed).To(BeFalse())
 				Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteFQDNInvalidError.Marshal()))
 			})
@@ -658,6 +656,7 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteFQDNInvalidError.Marshal()))
 			})
 		})
 

--- a/controllers/webhooks/networking/cfroute_validation_test.go
+++ b/controllers/webhooks/networking/cfroute_validation_test.go
@@ -377,7 +377,11 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteFQDNInvalidError.Marshal()))
+				err := webhooks.ValidationError{
+					Code:    webhooks.RouteFQDNInvalidError,
+					Message: "Route FQDN does not comply with RFC 1035 standards",
+				}
+				Expect(string(response.Result.Reason)).To(Equal(err.Marshal()))
 			})
 		})
 
@@ -657,7 +661,11 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteFQDNInvalidError.Marshal()))
+				err := webhooks.ValidationError{
+					Code:    webhooks.RouteFQDNInvalidError,
+					Message: "Route FQDN does not comply with RFC 1035 standards",
+				}
+				Expect(string(response.Result.Reason)).To(Equal(err.Marshal()))
 			})
 		})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
closes #853
## What is this change about?
<!-- _Please describe the change here._ -->
Removes Suspenders FQDN validation check from Route handler and ensures that Create Route always uses webhook validation. Should standardize error messages from using Create Route and Apply Manifest

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
`cf push N_ode` should give an FQDN error instead of a 403

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@acosta11 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
