### PR TITLE
E2E flake: Check for expected result rather than length service binding list

### DIFF
--- a/api/tests/e2e/service_bindings_test.go
+++ b/api/tests/e2e/service_bindings_test.go
@@ -93,7 +93,9 @@ var _ = Describe("Service Bindings", func() {
 			It("succeeds", func() {
 				Expect(httpError).NotTo(HaveOccurred())
 				Expect(httpResp).To(HaveRestyStatusCode(http.StatusOK))
-				Expect(result.Resources).To(HaveLen(1))
+				Expect(result.Resources).To(ContainElement(
+					MatchFields(IgnoreExtras, Fields{"GUID": Equal(bindingGUID)}),
+				))
 			})
 		})
 


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
Not really, though #303 is the umbrella issue

## What is this change about?
When listing service bindings in the e2e tests, bindings might be returned that were created by tests. So check for the binding we expect and ignore others.


## Does this PR introduce a breaking change?
No

## Acceptance Steps
Run the service binding e2e tests

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
