### PR TITLE
Refactor Validation Errors

### DIFF
--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -815,7 +815,7 @@ var _ = Describe("RouteHandler", func() {
 			})
 
 			It("returns an error", func() {
-				expectUnprocessableEntityError("Invalid Route, FQDN does not comply with RFC 1035 standards")
+				expectUnprocessableEntityError("Invalid Route, {\"validationErrorType\":\"RouteFQDNValidationError\",\"message\":\"FQDN does not comply with RFC 1035 standards\"}")
 			})
 		})
 

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
+
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
@@ -210,9 +212,11 @@ func (f *AppRepo) CreateApp(ctx context.Context, authInfo authorization.Info, ap
 	cfApp := appCreateMessage.toCFApp()
 	err = userClient.Create(ctx, &cfApp)
 	if err != nil {
-		if webhooks.HasErrorCode(err, webhooks.DuplicateAppError) {
-			errorDetail := fmt.Sprintf("App with the name '%s' already exists.", appCreateMessage.Name)
-			return AppRecord{}, apierrors.NewUniquenessError(err, errorDetail)
+		if validationError, ok := webhooks.WebhookErrorToValidationError(err); ok {
+			if validationError.Type == workloads.DuplicateAppError {
+				return AppRecord{}, apierrors.NewUniquenessError(err, validationError.Error())
+			}
+			return AppRecord{}, apierrors.NewUnprocessableEntityError(err, validationError.Error())
 		}
 
 		return AppRecord{}, apierrors.FromK8sError(err, AppResourceType)

--- a/api/repositories/org_repository.go
+++ b/api/repositories/org_repository.go
@@ -147,9 +147,8 @@ func (r *OrgRepo) CreateOrg(ctx context.Context, info authorization.Info, org Cr
 		OrgResourceType,
 	)
 	if err != nil {
-		if webhooks.HasErrorCode(err, webhooks.DuplicateOrgNameError) {
-			errorDetail := fmt.Sprintf("Organization '%s' already exists.", org.Name)
-			return OrgRecord{}, apierrors.NewUnprocessableEntityError(err, errorDetail)
+		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok {
+			return OrgRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
 		}
 		return OrgRecord{}, err
 	}
@@ -215,10 +214,8 @@ func (r *OrgRepo) CreateSpace(ctx context.Context, info authorization.Info, mess
 		SpaceResourceType,
 	)
 	if err != nil {
-		if webhooks.HasErrorCode(err, webhooks.DuplicateSpaceNameError) {
-			// Note: the cf cli expects the specific text 'Name must be unique per organization' in the error and ignores the error if it matches it.
-			errorDetail := fmt.Sprintf("Space '%s' already exists. Name must be unique per organization.", message.Name)
-			return SpaceRecord{}, apierrors.NewUnprocessableEntityError(err, errorDetail)
+		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok {
+			return SpaceRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
 		}
 		return SpaceRecord{}, err
 	}

--- a/api/repositories/service_instance_repository.go
+++ b/api/repositories/service_instance_repository.go
@@ -91,9 +91,8 @@ func (r *ServiceInstanceRepo) CreateServiceInstance(ctx context.Context, authInf
 	cfServiceInstance := message.toCFServiceInstance()
 	err = userClient.Create(ctx, &cfServiceInstance)
 	if err != nil {
-		if webhooks.HasErrorCode(err, webhooks.DuplicateServiceInstanceNameError) {
-			errorDetail := fmt.Sprintf("The service instance name is taken: %s.", message.Name)
-			return ServiceInstanceRecord{}, apierrors.NewUnprocessableEntityError(err, errorDetail)
+		if webhookError, ok := webhooks.WebhookErrorToValidationError(err); ok {
+			return ServiceInstanceRecord{}, apierrors.NewUnprocessableEntityError(err, webhookError.Error())
 		}
 		return ServiceInstanceRecord{}, apierrors.FromK8sError(err, ServiceInstanceResourceType)
 	}

--- a/api/tests/e2e/orgs_test.go
+++ b/api/tests/e2e/orgs_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Orgs", func() {
 			It("returns an unprocessable entity error", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(resultErr.Errors).To(ConsistOf(cfErr{
-					Detail: fmt.Sprintf(`Organization '%s' already exists.`, orgName),
+					Detail: fmt.Sprintf(`ValidationError-DuplicateOrgNameError: Organization '%s' already exists.`, orgName),
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
+						Detail: fmt.Sprintf("ValidationError-DuplicateRouteError: Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -237,7 +237,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
+						Detail: fmt.Sprintf("ValidationError-DuplicateRouteError: Route already exists with host '%s' and path '%s' for domain '%s'.", host, path, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -253,7 +253,7 @@ var _ = Describe("Routes", func() {
 				It("fails with a duplicate error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: fmt.Sprintf("Route already exists with host '%s' for domain '%s'.", host, domainName),
+						Detail: fmt.Sprintf("ValidationError-DuplicateRouteError: Route already exists with host '%s' for domain '%s'.", host, domainName),
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))
@@ -374,7 +374,7 @@ var _ = Describe("Routes", func() {
 				})
 
 				It("fails with an unprocessable entity error", func() {
-					expectUnprocessableEntityError(resp, errResp, "Routes cannot be mapped to destinations in different spaces.")
+					expectUnprocessableEntityError(resp, errResp, "ValidationError-RouteDestinationNotInSpaceError: Route destination app not found in space")
 				})
 			})
 		})

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Spaces", func() {
 			It("returns an unprocessable entity error", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 				Expect(createErr.Errors).To(ConsistOf(cfErr{
-					Detail: fmt.Sprintf(`Space '%s' already exists. Name must be unique per organization.`, spaceName),
+					Detail: fmt.Sprintf(`ValidationError-DuplicateSpaceNameError: Space '%s' already exists. Name must be unique per organization.`, spaceName),
 					Title:  "CF-UnprocessableEntity",
 					Code:   10008,
 				}))

--- a/controllers/config/webhook/manifests.yaml
+++ b/controllers/config/webhook/manifests.yaml
@@ -119,6 +119,50 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfapp
+  failurePolicy: Fail
+  name: vcfapp.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cfapps
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
+  failurePolicy: Fail
+  name: vsubns.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - hnc.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - subnamespaceanchors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   clientConfig:
     service:
       name: webhook-service
@@ -180,48 +224,4 @@ webhooks:
     - DELETE
     resources:
     - cfserviceinstances
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: vcfapp.workloads.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - workloads.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
-  failurePolicy: Fail
-  name: vsubns.workloads.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - hnc.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - subnamespaceanchors
   sideEffects: None

--- a/controllers/reference/cf-k8s-controllers.yaml
+++ b/controllers/reference/cf-k8s-controllers.yaml
@@ -2632,6 +2632,50 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: cf-k8s-controllers-webhook-service
+      namespace: cf-k8s-controllers-system
+      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfapp
+  failurePolicy: Fail
+  name: vcfapp.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - workloads.cloudfoundry.org
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cfapps
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: cf-k8s-controllers-webhook-service
+      namespace: cf-k8s-controllers-system
+      path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
+  failurePolicy: Fail
+  name: vsubns.workloads.cloudfoundry.org
+  rules:
+  - apiGroups:
+    - hnc.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - subnamespaceanchors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   clientConfig:
     service:
       name: cf-k8s-controllers-webhook-service
@@ -2693,48 +2737,4 @@ webhooks:
     - DELETE
     resources:
     - cfserviceinstances
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: cf-k8s-controllers-webhook-service
-      namespace: cf-k8s-controllers-system
-      path: /validate-workloads-cloudfoundry-org-v1alpha1-cfapp
-  failurePolicy: Fail
-  name: vcfapp.workloads.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - workloads.cloudfoundry.org
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - cfapps
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: cf-k8s-controllers-webhook-service
-      namespace: cf-k8s-controllers-system
-      path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchor
-  failurePolicy: Fail
-  name: vsubns.workloads.cloudfoundry.org
-  rules:
-  - apiGroups:
-    - hnc.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - subnamespaceanchors
   sideEffects: None

--- a/controllers/webhooks/cf_validation_errors.go
+++ b/controllers/webhooks/cf_validation_errors.go
@@ -7,116 +7,41 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-type ValidationErrorCode int
+const (
+	UnknownError        = "UnknownError"
+	UnknownErrorMessage = "An unknown error has occurred"
+)
 
 type ValidationError struct {
-	Code    ValidationErrorCode `json:"code"`
-	Message string              `json:"message"`
+	Type    string `json:"validationErrorType"`
+	Message string `json:"message"`
 }
 
-const (
-	UnknownError = ValidationErrorCode(iota)
-	DuplicateAppError
-	DuplicateOrgNameError
-	DuplicateSpaceNameError
-	DuplicateRouteError
-	DuplicateDomainError
-	DuplicateServiceInstanceNameError
-	RouteDestinationNotInSpace
-	HostNameIsInvalidError
-	PathValidationError
-)
+func (v ValidationError) Error() string {
+	return "ValidationError-" + v.Type + ": " + v.Message
+}
 
 func (v ValidationError) Marshal() string {
 	bytes, err := json.Marshal(v)
-	if err != nil {
+	if err != nil { // This (probably) can't fail, untested
 		return err.Error()
 	}
 	return string(bytes)
 }
 
-func (w ValidationErrorCode) Marshal() string {
-	bytes, err := json.Marshal(ValidationError{
-		Code:    w,
-		Message: w.GetMessage(),
-	})
-	if err != nil {
-		return err.Error()
+func WebhookErrorToValidationError(err error) (ValidationError, bool) {
+	statusError := new(k8serrors.StatusError)
+	if !errors.As(err, &statusError) {
+		return ValidationError{}, false
 	}
-	return string(bytes)
+
+	validationError := new(ValidationError)
+	if json.Unmarshal([]byte(statusError.Status().Reason), validationError) != nil {
+		return ValidationError{}, false
+	}
+	return *validationError, true
 }
 
-func (w *ValidationErrorCode) Unmarshall(payload string) {
-	validationErr := new(ValidationError)
-	err := json.Unmarshal([]byte(payload), validationErr)
-	if err != nil {
-		*w = UnknownError
-	}
-	*w = validationErr.Code
-}
-
-func (w ValidationErrorCode) GetMessage() string {
-	switch w {
-	case DuplicateAppError:
-		return "CFApp with the same spec.name exists"
-	case DuplicateOrgNameError:
-		return "Org with same name exists"
-	case DuplicateSpaceNameError:
-		return "Space with same name exists"
-	case DuplicateRouteError:
-		return "Route with same FQDN and path exists"
-	case DuplicateDomainError:
-		return "Overlapping domain exists"
-	case DuplicateServiceInstanceNameError:
-		return "CFServiceInstance with same spec.name exists"
-	case RouteDestinationNotInSpace:
-		return "Route destination app not found in space"
-	case HostNameIsInvalidError:
-		return "Missing or Invalid host - Routes in shared domains must have a valid host defined"
-	default:
-		return "An unknown error has occurred"
-	}
-}
-
-func HasErrorCode(err error, code ValidationErrorCode) bool {
-	if statusError := new(k8serrors.StatusError); errors.As(err, &statusError) {
-		reason := statusError.Status().Reason
-
-		val := new(ValidationErrorCode)
-		val.Unmarshall(string(reason))
-
-		if *val == code {
-			return true
-		}
-	}
-	return false
-}
-
-func IsValidationError(err error) bool {
-	if statusError := new(k8serrors.StatusError); errors.As(err, &statusError) {
-		reason := statusError.Status().Reason
-
-		val := new(ValidationErrorCode)
-		val.Unmarshall(string(reason))
-
-		if *val != UnknownError {
-			return true
-		}
-	}
-	return false
-}
-
-func GetErrorMessage(err error) string {
-	if statusError := new(k8serrors.StatusError); errors.As(err, &statusError) {
-		reason := statusError.Status().Reason
-
-		val := new(ValidationError)
-		err := json.Unmarshal([]byte(reason), val)
-		if err != nil {
-			return ""
-		}
-
-		return val.Message
-	}
-	return ""
+func AdmissionUnknownErrorReason() string {
+	return ValidationError{Type: UnknownError, Message: UnknownErrorMessage}.Marshal()
 }

--- a/controllers/webhooks/networking/cfdomain_validation.go
+++ b/controllers/webhooks/networking/cfdomain_validation.go
@@ -33,6 +33,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	DomainDecodingError  = "DomainDecodingError"
+	DuplicateDomainError = "DuplicateDomainError"
+)
+
 // log is for logging in this package.
 var log = logf.Log.WithName("domain-validation")
 
@@ -63,19 +68,23 @@ func (v *CFDomainValidation) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	err := v.decoder.Decode(req, &domain)
-	if err != nil {
+	if err != nil { // untested
 		errMessage := "Error while decoding CFDomain object"
 		log.Error(err, errMessage)
-		return admission.Denied(errMessage)
+		return admission.Denied(webhooks.ValidationError{Type: DomainDecodingError, Message: errMessage}.Marshal())
 	}
 
 	isOverlapping, err := v.domainIsOverlapping(ctx, domain.Spec.Name)
 	if err != nil {
-		return admission.Denied(err.Error())
+		validationError := webhooks.ValidationError{
+			Type:    webhooks.UnknownError,
+			Message: err.Error(),
+		}
+		return admission.Denied(validationError.Marshal())
 	}
 
 	if isOverlapping {
-		return admission.Denied(webhooks.DuplicateDomainError.Marshal())
+		return admission.Denied(webhooks.ValidationError{Type: DuplicateDomainError, Message: "Overlapping domain exists"}.Marshal())
 	}
 
 	return admission.Allowed("")

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -11,6 +11,7 @@ import (
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
+
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,6 +25,19 @@ import (
 
 const (
 	RouteEntityType = "route"
+
+	RouteDecodingError                     = "RouteDecodingError"
+	DuplicateRouteError                    = "DuplicateRouteError"
+	RouteDestinationNotInSpaceError        = "RouteDestinationNotInSpaceError"
+	RouteDestinationNotInSpaceErrorMessage = "Route destination app not found in space"
+	RouteHostNameValidationError           = "RouteHostNameValidationError"
+	RoutePathValidationError               = "RoutePathValidationError"
+	RouteFQDNValidationError               = "RouteFQDNValidationError"
+	RouteFQDNValidationErrorMessage        = "FQDN does not comply with RFC 1035 standards"
+
+	HostEmptyError  = "host cannot be empty"
+	HostLengthError = "host is too long (maximum is 63 characters)"
+	HostFormatError = "host must be either \"*\" or contain only alphanumeric characters, \"_\", or \"-\""
 
 	InvalidURIError          = "Invalid Route URI"
 	PathIsSlashError         = "Path cannot be a single slash"
@@ -70,75 +84,82 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 	var domain networkingv1alpha1.CFDomain
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
 		err := v.decoder.Decode(req, &route)
-		if err != nil {
+		if err != nil { // untested
 			errMessage := "Error while decoding CFRoute object"
 			logger.Error(err, errMessage)
-
-			return admission.Denied(errMessage)
+			return admission.Denied(webhooks.ValidationError{Type: RouteDecodingError, Message: errMessage}.Marshal())
 		}
 
 		err = v.Client.Get(ctx, types.NamespacedName{Name: route.Spec.DomainRef.Name, Namespace: route.Spec.DomainRef.Namespace}, &domain)
 		if err != nil {
 			errMessage := "Error while retrieving CFDomain object"
 			logger.Error(err, errMessage)
-
-			return admission.Denied(errMessage)
+			validationError := webhooks.ValidationError{
+				Type:    webhooks.UnknownError,
+				Message: errMessage,
+			}
+			return admission.Denied(validationError.Marshal())
 		}
 	}
 	if req.Operation == admissionv1.Update || req.Operation == admissionv1.Delete {
 		err := v.decoder.DecodeRaw(req.OldObject, &oldRoute)
-		if err != nil {
+		if err != nil { // untested
 			errMessage := "Error while decoding old CFRoute object"
 			logger.Error(err, errMessage)
-
-			return admission.Denied(errMessage)
+			return admission.Denied(webhooks.ValidationError{Type: RouteDecodingError, Message: errMessage}.Marshal())
 		}
 	}
 
 	var validatorErr error
 	switch req.Operation {
 	case admissionv1.Create:
-		_, err := isHost(route.Spec.Host)
-		if err != nil {
+		if err := isHost(route.Spec.Host); err != nil {
 			return admission.Denied(err.Error())
 		}
-		_, err = IsFQDN(route.Spec.Host, domain.Spec.Name)
-		if err != nil {
+		if _, err := IsFQDN(route.Spec.Host, domain.Spec.Name); err != nil {
 			return admission.Denied(err.Error())
 		}
-		err = validatePath(route)
-		if err != nil {
+		if err := validatePath(route); err != nil {
 			return admission.Denied(err.Error())
 		}
 
 		if err := v.checkDestinationsExistInNamespace(ctx, route); err != nil {
 			if k8serrors.IsNotFound(err) {
-				return admission.Denied(webhooks.RouteDestinationNotInSpace.Marshal())
+				return admission.Denied(webhooks.ValidationError{Type: RouteDestinationNotInSpaceError, Message: RouteDestinationNotInSpaceErrorMessage}.Marshal())
 			}
-			return admission.Denied(err.Error())
+			errMessage := "Error while checking Route Destinations in Namespace"
+			logger.Error(err, errMessage)
+			validationError := webhooks.ValidationError{
+				Type:    webhooks.UnknownError,
+				Message: errMessage,
+			}
+			return admission.Denied(validationError.Marshal())
 		}
 
 		validatorErr = v.duplicateValidator.ValidateCreate(ctx, logger, v.rootNamespace, uniqueName(route))
 
 	case admissionv1.Update:
-		_, err := isHost(route.Spec.Host)
-		if err != nil {
+		if err := isHost(route.Spec.Host); err != nil {
 			return admission.Denied(err.Error())
 		}
-		_, err = IsFQDN(route.Spec.Host, domain.Spec.Name)
-		if err != nil {
+		if _, err := IsFQDN(route.Spec.Host, domain.Spec.Name); err != nil {
 			return admission.Denied(err.Error())
 		}
-		err = validatePath(route)
-		if err != nil {
+		if err := validatePath(route); err != nil {
 			return admission.Denied(err.Error())
 		}
 
 		if err := v.checkDestinationsExistInNamespace(ctx, route); err != nil {
 			if k8serrors.IsNotFound(err) {
-				return admission.Denied(webhooks.RouteDestinationNotInSpace.Marshal())
+				return admission.Denied(webhooks.ValidationError{Type: RouteDestinationNotInSpaceError, Message: RouteDestinationNotInSpaceErrorMessage}.Marshal())
 			}
-			return admission.Denied(err.Error())
+			errMessage := "Error while checking Route Destinations in Namespace"
+			logger.Error(err, errMessage)
+			validationError := webhooks.ValidationError{
+				Type:    webhooks.UnknownError,
+				Message: errMessage,
+			}
+			return admission.Denied(validationError.Marshal())
 		}
 
 		validatorErr = v.duplicateValidator.ValidateUpdate(ctx, logger, v.rootNamespace, uniqueName(oldRoute), uniqueName(route))
@@ -159,13 +180,19 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 				route.Spec.Host, pathDetails, domain.Spec.Name)
 
 			ve := webhooks.ValidationError{
-				Code:    webhooks.DuplicateRouteError,
+				Type:    DuplicateRouteError,
 				Message: errorDetail,
 			}
 			return admission.Denied(ve.Marshal())
 		}
 
-		return admission.Denied(webhooks.UnknownError.Marshal())
+		errMessage := "Unknown error while checking Route Name Duplicate"
+		logger.Error(validatorErr, errMessage)
+		validationError := webhooks.ValidationError{
+			Type:    webhooks.UnknownError,
+			Message: errMessage,
+		}
+		return admission.Denied(validationError.Marshal())
 	}
 
 	return admission.Allowed("")
@@ -201,7 +228,7 @@ func validatePath(route networkingv1alpha1.CFRoute) error {
 
 	if len(errStrings) > 0 {
 		ve := webhooks.ValidationError{
-			Code:    webhooks.PathValidationError,
+			Type:    RoutePathValidationError,
 			Message: strings.Join(errStrings, ", "),
 		}
 		return errors.New(ve.Marshal())
@@ -215,28 +242,38 @@ func (v *CFRouteValidation) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
-func isHost(hostname string) (bool, error) {
+func isHost(hostname string) error {
 	const (
 		// HOST_REGEX - Must be either "*" or contain only alphanumeric characters, "_", or "-"
 		HOST_REGEX                  = "^([\\w\\-]+|\\*)?$"
 		MAXIMUM_DOMAIN_LABEL_LENGTH = 63
 	)
 
+	var errStrings []string
+
 	rxHost := regexp.MustCompile(HOST_REGEX)
 
 	if len(hostname) == 0 {
-		return false, errors.New("host cannot be empty")
+		errStrings = append(errStrings, HostEmptyError)
 	}
 
 	if len(hostname) > MAXIMUM_DOMAIN_LABEL_LENGTH {
-		return false, errors.New("host is too long (maximum is 63 characters)")
+		errStrings = append(errStrings, HostLengthError)
 	}
 
 	if !rxHost.MatchString(hostname) {
-		return false, errors.New("host must be either \"*\" or contain only alphanumeric characters, \"_\", or \"-\"")
+		errStrings = append(errStrings, HostFormatError)
 	}
 
-	return true, nil
+	if len(errStrings) > 0 {
+		ve := webhooks.ValidationError{
+			Type:    RouteHostNameValidationError,
+			Message: strings.Join(errStrings, ", "),
+		}
+		return errors.New(ve.Marshal())
+	}
+
+	return nil
 }
 
 func IsFQDN(host, domain string) (bool, error) {
@@ -264,7 +301,7 @@ func IsFQDN(host, domain string) (bool, error) {
 	fqdnLength := len(fqdn)
 
 	if fqdnLength < MINIMUM_FQDN_DOMAIN_LENGTH || fqdnLength > MAXIMUM_FQDN_DOMAIN_LENGTH || !rxDomain.MatchString(fqdn) {
-		return false, errors.New("FQDN does not comply with RFC 1035 standards")
+		return false, errors.New(webhooks.ValidationError{Type: RouteFQDNValidationError, Message: RouteFQDNValidationErrorMessage}.Marshal())
 	}
 
 	return true, nil

--- a/controllers/webhooks/networking/cfroute_validation_test.go
+++ b/controllers/webhooks/networking/cfroute_validation_test.go
@@ -140,7 +140,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.InvalidURIError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -154,7 +154,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathIsSlashError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -168,7 +168,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.InvalidURIError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -182,7 +182,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathHasQuestionMarkError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -196,7 +196,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathLengthExceededError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -210,7 +210,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.InvalidURIError + ", " + networking.PathHasQuestionMarkError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -231,7 +231,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.InvalidURIError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -245,7 +245,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathIsSlashError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -259,7 +259,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.InvalidURIError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -273,7 +273,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathHasQuestionMarkError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -287,7 +287,7 @@ var _ = Describe("CF Route Validation", func() {
 				It("denies the request", func() {
 					Expect(response.AdmissionResponse.Allowed).To(BeFalse())
 					err := webhooks.ValidationError{
-						Code:    webhooks.PathValidationError,
+						Type:    networking.RoutePathValidationError,
 						Message: networking.PathLengthExceededError,
 					}
 					Expect(string(response.AdmissionResponse.Result.Reason)).To(Equal(err.Marshal()))
@@ -334,7 +334,7 @@ var _ = Describe("CF Route Validation", func() {
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
 				err := webhooks.ValidationError{
-					Code:    webhooks.DuplicateRouteError,
+					Type:    networking.DuplicateRouteError,
 					Message: "Route already exists with host 'my-host' and path '/my-path' for domain 'test.domain.name'.",
 				}
 				Expect(string(response.Result.Reason)).To(Equal(err.Marshal()))
@@ -376,7 +376,8 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				ve := unmarshalValidatorError(string(response.Result.Reason))
+				Expect(ve.Type).To(Equal(webhooks.UnknownError))
 			})
 		})
 
@@ -498,7 +499,7 @@ var _ = Describe("CF Route Validation", func() {
 
 				It("denies the request", func() {
 					Expect(response.Allowed).To(BeFalse())
-					Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteDestinationNotInSpace.Marshal()))
+					Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: networking.RouteDestinationNotInSpaceError, Message: networking.RouteDestinationNotInSpaceErrorMessage}.Marshal()))
 				})
 			})
 
@@ -509,7 +510,8 @@ var _ = Describe("CF Route Validation", func() {
 
 				It("denies the request", func() {
 					Expect(response.Allowed).To(BeFalse())
-					Expect(string(response.Result.Reason)).To(Equal("foo"))
+					ve := unmarshalValidatorError(string(response.Result.Reason))
+					Expect(ve.Type).To(Equal(webhooks.UnknownError))
 				})
 			})
 		})
@@ -585,7 +587,7 @@ var _ = Describe("CF Route Validation", func() {
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
 				err := webhooks.ValidationError{
-					Code:    webhooks.DuplicateRouteError,
+					Type:    networking.DuplicateRouteError,
 					Message: "Route already exists with host 'my-host' and path '/new-path' for domain 'test.domain.name'.",
 				}
 				Expect(string(response.Result.Reason)).To(Equal(err.Marshal()))
@@ -599,7 +601,8 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				ve := unmarshalValidatorError(string(response.Result.Reason))
+				Expect(ve.Type).To(Equal(webhooks.UnknownError))
 			})
 		})
 
@@ -635,7 +638,7 @@ var _ = Describe("CF Route Validation", func() {
 
 				It("denies the request", func() {
 					Expect(response.Allowed).To(BeFalse())
-					Expect(string(response.Result.Reason)).To(Equal(webhooks.RouteDestinationNotInSpace.Marshal()))
+					Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: networking.RouteDestinationNotInSpaceError, Message: networking.RouteDestinationNotInSpaceErrorMessage}.Marshal()))
 				})
 			})
 
@@ -646,7 +649,8 @@ var _ = Describe("CF Route Validation", func() {
 
 				It("denies the request", func() {
 					Expect(response.Allowed).To(BeFalse())
-					Expect(string(response.Result.Reason)).To(Equal("foo"))
+					ve := unmarshalValidatorError(string(response.Result.Reason))
+					Expect(ve.Type).To(Equal(webhooks.UnknownError))
 				})
 			})
 		})
@@ -690,7 +694,8 @@ var _ = Describe("CF Route Validation", func() {
 
 			It("disallows the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				ve := unmarshalValidatorError(string(response.Result.Reason))
+				Expect(ve.Type).To(Equal(webhooks.UnknownError))
 			})
 		})
 	})
@@ -741,4 +746,10 @@ func initUpdateAdmissionRequestObj(objName, objNamespace string, operation admis
 		Raw: oldObjBytes,
 	}
 	return obj
+}
+
+func unmarshalValidatorError(errJSON string) webhooks.ValidationError {
+	ve := webhooks.ValidationError{}
+	Expect(json.Unmarshal([]byte(errJSON), &ve)).To(Succeed())
+	return ve
 }

--- a/controllers/webhooks/services/cfserviceinstance_validation_test.go
+++ b/controllers/webhooks/services/cfserviceinstance_validation_test.go
@@ -105,7 +105,7 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.DuplicateServiceInstanceNameError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: services.DuplicateServiceInstanceNameError, Message: `The service instance name is taken: ` + serviceInstance.Spec.Name}.Marshal()))
 			})
 		})
 
@@ -143,7 +143,7 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})
@@ -208,7 +208,7 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.DuplicateServiceInstanceNameError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: services.DuplicateServiceInstanceNameError, Message: `The service instance name is taken: ` + updatedServiceInstance.Spec.Name}.Marshal()))
 			})
 		})
 
