### PR TITLE
Make sure `cf_user` bindings are never propagated

### DIFF
--- a/api/repositories/role_repository.go
+++ b/api/repositories/role_repository.go
@@ -123,7 +123,9 @@ func (r *RoleRepo) CreateRole(ctx context.Context, authInfo authorization.Info, 
 		return RoleRecord{}, fmt.Errorf("invalid role type: %q", cfUserRoleType)
 	}
 
-	cfUserRoleBinding := createRoleBinding(r.rootNamespace, cfUserRoleType, role.Kind, role.User, uuid.NewString(), cfUserk8sRoleConfig.Name, annotations)
+	cfUserRoleBinding := createRoleBinding(r.rootNamespace, cfUserRoleType, role.Kind, role.User, uuid.NewString(), cfUserk8sRoleConfig.Name, map[string]string{
+		hnsv1alpha2.AnnotationNoneSelector: "true",
+	})
 	err = r.privilegedClient.Create(ctx, &cfUserRoleBinding)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {

--- a/api/repositories/role_repository_test.go
+++ b/api/repositories/role_repository_test.go
@@ -127,8 +127,9 @@ var _ = Describe("RoleRepository", func() {
 						roleCreateMessage.Type = "organization_manager"
 					})
 
-					It("enables the role binding propagation", func() {
+					It("enables the role binding propagation, but not for cf_user", func() {
 						Expect(getTheRoleBinding(expectedName, orgAnchor.Name).Annotations).NotTo(HaveKey(HavePrefix(hnsv1alpha2.AnnotationPropagatePrefix)))
+						Expect(getTheRoleBinding(cfUserExpectedName, rootNamespace).Annotations).To(HaveKeyWithValue(hnsv1alpha2.AnnotationNoneSelector, "true"))
 					})
 				})
 
@@ -139,9 +140,9 @@ var _ = Describe("RoleRepository", func() {
 						expectedName = "cf-2a6f4cbdd1777d57b5b7b2ee835785dafa68c147719c10948397cfc2ea7246a3"
 					})
 
-					It("enables the role binding propagation", func() {
-						Expect(createErr).NotTo(HaveOccurred())
+					It("disables the role binding propagation", func() {
 						Expect(getTheRoleBinding(expectedName, orgAnchor.Name).Annotations).To(HaveKeyWithValue(hnsv1alpha2.AnnotationNoneSelector, "true"))
+						Expect(getTheRoleBinding(cfUserExpectedName, rootNamespace).Annotations).To(HaveKeyWithValue(hnsv1alpha2.AnnotationNoneSelector, "true"))
 					})
 				})
 			})


### PR DESCRIPTION
## Is there a related GitHub Issue?
#905

## What is this change about?
This makes sure that `cf_user` bindings are always annotated with `propagate.hnc.x-k8s.io/none=true`, as we never want them to propagate.

## Does this PR introduce a breaking change?
No.

## Acceptance Steps
* Create `org1` with `space1` inside it.
* Assign `OrgManager` to user `foo` in `org1`
* See that the `root-namespace-rolebinding` for user `foo` only exists in the `cf` namespace, but *not* in the `org1` or `space1` namespaces.
