### PR TITLE
Fix RBAC issue for apply manifest endpoint

### DIFF
--- a/api/actions/apply_manifest.go
+++ b/api/actions/apply_manifest.go
@@ -64,7 +64,7 @@ func (a *ApplyManifest) checkAndUpdateDefaultRoute(ctx context.Context, authInfo
 		return nil
 	}
 
-	existingRoutes, err := a.routeRepo.ListRoutesForApp(ctx, authInfo, appRecord.SpaceGUID, appRecord.GUID)
+	existingRoutes, err := a.routeRepo.ListRoutesForApp(ctx, authInfo, appRecord.GUID, appRecord.SpaceGUID)
 	if err != nil {
 		return err
 	}

--- a/api/tests/e2e/e2e_suite_test.go
+++ b/api/tests/e2e/e2e_suite_test.go
@@ -121,9 +121,10 @@ type manifestResource struct {
 }
 
 type applicationResource struct {
-	Name      string                               `yaml:"name"`
-	Processes []manifestApplicationProcessResource `yaml:"processes"`
-	Routes    []manifestRouteResource              `yaml:"routes"`
+	Name         string                               `yaml:"name"`
+	DefaultRoute bool                                 `yaml:"default-route"`
+	Processes    []manifestApplicationProcessResource `yaml:"processes"`
+	Routes       []manifestRouteResource              `yaml:"routes"`
 }
 
 type manifestApplicationProcessResource struct {


### PR DESCRIPTION


## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No, but related to the changes introduced in #741  

## What is this change about?
<!-- _Please describe the change here._ -->

Fix RBAC issue for apply manifest endpoint

- while invoking the `ListRoutesForApp()` function from `apply_manifest_action`, we were incorrectly passing `appGUID` as `spaceGUID` and vice versa. this PR fixes this issue

- `privilegedClient` was used in the repo method until the changes to address issue #741 was merged. We think `privilegedClient` dealt with non-existent spaces differently, causing the bug to fly under the radar. 

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
`cf push` should now succeed

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@tcdowney @Birdrock @gnovv 