@@ -219,7 +219,7 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})
@@ -262,7 +262,7 @@ var _ = Describe("CFServiceInstanceValidatingWebhook", func() {
 
 			It("disallows the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/cfapp_validation_test.go
+++ b/controllers/webhooks/workloads/cfapp_validation_test.go
@@ -103,7 +103,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.DuplicateAppError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: workloads.DuplicateAppError, Message: `App with the name '` + app.Spec.Name + `' already exists.`}.Marshal()))
 			})
 		})
 
@@ -141,7 +141,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})
@@ -206,7 +206,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.DuplicateAppError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.ValidationError{Type: workloads.DuplicateAppError, Message: `App with the name '` + updatedApp.Spec.Name + `' already exists.`}.Marshal()))
 			})
 		})
 
@@ -217,7 +217,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 
 			It("denies the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})
@@ -260,7 +260,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 
 			It("disallows the request", func() {
 				Expect(response.Allowed).To(BeFalse())
-				Expect(string(response.Result.Reason)).To(Equal(webhooks.UnknownError.Marshal()))
+				Expect(string(response.Result.Reason)).To(Equal(webhooks.AdmissionUnknownErrorReason()))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/integration/cfapp_validation_integration_test.go
+++ b/controllers/webhooks/workloads/integration/cfapp_validation_integration_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
@@ -93,7 +94,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(createErr).To(MatchError(ContainSubstring("CFApp with the same spec.name exists")))
+				Expect(createErr).To(MatchError(ContainSubstring(fmt.Sprintf("App with the name '%s' already exists.", app1Name))))
 			})
 		})
 
