### PR TITLE
retry getting service account tokens

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -23,8 +23,8 @@ getToken() {
   local name namespace secret
   name=${1:?}
   namespace=${2:?}
-  secret="$(kubectl get serviceaccounts -n "$namespace" "$name" -ojsonpath='{.secrets[0].name}')"
-  kubectl get secrets -n "$namespace" "$secret" -ojsonpath='{.data.token}' | base64 -d
+  secretName="$(kubectl get serviceaccounts -n "$namespace" "$name" -ojsonpath='{.secrets[0].name}')"
+  kubectl get secrets -n "$namespace" "$secretName" -ojsonpath='{.data.token}' | base64 -d
 }
 
 extra_args=()
@@ -95,7 +95,10 @@ else
 
     for n in $(seq 1 $usersToCreate); do
       E2E_SERVICE_ACCOUNTS="$E2E_SERVICE_ACCOUNTS e2e-service-account-$n"
-      token="$(getToken "e2e-service-account-$n" "$ROOT_NAMESPACE")"
+      token=""
+      while [ -z "$token" ]; do
+        token="$(getToken "e2e-service-account-$n" "$ROOT_NAMESPACE")"
+      done
       E2E_SERVICE_ACCOUNT_TOKENS="$E2E_SERVICE_ACCOUNT_TOKENS $token"
     done
     export E2E_SERVICE_ACCOUNTS E2E_SERVICE_ACCOUNT_TOKENS


### PR DESCRIPTION

<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
No

## What is this change about?
The new up-front user cert and service account creation scripting for e2es is causing a problem when the service account token isn't ready when we try to fetch it. This adds a retry loop so we will eventually get the token.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
E2es should be greener

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
