### PR TITLE
Bump HNC to v1.0.0

### DIFF
--- a/dependencies/hnc/base/default-v1.0.0.yaml
+++ b/dependencies/hnc/base/default-v1.0.0.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: hierarchyconfigurations.hnc.x-k8s.io
 spec:
@@ -45,6 +45,38 @@ spec:
               allowCascadingDeletion:
                 description: AllowCascadingDeletion indicates if the subnamespaces of this namespace are allowed to cascading delete.
                 type: boolean
+              annotations:
+                description: Annotations is a list of annotations and values to apply to the current namespace and all of its descendants. All annotation keys must match a regex specified on the command line by --managed-namespace-annotation. A namespace cannot have a KVP that conflicts with one of its ancestors.
+                items:
+                  description: MetaKVP represents a label or annotation
+                  properties:
+                    key:
+                      description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                      type: string
+                    value:
+                      description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              labels:
+                description: Lables is a list of labels and values to apply to the current namespace and all of its descendants. All label keys must match a regex specified on the command line by --managed-namespace-label. A namespace cannot have a KVP that conflicts with one of its ancestors.
+                items:
+                  description: MetaKVP represents a label or annotation
+                  properties:
+                    key:
+                      description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                      type: string
+                    value:
+                      description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
               parent:
                 description: Parent indicates the parent of this namespace, if any.
                 type: string
@@ -60,7 +92,7 @@ spec:
               conditions:
                 description: Conditions describes the errors, if any.
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -116,7 +148,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: hncconfigurations.hnc.x-k8s.io
 spec:
@@ -178,7 +210,7 @@ spec:
               conditions:
                 description: Conditions describes the errors, if any. If there are any conditions with "ActivitiesHalted" reason, this means that HNC cannot function in the affected namespaces. The HierarchyConfiguration object in each of the affected namespaces will have more information. To learn more about conditions, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#admin-conditions.
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
@@ -265,7 +297,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: subnamespaceanchors.hnc.x-k8s.io
 spec:
@@ -291,6 +323,41 @@ spec:
             description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
+            type: object
+          spec:
+            properties:
+              annotations:
+                description: Annotations is a list of annotations and values to apply to the current subnamespace and all of its descendants. All annotation keys must match a regex specified on the command line by --managed-namespace-annotation. All annotation keys must be managed annotations (see HNC docs) and must match a regex
+                items:
+                  description: MetaKVP represents a label or annotation
+                  properties:
+                    key:
+                      description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                      type: string
+                    value:
+                      description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              labels:
+                description: Labels is a list of labels and values to apply to the current subnamespace and all of its descendants. All label keys must match a regex specified on the command line by --managed-namespace-label. All label keys must be managed labels (see HNC docs) and must match a regex
+                items:
+                  description: MetaKVP represents a label or annotation
+                  properties:
+                    key:
+                      description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                      type: string
+                    value:
+                      description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
             type: object
           status:
             description: SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
@@ -518,16 +585,22 @@ spec:
         - --webhook-server-port=9443
         - --metrics-addr=:8080
         - --max-reconciles=10
-        - --apiserver-qps-throttle=200
-        - --enable-internal-cert-management
-        - --cert-restart-on-secret-refresh
+        - --apiserver-qps-throttle=50
         - --excluded-namespace=kube-system
         - --excluded-namespace=kube-public
         - --excluded-namespace=hnc-system
         - --excluded-namespace=kube-node-lease
+        - --enable-internal-cert-management
+        - --cert-restart-on-secret-refresh
         command:
         - /manager
-        image: gcr.io/k8s-staging-multitenancy/hnc-manager:v0.9.0
+        image: gcr.io/k8s-staging-multitenancy/hnc-manager:v1.0.0
+        livenessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 10
         name: manager
         ports:
         - containerPort: 9443
@@ -536,13 +609,24 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          periodSeconds: 5
         resources:
           limits:
-            cpu: 500m
+            cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 200m
+            cpu: 100m
             memory: 150Mi
+        startupProbe:
+          failureThreshold: 100
+          httpGet:
+            path: /readyz
+            port: 8081
+          periodSeconds: 5
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/dependencies/hnc/base/kustomization.yaml
+++ b/dependencies/hnc/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - default-v1.0.0.yaml

--- a/dependencies/hnc/cf/deployment.yaml
+++ b/dependencies/hnc/cf/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hnc-controller-manager
+  namespace: hnc-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+          # adding this to only check namespaces beginning with 'cf'
+        - --included-namespace-regex=cf.*
+          # changing this from 50
+        - --apiserver-qps-throttle=200
+          # the rest are from the default, but must be included :(
+        - --webhook-server-port=9443
+        - --metrics-addr=:8080
+        - --max-reconciles=10
+        - --excluded-namespace=kube-system
+        - --excluded-namespace=kube-public
+        - --excluded-namespace=hnc-system
+        - --excluded-namespace=kube-node-lease
+        - --enable-internal-cert-management
+        - --cert-restart-on-secret-refresh
+        resources:
+          limits:
+            # increase limit from 100m
+            cpu: 500m
+          requests:
+            # increase request from 100m
+            cpu: 200m

--- a/dependencies/hnc/cf/kustomization.yaml
+++ b/dependencies/hnc/cf/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../base
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.11.2
 	sigs.k8s.io/controller-tools v0.8.0
-	sigs.k8s.io/hierarchical-namespaces v0.9.0
+	sigs.k8s.io/hierarchical-namespaces v1.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2982,6 +2982,8 @@ sigs.k8s.io/gateway-api v0.3.0/go.mod h1:Wb8bx7QhGVZxOSEU3i9vw/JqTB5Nlai9MLMYVZe
 sigs.k8s.io/gateway-api v0.4.1/go.mod h1:r3eiNP+0el+NTLwaTfOrCNXy8TukC+dIM3ggc+fbNWk=
 sigs.k8s.io/hierarchical-namespaces v0.9.0 h1:GbNkRITpJ8SwnZoO3ZillHDn0D/AySP5Fosa2ZPEol0=
 sigs.k8s.io/hierarchical-namespaces v0.9.0/go.mod h1:qHqqjgYqzMPg7BwpkndOkK7dwmzBdUj0tvSSrmQzouk=
+sigs.k8s.io/hierarchical-namespaces v1.0.0 h1:rgfkknTEFhAF/28p1sKdiJqUa+OvvNQ20rlyFGIRaro=
+sigs.k8s.io/hierarchical-namespaces v1.0.0/go.mod h1:zqfhmqEdCUY2S75WsrmfPPu+ns35522mBDkqaHNjrSs=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/kustomize/api v0.8.5/go.mod h1:M377apnKT5ZHJS++6H4rQoCHmWtt6qTpp3mbe7p6OLY=


### PR DESCRIPTION


<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
#908 and also does the dependabot PR to bump HNC to v1.0.0 in full.

## What is this change about?
Bump HNC to v1.0.0 production release!!!

When taking the new `default.yaml` for v1.0.0 from the hnc release, I realised it could be easy to lose the manual modifications we had made to the previous `hnc-manager-v0.9.0.yaml` file. So I've put the changes
in a patch file to apply with kustomize to make this more secure.

The bash lines to wait for HNC to come up fully have also been removed as v1.0.0 has a proper /readyz implementation.

Fixes: https://github.com/cloudfoundry/cf-k8s-controllers/issues/908

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es green

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