@@ -106,7 +107,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(createErr).To(MatchError(ContainSubstring("CFApp with the same spec.name exists")))
+				Expect(createErr).To(MatchError(ContainSubstring(fmt.Sprintf("App with the name '%s' already exists.", app1Name))))
 			})
 		})
 	})
@@ -171,7 +172,7 @@ var _ = Describe("CFAppValidatingWebhook", func() {
 			})
 
 			It("should fail", func() {
-				Expect(updateErr).To(MatchError(ContainSubstring("CFApp with the same spec.name exists")))
+				Expect(updateErr).To(MatchError(ContainSubstring(fmt.Sprintf("App with the name '%s' already exists.", app2Name))))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/integration/subnamespaceanchor_validation_test.go
+++ b/controllers/webhooks/workloads/integration/subnamespaceanchor_validation_test.go
@@ -64,7 +64,7 @@ var _ = Describe("SubnamespaceanchorValidation", func() {
 		When("the name already exists in its namespace", func() {
 			It("fails", func() {
 				_, err := createOrg(otherNamespace.Name, "my-org")
-				Expect(err).To(MatchError(ContainSubstring("Org with same name exists")))
+				Expect(err).To(MatchError(ContainSubstring("Organization 'my-org' already exists.")))
 			})
 		})
 	})
@@ -85,7 +85,7 @@ var _ = Describe("SubnamespaceanchorValidation", func() {
 		When("the name already exists in the org namespace", func() {
 			It("fails", func() {
 				_, err := createSpace(otherNamespace.Name, "my-space")
-				Expect(err).To(MatchError(ContainSubstring("Space with same name exists")))
+				Expect(err).To(MatchError(ContainSubstring("Name must be unique per organization")))
 			})
 		})
 	})
@@ -142,7 +142,7 @@ var _ = Describe("SubnamespaceanchorValidation", func() {
 			})
 
 			It("fails", func() {
-				Expect(k8sClient.Patch(ctx, updatedOrg, client.MergeFrom(org))).To(MatchError(ContainSubstring("Org with same name exists")))
+				Expect(k8sClient.Patch(ctx, updatedOrg, client.MergeFrom(org))).To(MatchError(ContainSubstring("Organization 'another-org' already exists.")))
 			})
 		})
 	})
