### PR TITLE
Backfill missing unit tests for ApplyManifest

### DIFF
--- a/api/actions/apply_manifest_test.go
+++ b/api/actions/apply_manifest_test.go
@@ -12,6 +12,7 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 	"code.cloudfoundry.org/cf-k8s-controllers/tests/matchers"
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,6 +23,7 @@ var _ = Describe("ApplyManifest", func() {
 		spaceGUID         = "test-space-guid"
 		appName           = "my-app"
 		appGUID           = "my-app-guid"
+		appEtcdUID        = types.UID("my-app-etcd-uid")
 		defaultDomainName = "default-domain.com"
 		defaultDomainGUID = "default-domain-guid"
 		rootNamespace     = "cf"
@@ -40,17 +42,12 @@ var _ = Describe("ApplyManifest", func() {
 
 	BeforeEach(func() {
 		appRepo = new(fake.CFAppRepository)
-		appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{
-			Name: appName,
-			GUID: appGUID,
-		}, nil)
 		domainRepo = new(fake.CFDomainRepository)
-		defaultDomainRecord := repositories.DomainRecord{
+		domainRepo.GetDomainByNameReturns(repositories.DomainRecord{
 			Name:      defaultDomainName,
 			GUID:      defaultDomainGUID,
 			Namespace: rootNamespace,
-		}
-		domainRepo.GetDomainByNameReturns(defaultDomainRecord, nil)
+		}, nil)
 
 		processRepo = new(fake.CFProcessRepository)
 		routeRepo = new(fake.CFRouteRepository)
@@ -60,6 +57,7 @@ var _ = Describe("ApplyManifest", func() {
 			Applications: []payloads.ManifestApplication{
 				{
 					Name: appName,
+					Env:  map[string]string{"FOO": "bar"},
 					Processes: []payloads.ManifestApplicationProcess{
 						{Type: "bob"},
 					},
@@ -72,6 +70,15 @@ var _ = Describe("ApplyManifest", func() {
 
 	JustBeforeEach(func() {
 		applyErr = applyManifestAction.Invoke(context.Background(), authInfo, spaceGUID, defaultDomainName, manifest)
+	})
+
+	It("fetches the app correctly", func() {
+		Expect(appRepo.GetAppByNameAndSpaceCallCount()).To(Equal(1))
+
+		_, actualAuthInfo, actualAppName, actualSpaceGUID := appRepo.GetAppByNameAndSpaceArgsForCall(0)
+		Expect(actualAuthInfo).To(Equal(authInfo))
+		Expect(actualAppName).To(Equal(appName))
+		Expect(actualSpaceGUID).To(Equal(spaceGUID))
 	})
 
 	When("fetching the app returns a Forbidden error", func() {
@@ -88,7 +95,7 @@ var _ = Describe("ApplyManifest", func() {
 		})
 	})
 
-	When("fetching the app a non-API error", func() {
+	When("fetching the app returns a non-API error", func() {
 		BeforeEach(func() {
 			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, errors.New("boom"))
 		})
@@ -105,6 +112,23 @@ var _ = Describe("ApplyManifest", func() {
 	When("the app does not exist", func() {
 		BeforeEach(func() {
 			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{}, apierrors.NewNotFoundError(nil, repositories.AppResourceType))
+			appRepo.CreateAppReturns(repositories.AppRecord{GUID: appGUID}, nil)
+		})
+
+		It("creates the app and its processes", func() {
+			Expect(appRepo.CreateAppCallCount()).To(Equal(1))
+
+			_, actualAuthInfo, appMessage := appRepo.CreateAppArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(appMessage.Name).To(Equal(appName))
+			Expect(appMessage.SpaceGUID).To(Equal(spaceGUID))
+
+			Expect(processRepo.CreateProcessCallCount()).To(Equal(1))
+			_, actualAuthInfo, processMessage := processRepo.CreateProcessArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(processMessage.AppGUID).To(Equal(appGUID))
+			Expect(processMessage.SpaceGUID).To(Equal(spaceGUID))
+			Expect(processMessage.Type).To(Equal("bob"))
 		})
 
 		When("creating the app errors", func() {
@@ -129,11 +153,24 @@ var _ = Describe("ApplyManifest", func() {
 	})
 
 	When("the app exists", func() {
-		var appRecord repositories.AppRecord
-
 		BeforeEach(func() {
-			appRecord = repositories.AppRecord{GUID: "my-app-guid", Name: appName, SpaceGUID: spaceGUID}
-			appRepo.GetAppByNameAndSpaceReturns(appRecord, nil)
+			appRepo.GetAppByNameAndSpaceReturns(repositories.AppRecord{
+				Name:      appName,
+				GUID:      appGUID,
+				EtcdUID:   appEtcdUID,
+				SpaceGUID: spaceGUID,
+			}, nil)
+		})
+
+		It("updates the app env vars", func() {
+			Expect(appRepo.CreateOrPatchAppEnvVarsCallCount()).To(Equal(1))
+
+			_, actualAuthInfo, message := appRepo.CreateOrPatchAppEnvVarsArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(message.AppGUID).To(Equal(appGUID))
+			Expect(message.SpaceGUID).To(Equal(spaceGUID))
+			Expect(message.AppEtcdUID).To(Equal(appEtcdUID))
+			Expect(message.EnvironmentVariables).To(Equal(map[string]string{"FOO": "bar"}))
 		})
 
 		When("updating the env vars errors", func() {
@@ -144,6 +181,16 @@ var _ = Describe("ApplyManifest", func() {
 			It("returns an error", func() {
 				Expect(applyErr).To(MatchError(ContainSubstring("boom")))
 			})
+		})
+
+		It("checks if the process exists correctly", func() {
+			Expect(processRepo.GetProcessByAppTypeAndSpaceCallCount()).To(Equal(1))
+
+			_, actualAuthInfo, actualAppGUID, actualProcessType, actualSpaceGUID := processRepo.GetProcessByAppTypeAndSpaceArgsForCall(0)
+			Expect(actualAuthInfo).To(Equal(authInfo))
+			Expect(actualAppGUID).To(Equal(appGUID))
+			Expect(actualProcessType).To(Equal("bob"))
+			Expect(actualSpaceGUID).To(Equal(spaceGUID))
 		})
 
 		When("checking if the process exists errors", func() {
@@ -159,6 +206,15 @@ var _ = Describe("ApplyManifest", func() {
 		When("the process already exists", func() {
 			BeforeEach(func() {
 				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{GUID: "totes-real"}, nil)
+			})
+
+			It("patches the process", func() {
+				Expect(processRepo.PatchProcessCallCount()).To(Equal(1))
+
+				_, actualAuthInfo, message := processRepo.PatchProcessArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(message.ProcessGUID).To(Equal("totes-real"))
+				Expect(message.SpaceGUID).To(Equal(spaceGUID))
 			})
 
 			When("patching the process errors", func() {
@@ -177,6 +233,16 @@ var _ = Describe("ApplyManifest", func() {
 				processRepo.GetProcessByAppTypeAndSpaceReturns(repositories.ProcessRecord{}, apierrors.NewNotFoundError(nil, repositories.ProcessResourceType))
 			})
 
+			It("creates the process", func() {
+				Expect(processRepo.CreateProcessCallCount()).To(Equal(1))
+
+				_, actualAuthInfo, message := processRepo.CreateProcessArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(message.AppGUID).To(Equal(appGUID))
+				Expect(message.SpaceGUID).To(Equal(spaceGUID))
+				Expect(message.Type).To(Equal("bob"))
+			})
+
 			When("creating the process errors", func() {
 				BeforeEach(func() {
 					processRepo.CreateProcessReturns(errors.New("boom"))
@@ -187,145 +253,197 @@ var _ = Describe("ApplyManifest", func() {
 				})
 			})
 		})
-	})
 
-	When("default route is specified for the app, and no routes are specified", func() {
-		BeforeEach(func() {
-			manifest.Applications[0].DefaultRoute = true
-		})
-
-		When("the app has no existing route destinations", func() {
-			It("fetches the default domain, and calls create route for the default destination", func() {
-				Expect(applyErr).To(Succeed())
-				Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(1))
-				_, _, createMessage := routeRepo.GetOrCreateRouteArgsForCall(0)
-				Expect(createMessage.Host).To(Equal(appName))
-				Expect(createMessage.Path).To(Equal(""))
-				Expect(createMessage.DomainGUID).To(Equal(defaultDomainGUID))
-
-				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(1))
-				_, _, destinationsMessage := routeRepo.AddDestinationsToRouteArgsForCall(0)
-				Expect(destinationsMessage.NewDestinations).To(HaveLen(1))
-				Expect(destinationsMessage.NewDestinations[0].AppGUID).To(Equal(appGUID))
-			})
-
-			When("fetching the destinations for the app fails", func() {
-				BeforeEach(func() {
-					routeRepo.ListRoutesForAppReturns([]repositories.RouteRecord{}, errors.New("fail-on-purpose"))
-				})
-				It("returns an error", func() {
-					Expect(applyErr).NotTo(Succeed())
-				})
-			})
-
-			When("fetching the default domain fails with a NotFound error", func() {
-				BeforeEach(func() {
-					domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, apierrors.NewNotFoundError(errors.New("boom"), repositories.DomainResourceType))
-				})
-
-				It("returns an UnprocessibleEntity error with a friendly message", func() {
-					Expect(applyErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
-					var apierr apierrors.ApiError
-					ok := errors.As(applyErr, &apierr)
-					Expect(ok).To(BeTrue())
-					Expect(apierr.Detail()).To(Equal(
-						fmt.Sprintf("The configured default domain %q was not found", defaultDomainName),
-					))
-				})
-			})
-
-			When("fetching the default domain fails", func() {
-				BeforeEach(func() {
-					domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, errors.New("fail-on-purpose"))
-				})
-
-				It("returns an error", func() {
-					Expect(applyErr).To(MatchError("fail-on-purpose"))
-				})
-			})
-		})
-		When("the app already has a route destination", func() {
+		When("default route is specified for the app, and no routes are specified", func() {
 			BeforeEach(func() {
-				routeRepo.ListRoutesForAppReturns([]repositories.RouteRecord{{
-					GUID: "some-other-route-guid",
-				}}, nil)
-			})
-			It("does not call GetOrCreateRoute, but does not return an error", func() {
-				Expect(applyErr).To(Succeed())
-				Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(0))
-				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
-			})
-		})
-	})
-
-	When("a route is specified for the app", func() {
-		BeforeEach(func() {
-			manifest.Applications[0].Routes = []payloads.ManifestRoute{
-				{Route: stringPointer("my-app.my-domain.com/path")},
-			}
-		})
-
-		When("fetching the domain errors", func() {
-			BeforeEach(func() {
-				domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, errors.New("boom"))
-			})
-
-			It("doesn't create the route", func() {
-				Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(0))
-			})
-
-			It("doesn't add destinations to a route", func() {
-				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
-			})
-
-			It("errors", func() {
-				Expect(applyErr).To(MatchError(ContainSubstring("boom")))
-			})
-		})
-
-		When("fetching/creating the route errors", func() {
-			BeforeEach(func() {
-				routeRepo.GetOrCreateRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
-			})
-
-			It("doesn't add destinations to a route", func() {
-				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
-			})
-
-			It("errors", func() {
-				Expect(applyErr).To(MatchError(ContainSubstring("boom")))
-			})
-		})
-
-		When("adding the destination to the route errors", func() {
-			BeforeEach(func() {
-				routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
-			})
-
-			It("errors", func() {
-				Expect(applyErr).To(MatchError(ContainSubstring("boom")))
-			})
-		})
-
-		When("defaultRoute:true is set on the manifest along with the routes", func() {
-			BeforeEach(func() {
-				manifest.Applications[0].Routes = []payloads.ManifestRoute{
-					{Route: stringPointer("NOT-MY-APP.my-domain.com/path")},
-				}
 				manifest.Applications[0].DefaultRoute = true
 			})
 
-			It("is ignored, and AddDestinationsToRouteCallCount is called without adding a default destination to the existing route list", func() {
-				Expect(applyErr).To(Succeed())
-				Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(len(manifest.Applications[0].Routes)))
-				_, _, createMessage := routeRepo.GetOrCreateRouteArgsForCall(0)
-				Expect(createMessage.Host).To(Equal("NOT-MY-APP"))
-				Expect(createMessage.Path).To(Equal("/path"))
-				Expect(createMessage.DomainGUID).To(Equal(defaultDomainGUID))
+			It("checks for existing routes correctly", func() {
+				Expect(routeRepo.ListRoutesForAppCallCount()).To(Equal(1))
+
+				_, actualAuthInfo, actualAppGUID, actualSpaceGUID := routeRepo.ListRoutesForAppArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(actualAppGUID).To(Equal(appGUID))
+				Expect(actualSpaceGUID).To(Equal(spaceGUID))
+			})
+
+			When("checking for existing routes fails", func() {
+				BeforeEach(func() {
+					routeRepo.ListRoutesForAppReturns(nil, errors.New("boom"))
+				})
+
+				It("returns the error", func() {
+					Expect(applyErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the app has no existing route destinations", func() {
+				It("fetches the default domain, and calls create route for the default destination", func() {
+					Expect(applyErr).To(Succeed())
+					Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(1))
+					_, _, createMessage := routeRepo.GetOrCreateRouteArgsForCall(0)
+					Expect(createMessage.Host).To(Equal(appName))
+					Expect(createMessage.Path).To(Equal(""))
+					Expect(createMessage.DomainGUID).To(Equal(defaultDomainGUID))
+
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(1))
+					_, _, destinationsMessage := routeRepo.AddDestinationsToRouteArgsForCall(0)
+					Expect(destinationsMessage.NewDestinations).To(HaveLen(1))
+					Expect(destinationsMessage.NewDestinations[0].AppGUID).To(Equal(appGUID))
+				})
+
+				When("fetching the default domain fails with a NotFound error", func() {
+					BeforeEach(func() {
+						domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, apierrors.NewNotFoundError(errors.New("boom"), repositories.DomainResourceType))
+					})
+
+					It("returns an UnprocessibleEntity error with a friendly message", func() {
+						Expect(applyErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.UnprocessableEntityError{}))
+						var apierr apierrors.ApiError
+						ok := errors.As(applyErr, &apierr)
+						Expect(ok).To(BeTrue())
+						Expect(apierr.Detail()).To(Equal(
+							fmt.Sprintf("The configured default domain %q was not found", defaultDomainName),
+						))
+					})
+				})
+
+				When("fetching the default domain fails", func() {
+					BeforeEach(func() {
+						domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, errors.New("fail-on-purpose"))
+					})
+
+					It("returns an error", func() {
+						Expect(applyErr).To(MatchError("fail-on-purpose"))
+					})
+				})
+			})
+
+			When("the app already has a route destination", func() {
+				BeforeEach(func() {
+					routeRepo.ListRoutesForAppReturns([]repositories.RouteRecord{{
+						GUID: "some-other-route-guid",
+					}}, nil)
+				})
+
+				It("does not call GetOrCreateRoute, but does not return an error", func() {
+					Expect(applyErr).To(Succeed())
+					Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(0))
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+			})
+		})
+
+		When("a route is specified for the app", func() {
+			BeforeEach(func() {
+				domainRepo.GetDomainByNameReturns(repositories.DomainRecord{
+					Name:      "my-domain.com",
+					GUID:      "my-domain-guid",
+					Namespace: "my-domain-ns",
+				}, nil)
+				routeRepo.GetOrCreateRouteReturns(repositories.RouteRecord{
+					GUID:         "route-guid",
+					SpaceGUID:    spaceGUID,
+					Destinations: []repositories.DestinationRecord{{GUID: "existing-destination-guid"}},
+				}, nil)
+				manifest.Applications[0].Routes = []payloads.ManifestRoute{
+					{Route: stringPointer("my-app.my-domain.com/path")},
+				}
+			})
+
+			It("creates or updates the route", func() {
+				Expect(domainRepo.GetDomainByNameCallCount()).To(Equal(1))
+				_, actualAuthInfo, domainName := domainRepo.GetDomainByNameArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(domainName).To(Equal("my-domain.com"))
+
+				Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(1))
+				_, actualAuthInfo, getOrCreateMessage := routeRepo.GetOrCreateRouteArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(getOrCreateMessage.Host).To(Equal("my-app"))
+				Expect(getOrCreateMessage.Path).To(Equal("/path"))
+				Expect(getOrCreateMessage.SpaceGUID).To(Equal(spaceGUID))
+				Expect(getOrCreateMessage.DomainGUID).To(Equal("my-domain-guid"))
+				Expect(getOrCreateMessage.DomainName).To(Equal("my-domain.com"))
+				Expect(getOrCreateMessage.DomainNamespace).To(Equal("my-domain-ns"))
 
 				Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(1))
-				_, _, destinationsMessage := routeRepo.AddDestinationsToRouteArgsForCall(0)
-				Expect(destinationsMessage.NewDestinations).To(HaveLen(1))
+				_, actualAuthInfo, addDestMessage := routeRepo.AddDestinationsToRouteArgsForCall(0)
+				Expect(actualAuthInfo).To(Equal(authInfo))
+				Expect(addDestMessage.RouteGUID).To(Equal("route-guid"))
+				Expect(addDestMessage.SpaceGUID).To(Equal(spaceGUID))
+				Expect(addDestMessage.ExistingDestinations).To(ConsistOf(repositories.DestinationRecord{GUID: "existing-destination-guid"}))
+				Expect(addDestMessage.NewDestinations).To(ConsistOf(repositories.DestinationMessage{
+					AppGUID:     appGUID,
+					ProcessType: "web",
+					Port:        8080,
+					Protocol:    "http1",
+				}))
+			})
+
+			When("fetching the domain errors", func() {
+				BeforeEach(func() {
+					domainRepo.GetDomainByNameReturns(repositories.DomainRecord{}, errors.New("boom"))
+				})
+
+				It("doesn't create the route", func() {
+					Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(0))
+				})
+
+				It("doesn't add destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+
+				It("errors", func() {
+					Expect(applyErr).To(MatchError(ContainSubstring("boom")))
+				})
+			})
+
+			When("fetching/creating the route errors", func() {
+				BeforeEach(func() {
+					routeRepo.GetOrCreateRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
+				})
+
+				It("doesn't add destinations to a route", func() {
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(0))
+				})
+
+				It("errors", func() {
+					Expect(applyErr).To(MatchError(ContainSubstring("boom")))
+				})
+			})
+
+			When("adding the destination to the route errors", func() {
+				BeforeEach(func() {
+					routeRepo.AddDestinationsToRouteReturns(repositories.RouteRecord{}, errors.New("boom"))
+				})
+
+				It("errors", func() {
+					Expect(applyErr).To(MatchError(ContainSubstring("boom")))
+				})
+			})
+
+			When("defaultRoute:true is set on the manifest along with the routes", func() {
+				BeforeEach(func() {
+					manifest.Applications[0].Routes = []payloads.ManifestRoute{
+						{Route: stringPointer("NOT-MY-APP.my-domain.com/path")},
+					}
+					manifest.Applications[0].DefaultRoute = true
+				})
+
+				It("is ignored, and AddDestinationsToRoute is called without adding a default destination to the existing route list", func() {
+					Expect(applyErr).To(Succeed())
+					Expect(routeRepo.GetOrCreateRouteCallCount()).To(Equal(len(manifest.Applications[0].Routes)))
+					_, _, createMessage := routeRepo.GetOrCreateRouteArgsForCall(0)
+					Expect(createMessage.Host).To(Equal("NOT-MY-APP"))
+					Expect(createMessage.Path).To(Equal("/path"))
+					Expect(createMessage.DomainGUID).To(Equal("my-domain-guid"))
+
+					Expect(routeRepo.AddDestinationsToRouteCallCount()).To(Equal(1))
+					_, _, destinationsMessage := routeRepo.AddDestinationsToRouteArgsForCall(0)
+					Expect(destinationsMessage.NewDestinations).To(HaveLen(1))
+				})
 			})
 		})
 	})

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -179,7 +179,6 @@ var _ = Describe("AppRepository", func() {
 				Expect(getErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
 			})
 		})
-
 	})
 
 	Describe("ListApps", Serial, func() {

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -305,9 +305,7 @@ var _ = Describe("ProcessRepo", func() {
 	})
 
 	Describe("CreateProcess", func() {
-		var (
-			createErr error
-		)
+		var createErr error
 		JustBeforeEach(func() {
 			createErr = processRepo.CreateProcess(ctx, authInfo, repositories.CreateProcessMessage{
 				AppGUID:     app1GUID,
@@ -366,7 +364,6 @@ var _ = Describe("ProcessRepo", func() {
 				Expect(createErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
-
 	})
 
 	Describe("GetProcessByAppTypeAndSpace", func() {

--- a/api/repositories/route_repository_test.go
+++ b/api/repositories/route_repository_test.go
@@ -579,7 +579,6 @@ var _ = Describe("RouteRepository", func() {
 				Expect(listErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
-
 	})
 
 	Describe("CreateRoute", func() {
@@ -818,7 +817,6 @@ var _ = Describe("RouteRepository", func() {
 				Expect(routeErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
 			})
 		})
-
 	})
 
 	Describe("AddDestinationsToRoute", func() {

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -410,7 +410,6 @@ var _ = Describe("Spaces", func() {
 				})
 			})
 		})
-
 	})
 
 	Describe("manifest diff", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, although #886 is related.

## What is this change about?
This adds unit tests for all positive cases in `ApplyManifest`. I assume these were missing as we wanted to rely on the integration tests, but #886 shows that it's easy to miss things as simple as swapping the order of two arguments.

## Does this PR introduce a breaking change?
No.
