### PR TITLE
Fix e2e list flakes for app and service binding

### DIFF
--- a/api/tests/e2e/apps_test.go
+++ b/api/tests/e2e/apps_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Apps", func() {
 		It("returns apps only in authorized spaces", func() {
 			Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 
-			Expect(result.Resources).To(ConsistOf(
+			Expect(result.Resources).To(ContainElements(
 				MatchFields(IgnoreExtras, Fields{"GUID": Equal(app1GUID)}),
 				MatchFields(IgnoreExtras, Fields{"GUID": Equal(app2GUID)}),
 				MatchFields(IgnoreExtras, Fields{"GUID": Equal(app5GUID)}),

--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Service Bindings", func() {
 			It("succeeds", func() {
 				Expect(httpError).NotTo(HaveOccurred())
 				Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
-				Expect(result.Resources).To(HaveLen(1))
+				Expect(len(result.Resources)).To(BeNumerically(">=", 1))
 			})
 
 			It("doesn't return anything in the 'included' list", func() {
@@ -123,9 +123,9 @@ var _ = Describe("Service Bindings", func() {
 				It("returns an app in the 'included' list", func() {
 					Expect(httpError).NotTo(HaveOccurred())
 					Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
-					Expect(result.Resources).To(HaveLen(1))
+					Expect(len(result.Resources)).To(BeNumerically(">=", 1))
 					Expect(result.Included).NotTo(BeNil())
-					Expect(result.Included.Apps).To(ConsistOf(
+					Expect(result.Included.Apps).To(ContainElement(
 						MatchFields(IgnoreExtras, Fields{"GUID": Equal(appGUID)}),
 					))
 				})


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Some app and service binding tests checking list results need to account for apps and service bindings created by other tests. So instead of checking for an absolute length of the list results, check that expected elements are contained, and unexpected elements are not contained. That is sufficient in an e2e test.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2e tests pass