@@ -199,7 +199,7 @@ var _ = Describe("SubnamespaceanchorValidation", func() {
 			})
 
 			It("fails", func() {
-				Expect(k8sClient.Patch(ctx, updatedSpace, client.MergeFrom(space))).To(MatchError(ContainSubstring("Space with same name exists")))
+				Expect(k8sClient.Patch(ctx, updatedSpace, client.MergeFrom(space))).To(MatchError(ContainSubstring("Name must be unique per organization")))
 			})
 		})
 	})

--- a/controllers/webhooks/workloads/subnamespaceanchor_validation.go
+++ b/controllers/webhooks/workloads/subnamespaceanchor_validation.go
@@ -3,6 +3,7 @@ package workloads
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
 	"github.com/go-logr/logr"
@@ -21,6 +22,13 @@ const (
 	SpaceNameLabel  = "cloudfoundry.org/space-name"
 	OrgEntityType   = "org"
 	SpaceEntityType = "space"
+
+	DuplicateOrgNameError = "DuplicateOrgNameError"
+	// Note: the cf cli expects the specfic text `Organization '.*' already exists.` in the error and ignores the error if it matches it.
+	duplicateOrgNameErrorMessage = "Organization '%s' already exists."
+	DuplicateSpaceNameError      = "DuplicateSpaceNameError"
+	// Note: the cf cli expects the specific text `Name must be unique per organization` in the error and ignores the error if it matches it.
+	duplicateSpaceNameErrorMessage = "Space '%s' already exists. Name must be unique per organization."
 )
 
 var subnsLogger = logf.Log.WithName("subns-validate")
