### PR TITLE
Fix Route FQDN Validating Webhook

### DIFF
--- a/api/apis/route_handler.go
+++ b/api/apis/route_handler.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/cf-k8s-controllers/api/payloads"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/presenter"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/networking"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
@@ -161,14 +160,7 @@ func (h *RouteHandler) routeCreateHandler(authInfo authorization.Info, r *http.R
 		)
 	}
 
-	_, err = networking.IsFQDN(payload.Host, domain.Name)
-	if err != nil {
-		h.logger.Info(err.Error(), "HostName", payload.Host, "Domain Name", domain.Name)
-		return nil, apierrors.NewUnprocessableEntityError(err, fmt.Sprintf("Invalid Route, %v", err.Error()))
-	}
-
 	createRouteMessage := payload.ToMessage(domain.Namespace, domain.Name)
-
 	responseRouteRecord, err := h.routeRepo.CreateRoute(ctx, authInfo, createRouteMessage)
 	if err != nil {
 		h.logger.Error(err, "Failed to create route", "Route Host", payload.Host)

--- a/api/apis/route_handler_test.go
+++ b/api/apis/route_handler_test.go
@@ -7,15 +7,14 @@ import (
 	"net/http"
 	"strings"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
-	. "github.com/onsi/gomega/gstruct"
-
 	. "code.cloudfoundry.org/cf-k8s-controllers/api/apis"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apis/fake"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/repositories"
 
+	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -803,37 +802,6 @@ var _ = Describe("RouteHandler", func() {
 
 			It("returns an error", func() {
 				expectUnprocessableEntityError("Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag")
-			})
-		})
-
-		When("the FQDN is invalid with invalid characters", func() {
-			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{
-					GUID: testDomainGUID,
-					Name: "this-is-@n-inv@lid-dom@in-n@me",
-				}, nil)
-			})
-
-			It("returns an error", func() {
-				Expect(rr).To(HaveHTTPStatus(http.StatusUnprocessableEntity))
-				Expect(rr).To(HaveHTTPHeaderWithValue("Content-Type", jsonHeader))
-				// This is ugly, but we are going to deprecate this test
-				Expect(rr.Body.String()).To(ContainSubstring(`FQDN does not comply with RFC 1035 standards`))
-				Expect(rr.Body.String()).To(ContainSubstring(`"code":10008`))
-				Expect(rr.Body.String()).To(ContainSubstring(`"title":"CF-UnprocessableEntity"`))
-			})
-		})
-
-		When("the FQDN is invalid with invalid length", func() {
-			BeforeEach(func() {
-				domainRepo.GetDomainReturns(repositories.DomainRecord{
-					GUID: testDomainGUID,
-					Name: "a-very-looooooooooooong-invalid-domain-name-that-should-fail-validation",
-				}, nil)
-			})
-
-			It("returns an error", func() {
-				expectUnprocessableEntityError("Invalid Route, subdomains must each be at most 63 characters")
 			})
 		})
 

--- a/api/repositories/app_repository.go
+++ b/api/repositories/app_repository.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
-
 	"code.cloudfoundry.org/cf-k8s-controllers/api/apierrors"
 	"code.cloudfoundry.org/cf-k8s-controllers/api/authorization"
 	workloadsv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/workloads/v1alpha1"
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks"
+	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/workloads"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -1,15 +1,23 @@
 package e2e_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
