### PR TITLE
Remove hard-coded `vcap.me` in e2e test

### DIFF
--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -314,7 +314,7 @@ var _ = Describe("Spaces", func() {
 			spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
 			resultErr = cfErrs{}
 
-			route := "manifested-app.vcap.me"
+			route := fmt.Sprintf("manifested-app.%s", appFQDN)
 			command := "whatever"
 			manifest = manifestResource{
 				Version: 1,


### PR DESCRIPTION
Use the appFQDN var instead