@@ -51,7 +59,7 @@ func (v *SubnamespaceAnchorValidation) Handle(ctx context.Context, req admission
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
 		if err := v.decoder.Decode(req, anchor); err != nil {
 			subnsLogger.Error(err, "failed to decode subnamespace anchor", "request", req)
-			return admission.Denied(webhooks.UnknownError.Marshal())
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 		}
 
 		if valid, response := v.validateLabels(anchor); !valid {
@@ -61,7 +69,7 @@ func (v *SubnamespaceAnchorValidation) Handle(ctx context.Context, req admission
 		var err error
 		handler, err = v.newHandler(anchor)
 		if err != nil {
-			return admission.Denied(webhooks.UnknownError.Marshal())
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 		}
 
 	}
@@ -70,7 +78,7 @@ func (v *SubnamespaceAnchorValidation) Handle(ctx context.Context, req admission
 	if req.Operation == admissionv1.Update || req.Operation == admissionv1.Delete {
 		if err := v.decoder.DecodeRaw(req.OldObject, oldAnchor); err != nil {
 			subnsLogger.Error(err, "failed to decode old subnamespace anchor", "request", req)
-			return admission.Denied(webhooks.UnknownError.Marshal())
+			return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 		}
 
 		if valid, _ := v.validateLabels(oldAnchor); !valid {
@@ -97,7 +105,7 @@ func (v *SubnamespaceAnchorValidation) Handle(ctx context.Context, req admission
 	}
 
 	subnsLogger.Info("unexpected operation", "operation", req.Operation)
-	return admission.Denied(webhooks.UnknownError.Marshal())
+	return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 }
 
 func (v *SubnamespaceAnchorValidation) validateLabels(anchor *v1alpha2.SubnamespaceAnchor) (bool, admission.Response) {
@@ -107,7 +115,7 @@ func (v *SubnamespaceAnchorValidation) validateLabels(anchor *v1alpha2.Subnamesp
 
 	if anchor.Labels[OrgNameLabel] != "" && anchor.Labels[SpaceNameLabel] != "" {
 		subnsLogger.Info("cannot have both org and space labels set", "anchor", anchor)
-		return false, admission.Denied(webhooks.UnknownError.Marshal())
+		return false, admission.Denied(webhooks.AdmissionUnknownErrorReason())
 	}
 
 	return true, admission.Response{}
@@ -121,7 +129,7 @@ func (v *SubnamespaceAnchorValidation) newHandler(anchor *v1alpha2.SubnamespaceA
 			subnsLogger.WithValues("entityType", OrgEntityType),
 			v.duplicateOrgValidator,
 			OrgNameLabel,
-			webhooks.DuplicateOrgNameError,
+			webhooks.ValidationError{Type: DuplicateOrgNameError, Message: duplicateOrgNameErrorMessage},
 		), nil
 
 	case anchor.Labels[SpaceNameLabel] != "" && anchor.Labels[OrgNameLabel] == "":
@@ -129,7 +137,7 @@ func (v *SubnamespaceAnchorValidation) newHandler(anchor *v1alpha2.SubnamespaceA
 			subnsLogger.WithValues("entityType", SpaceEntityType),
 			v.duplicateSpaceValidator,
 			SpaceNameLabel,
-			webhooks.DuplicateSpaceNameError,
+			webhooks.ValidationError{Type: DuplicateSpaceNameError, Message: duplicateSpaceNameErrorMessage},
 		), nil
 
 	default:
@@ -139,10 +147,18 @@ func (v *SubnamespaceAnchorValidation) newHandler(anchor *v1alpha2.SubnamespaceA
 	}
 }
 
+func (h *subnamespaceAnchorHandler) RenderDuplicateError(duplicateName string) string {
+	formattedDuplicateError := webhooks.ValidationError{
+		Type:    h.duplicateError.Type,
+		Message: fmt.Sprintf(h.duplicateError.Message, duplicateName),
+	}
+	return formattedDuplicateError.Marshal()
+}
+
 type subnamespaceAnchorHandler struct {
 	duplicateValidator NameValidator
 	nameLabel          string
-	duplicateError     webhooks.ValidationErrorCode
+	duplicateError     webhooks.ValidationError
 	logger             logr.Logger
 }
 
@@ -150,7 +166,7 @@ func NewSubnamespaceAnchorHandler(
 	logger logr.Logger,
 	duplicateValidator NameValidator,
 	nameLabel string,
-	duplicateError webhooks.ValidationErrorCode,
+	duplicateError webhooks.ValidationError,
 ) subnamespaceAnchorHandler {
 	return subnamespaceAnchorHandler{
 		duplicateValidator: duplicateValidator,
@@ -161,24 +177,26 @@ func NewSubnamespaceAnchorHandler(
 }
 
 func (h subnamespaceAnchorHandler) handleCreate(ctx context.Context, anchor *v1alpha2.SubnamespaceAnchor) admission.Response {
-	if err := h.duplicateValidator.ValidateCreate(ctx, h.logger, anchor.Namespace, h.getName(anchor)); err != nil {
+	anchorName := h.getName(anchor)
+	if err := h.duplicateValidator.ValidateCreate(ctx, h.logger, anchor.Namespace, anchorName); err != nil {
 		if errors.Is(err, webhooks.ErrorDuplicateName) {
-			return admission.Denied(h.duplicateError.Marshal())
+			return admission.Denied(h.RenderDuplicateError(anchorName))
 		}
 
-		return admission.Denied(webhooks.UnknownError.Marshal())
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 	}
 
 	return admission.Allowed("")
 }
 
 func (h subnamespaceAnchorHandler) handleUpdate(ctx context.Context, oldAnchor, newAnchor *v1alpha2.SubnamespaceAnchor) admission.Response {
-	if err := h.duplicateValidator.ValidateUpdate(ctx, h.logger, oldAnchor.Namespace, h.getName(oldAnchor), h.getName(newAnchor)); err != nil {
+	newAnchorName := h.getName(newAnchor)
+	if err := h.duplicateValidator.ValidateUpdate(ctx, h.logger, oldAnchor.Namespace, h.getName(oldAnchor), newAnchorName); err != nil {
 		if errors.Is(err, webhooks.ErrorDuplicateName) {
-			return admission.Denied(h.duplicateError.Marshal())
+			return admission.Denied(h.RenderDuplicateError(newAnchorName))
 		}
 
-		return admission.Denied(webhooks.UnknownError.Marshal())
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 	}
 
 	return admission.Allowed("")
@@ -186,7 +204,7 @@ func (h subnamespaceAnchorHandler) handleUpdate(ctx context.Context, oldAnchor, 
 
 func (h subnamespaceAnchorHandler) handleDelete(ctx context.Context, oldAnchor *v1alpha2.SubnamespaceAnchor) admission.Response {
 	if err := h.duplicateValidator.ValidateDelete(ctx, h.logger, oldAnchor.Namespace, h.getName(oldAnchor)); err != nil {
-		return admission.Denied(webhooks.UnknownError.Marshal())
+		return admission.Denied(webhooks.AdmissionUnknownErrorReason())
 	}
 
 	return admission.Allowed("")

--- a/controllers/webhooks/workloads/subnamespaceanchor_validation_test.go
+++ b/controllers/webhooks/workloads/subnamespaceanchor_validation_test.go
@@ -5,17 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads/fake"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads/integration/helpers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	hnsv1alpha2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
-
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads/fake"
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads/integration/helpers"
 )
 
 var _ = Describe("SubnamespaceanchorValidation", func() {


### PR DESCRIPTION
## Is there a related GitHub Issue?
No. Done as support to #852

## What is this change about?
Refactor validation errors. `code` was used to extract canned messages after serialization/deserialization. This isn't as helpful as we'd like, so we replaced this with a `validationErrorType` and made some messaging more dynamic.

## Does this PR introduce a breaking change?
Should not contain breaking changes.

## Acceptance Steps
Run all the tests.

## Tag your pair, your PM, and/or team
@gnovv @matt-royal @tcdowney @gcapizzi 
