### PR TITLE
Generate a unique app name for manifested-app application tests

### DIFF
--- a/api/tests/e2e/spaces_test.go
+++ b/api/tests/e2e/spaces_test.go
@@ -313,13 +313,14 @@ var _ = Describe("Spaces", func() {
 		BeforeEach(func() {
 			spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
 			resultErr = cfErrs{}
+			appName := generateGUID("manifested-app")
 
-			route := fmt.Sprintf("manifested-app.%s", appFQDN)
+			route := fmt.Sprintf("%s.%s", appName, appFQDN)
 			command := "whatever"
 			manifest = manifestResource{
 				Version: 1,
 				Applications: []applicationResource{{
-					Name: "manifested-app",
+					Name: appName,
 					Processes: []manifestApplicationProcessResource{{
 						Type:    "web",
 						Command: &command,


### PR DESCRIPTION
<!--
Thanks for contributing!

We've designed this PR template to speed up the PR review and merge process - please use it.
-->

## Is there a related GitHub Issue?
#303 is the umbrella issue

## What is this change about?
Since all the apply manifest tests might run in parallel, unique app and route names must be supplied to avoid duplicate naming errors.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2e test flake less

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
