### PR TITLE
Issue/300 run e2e on concourse

### DIFF
--- a/api/config/overlays/pr-e2e/apiconfig/cf_k8s_api_config.yaml
+++ b/api/config/overlays/pr-e2e/apiconfig/cf_k8s_api_config.yaml
@@ -1,0 +1,14 @@
+externalFQDN: cf.pr-e2e.cf-k8s.cf
+internalPort: 9000
+
+rootNamespace: cf
+defaultLifecycleConfig:
+  type: buildpack
+  stack: cflinuxfs3
+  stagingMemoryMB: 1024
+  stagingDiskMB: 1024
+packageRegistryBase: europe-west1-docker.pkg.dev/cf-on-k8s-wg/pr-e2e-images
+packageRegistrySecretName: image-registry-credentials # Create this secret in the rootNamespace
+authEnabled: true
+clusterBuilderName: cf-kpack-cluster-builder
+defaultDomainName: pr-e2e.cf-k8s.cf

--- a/api/config/overlays/pr-e2e/kustomization.yaml
+++ b/api/config/overlays/pr-e2e/kustomization.yaml
@@ -1,0 +1,22 @@
+configMapGenerator:
+- behavior: merge
+  files:
+  - apiconfig/cf_k8s_api_config.yaml
+  name: config
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patches:
+- target:
+    group: projectcontour.io
+    version: v1
+    kind: HTTPProxy
+    name: proxy
+  patch: |-
+    - op: replace
+      path: /spec/virtualhost/fqdn
+      value: "cf.pr-e2e.cf-k8s.cf"

--- a/controllers/config/overlays/pr-e2e/controllersconfig/cf_k8s_controllers_config.yaml
+++ b/controllers/config/overlays/pr-e2e/controllersconfig/cf_k8s_controllers_config.yaml
@@ -1,0 +1,8 @@
+kpackImageTag: europe-west1-docker.pkg.dev/cf-on-k8s-wg/pr-e2e-images/kpack/beta
+clusterBuilderName: cf-kpack-cluster-builder
+cfProcessDefaults:
+  memoryMB: 1024
+  diskQuotaMB: 1024
+cfRootNamespace: cf
+cfk8s_controller_namespace: cf-k8s-controllers-system
+workloads_tls_secret_name: cf-k8s-workloads-ingress-cert

--- a/controllers/config/overlays/pr-e2e/kustomization.yaml
+++ b/controllers/config/overlays/pr-e2e/kustomization.yaml
@@ -1,0 +1,11 @@
+configMapGenerator:
+- behavior: merge
+  files:
+  - controllersconfig/cf_k8s_controllers_config.yaml
+  name: config
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default

--- a/scripts/assets/cf-k8s-api-kbld.yml
+++ b/scripts/assets/cf-k8s-api-kbld.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: cloudfoundry/cf-k8s-api:latest
+  path: .
+  docker:
+    build:
+      file: api/Dockerfile
+      # rawOptions: ["--build-arg", "GIT_SHA=eirini-controller-dirty", "--tag", "eirini-controller"]
+      buildkit: true
+destinations:
+- image: cloudfoundry/cf-k8s-api:latest
+  newImage: europe-west1-docker.pkg.dev/cf-on-k8s-wg/ci/cf-k8s-api

--- a/scripts/assets/cf-k8s-controllers-kbld.yml
+++ b/scripts/assets/cf-k8s-controllers-kbld.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: cloudfoundry/cf-k8s-controllers:latest
+  path: .
+  docker:
+    build:
+      file: controllers/Dockerfile
+      # rawOptions: ["--build-arg", "GIT_SHA=eirini-controller-dirty", "--tag", "eirini-controller"]
+      buildkit: true
+destinations:
+- image: cloudfoundry/cf-k8s-controllers:latest
+  newImage: europe-west1-docker.pkg.dev/cf-on-k8s-wg/ci/cf-k8s-controllers

--- a/scripts/create-new-user.sh
+++ b/scripts/create-new-user.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if [[ $# -ne 1 ]]; then
   cat <<EOF >&2
 Usage:
@@ -12,9 +14,12 @@ EOF
 fi
 
 username="$1"
-priv_key_file="$(mktemp)"
-csr_file="$(mktemp)"
-cert_file="$(mktemp)"
+tmp="$(mktemp -d)"
+trap "rm -rf $tmp" EXIT
+
+priv_key_file="$tmp/key.pem"
+csr_file="$tmp/csr.pem"
+cert_file="$tmp/cert.pem"
 csr_name="$(echo ${RANDOM} | shasum | head -c 40)"
 
 openssl req -new -newkey rsa:4096 \
@@ -36,7 +41,16 @@ spec:
 EOF
 
 kubectl certificate approve "${csr_name}"
-kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}' | base64 --decode >"${cert_file}"
+
+certificate="$(kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}')"
+until [ -n "$certificate" ]; do
+  certificate="$(kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}')"
+  echo -n .
+  sleep 1
+done
+
+echo $certificate | base64 --decode >"${cert_file}"
+
 kubectl config set-credentials "${username}" --client-certificate="${cert_file}" --client-key="${priv_key_file}" --embed-certs
 
 cat <<EOF

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -230,6 +230,7 @@ function install_dependencies() {
       export DOCKER_SERVER="localregistry-docker-registry.default.svc.cluster.local:30050"
       export DOCKER_USERNAME="whatevs"
       export DOCKER_PASSWORD="whatevs"
+      export KPACK_TAG="localregistry-docker-registry.default.svc.cluster.local:30050/cf-relint-greengrass/cf-k8s-controllers/kpack/beta"
     fi
 
     "${SCRIPT_DIR}/install-dependencies.sh"

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -103,9 +103,8 @@ kubectl apply -f "${DEP_DIR}/kpack/service_account.yaml"
 kubectl apply -f "${DEP_DIR}/kpack/cluster_stack.yaml" \
   -f "${DEP_DIR}/kpack/cluster_store.yaml"
 
-if [[ -n "${DOCKER_SERVER:=}" ]]; then
-  cat dependencies/kpack/cluster_builder.yaml | sed "s/tag: gcr.io/tag: ${DOCKER_SERVER}/g" >/tmp/clusterbuilder.yml
-  kubectl apply -f /tmp/clusterbuilder.yml
+if [[ -n "${KPACK_TAG:=}" ]]; then
+  sed "s|tag: gcr\.io.*$|tag: $KPACK_TAG|" "$DEP_DIR/kpack/cluster_builder.yaml" | kubectl apply -f-
 else
   kubectl apply -f "${DEP_DIR}/kpack/cluster_builder.yaml"
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -42,7 +42,8 @@ else
     export APP_FQDN=vcap.me
   fi
 
-  export KUBECONFIG="${HOME}/.kube/e2e.yml"
+  export KUBECONFIG="${KUBECONFIG:-$HOME/kube/e2e.yml}"
+
   if [ -z "${SKIP_DEPLOY}" ]; then
     "${SCRIPT_DIR}/deploy-on-kind.sh" -l e2e
   fi


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#300
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->

## What is this change about?
We are preparing the codebase to run e2e tests on concourse.

This requires kustomize overlays to set a different domain name. And we've added greater control when using a different image registry in the install-dependencies script.

This also fixes a problem when the create user script doesn't wait long enough to get the certificate. This sometimes takes longer on GCP.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es should still work fine locally and on github actions.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
