### PR TITLE
Correct apply-manifest error when user can't access space

### DIFF
--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -181,7 +181,7 @@ func (f *AppRepo) GetAppByNameAndSpace(ctx context.Context, authInfo authorizati
 	appList := new(workloadsv1alpha1.CFAppList)
 	err = userClient.List(ctx, appList, client.InNamespace(spaceGUID))
 	if err != nil {
-		return AppRecord{}, apierrors.FromK8sError(fmt.Errorf("get app: failed to list apps: %w", err), AppResourceType)
+		return AppRecord{}, apierrors.FromK8sError(fmt.Errorf("get app: failed to list apps: %w", err), SpaceResourceType)
 	}
 
 	var matchingApps []workloadsv1alpha1.CFApp

--- a/api/repositories/app_repository_test.go
+++ b/api/repositories/app_repository_test.go
@@ -147,9 +147,9 @@ var _ = Describe("AppRepository", func() {
 			appRecord, getErr = appRepo.GetAppByNameAndSpace(context.Background(), authInfo, cfApp1.Spec.Name, querySpaceName)
 		})
 
-		When("the user is authorized in the space", func() {
+		When("the user is able to get apps in the space", func() {
 			BeforeEach(func() {
-				createRoleBinding(testCtx, userName, spaceDeveloperRole.Name, querySpaceName)
+				createRoleBinding(testCtx, userName, spaceManagerRole.Name, querySpaceName)
 			})
 
 			It("returns the record", func() {
@@ -164,9 +164,10 @@ var _ = Describe("AppRepository", func() {
 			})
 		})
 
-		When("the user is not authorized in the space", func() {
+		When("the user is not authorized in the space at all", func() {
 			It("returns a forbidden error", func() {
 				Expect(getErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.ForbiddenError{}))
+				Expect(getErr.(apierrors.ForbiddenError).ResourceType()).To(Equal(SpaceResourceType))
 			})
 		})
 
@@ -175,6 +176,7 @@ var _ = Describe("AppRepository", func() {
 				querySpaceName = space2.Name
 				createRoleBinding(testCtx, userName, spaceDeveloperRole.Name, querySpaceName)
 			})
+
 			It("returns a NotFoundError", func() {
 				Expect(getErr).To(matchers.WrapErrorAssignableToTypeOf(apierrors.NotFoundError{}))
 			})

--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -409,7 +409,7 @@ var _ = Describe("Spaces", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusNotFound))
 					Expect(resultErr.Errors).To(ConsistOf(
 						cfErr{
-							Detail: "App not found. Ensure it exists and you have access to it.",
+							Detail: "Space not found. Ensure it exists and you have access to it.",
 							Title:  "CF-ResourceNotFound",
 							Code:   10010,
 						},


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#741. This resolves an issue with the original PR

## What is this change about?
Correct the error message when a user applies a manifest to a space they can't access

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
See issue

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@gcapizzi 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
