### PR TITLE
Update kbld config to use kubectlBuildkit

### DIFF
--- a/scripts/assets/cf-k8s-api-kbld.yml
+++ b/scripts/assets/cf-k8s-api-kbld.yml
@@ -4,11 +4,9 @@ kind: Config
 sources:
 - image: cloudfoundry/cf-k8s-api:latest
   path: .
-  docker:
+  kubectlBuildkit:
     build:
       file: api/Dockerfile
-      # rawOptions: ["--build-arg", "GIT_SHA=eirini-controller-dirty", "--tag", "eirini-controller"]
-      buildkit: true
 destinations:
 - image: cloudfoundry/cf-k8s-api:latest
   newImage: europe-west1-docker.pkg.dev/cf-on-k8s-wg/ci/cf-k8s-api

--- a/scripts/assets/cf-k8s-controllers-kbld.yml
+++ b/scripts/assets/cf-k8s-controllers-kbld.yml
@@ -4,11 +4,9 @@ kind: Config
 sources:
 - image: cloudfoundry/cf-k8s-controllers:latest
   path: .
-  docker:
+  kubectlBuildkit:
     build:
       file: controllers/Dockerfile
-      # rawOptions: ["--build-arg", "GIT_SHA=eirini-controller-dirty", "--tag", "eirini-controller"]
-      buildkit: true
 destinations:
 - image: cloudfoundry/cf-k8s-controllers:latest
   newImage: europe-west1-docker.pkg.dev/cf-on-k8s-wg/ci/cf-k8s-controllers


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ -->
No

## What is this change about?
<!-- _Please describe the change here._ -->
This aligns the config with the concourse e2e configuration, which no longer uses docker to build the images within a docker-in-docker container image.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
The e2e deploy step on concourse should succeed.

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