+
+	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Routes", func() {
@@ -261,14 +269,45 @@ var _ = Describe("Routes", func() {
 			})
 
 			When("the host on the route is invalid", func() {
+				const (
+					domainName = "inv@liddom@in"
+				)
+
+				var (
+					// we need a K8s client for this test case for when the default domain name is not compliant
+					k8sClient k8sclient.WithWatch
+				)
+
 				BeforeEach(func() {
-					host = "inv@lid"
+					config, err := controllerruntime.GetConfig()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(networkingv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+					k8sClient, err = k8sclient.NewWithWatch(config, k8sclient.Options{Scheme: scheme.Scheme})
+					Expect(err).NotTo(HaveOccurred())
+					domainGUID = uuid.NewString()
+					domain := &networkingv1alpha1.CFDomain{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      domainGUID,
+							Namespace: rootNamespace,
+						},
+						Spec: networkingv1alpha1.CFDomainSpec{
+							Name: domainName,
+						},
+					}
+					Expect(
+						k8sClient.Create(context.Background(), domain),
+					).To(Succeed())
+				})
+
+				AfterEach(func() {
+					Expect(
+						k8sClient.Delete(context.Background(), &networkingv1alpha1.CFDomain{ObjectMeta: metav1.ObjectMeta{Namespace: rootNamespace, Name: domainGUID}})).To(Succeed())
 				})
 
 				It("fails with a invalid route error", func() {
 					Expect(resp).To(HaveRestyStatusCode(http.StatusUnprocessableEntity))
 					Expect(createErr.Errors).To(ConsistOf(cfErr{
-						Detail: "Key: 'RouteCreate.Host' Error:Field validation for 'Host' failed on the 'hostname_rfc1123' tag",
+						Detail: "ValidationError-RouteFQDNValidationError: FQDN does not comply with RFC 1035 standards",
 						Title:  "CF-UnprocessableEntity",
 						Code:   10008,
 					}))

--- a/controllers/webhooks/networking/cfdomain_validation_test.go
+++ b/controllers/webhooks/networking/cfdomain_validation_test.go
@@ -5,16 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/google/uuid"
-	admissionv1 "k8s.io/api/admission/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	networkingv1alpha1 "code.cloudfoundry.org/cf-k8s-controllers/controllers/apis/networking/v1alpha1"
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/networking"
 	"code.cloudfoundry.org/cf-k8s-controllers/controllers/webhooks/networking/fake"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -287,7 +287,7 @@ func IsFQDN(host, domain string) (bool, error) {
 		// of the domain.
 		MAXIMUM_FQDN_DOMAIN_LENGTH = 253
 		MINIMUM_FQDN_DOMAIN_LENGTH = 3
-		DOMAIN_REGEX               = "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])\\.)+([a-z0-9]|[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9])$"
+		DOMAIN_REGEX               = "^[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$"
 		SUBDOMAIN_REGEX            = "^([^\\.]{0,63}\\.)*[^\\.]{0,63}$"
 	)
 

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -32,6 +32,8 @@ const (
 	RouteDestinationNotInSpaceErrorMessage = "Route destination app not found in space"
 	RouteHostNameValidationErrorType       = "RouteHostNameValidationError"
 	RoutePathValidationErrorType           = "RoutePathValidationError"
+	RouteSubdomainValidationErrorType      = "RouteSubdomainValidationError"
+	RouteSubdomainValidationErrorMessage   = "Subdomains must each be at most 63 characters"
 	RouteFQDNValidationErrorType           = "RouteFQDNValidationError"
 	RouteFQDNValidationErrorMessage        = "FQDN does not comply with RFC 1035 standards"
 
@@ -294,7 +296,7 @@ func IsFQDN(host, domain string) (bool, error) {
 	rxSubdomain := regexp.MustCompile(SUBDOMAIN_REGEX)
 
 	if !rxSubdomain.MatchString(fqdn) {
-		return false, errors.New("subdomains must each be at most 63 characters")
+		return false, errors.New(webhooks.ValidationError{Type: RouteSubdomainValidationErrorType, Message: RouteSubdomainValidationErrorMessage}.Marshal())
 	}
 
 	rxDomain := regexp.MustCompile(DOMAIN_REGEX)

--- a/controllers/webhooks/networking/cfroute_validation.go
+++ b/controllers/webhooks/networking/cfroute_validation.go
@@ -201,7 +201,7 @@ func (v *CFRouteValidation) Handle(ctx context.Context, req admission.Request) a
 }
 
 func uniqueName(route networkingv1alpha1.CFRoute) string {
-	return strings.Join([]string{route.Spec.Host, route.Spec.DomainRef.Namespace, route.Spec.DomainRef.Name, route.Spec.Path}, "::")
+	return strings.Join([]string{strings.ToLower(route.Spec.Host), route.Spec.DomainRef.Namespace, route.Spec.DomainRef.Name, route.Spec.Path}, "::")
 }
 
 func validatePath(route networkingv1alpha1.CFRoute) error {

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -170,7 +170,7 @@ echo "**************************************"
 echo "Installing Service Binding Controller"
 echo "**************************************"
 
-#kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
+kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
 
 echo "******"
 echo "Done"

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -170,7 +170,7 @@ echo "**************************************"
 echo "Installing Service Binding Controller"
 echo "**************************************"
 
-kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
+#kubectl apply -f https://github.com/vmware-tanzu/servicebinding/releases/download/v0.7.1/service-bindings-0.7.1.yaml
 
 echo "******"
 echo "Done"


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
closes #853
## What is this change about?
<!-- _Please describe the change here._ -->
- Modifies FQDN regex to allow domains w/ upper-case letters
- Removes extra api shim FQDN check to instead elevate webhook error
- Modifies route FQDN e2e test to use k8s client and create an invalid domain for just one edge case

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
see bug.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@acosta11 
@Birdrock 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
