### PR TITLE
No longer run codeql on every PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '35 13 * * 6'
 


### PR DESCRIPTION
Now that all checks take ~12m on gh actions it has become the bottleneck
with runtime of ~20m. Maybe runnign it on main only is a good compromise
that will improve our dev turnaround