### PR TITLE
Tweak waiting for HNC propagation

### DIFF
--- a/dependencies/hnc/cf/deployment.yaml
+++ b/dependencies/hnc/cf/deployment.yaml
@@ -12,7 +12,7 @@ spec:
           # adding this to only check namespaces beginning with 'cf'
         - --included-namespace-regex=cf.*
           # changing this from 50
-        - --apiserver-qps-throttle=200
+        - --apiserver-qps-throttle=50
           # the rest are from the default, but must be included :(
         - --webhook-server-port=9443
         - --metrics-addr=:8080


### PR DESCRIPTION

## Is there a related GitHub Issue?
Supposedly #303.

## What is this change about?
We have reverted the HNC qps setting to 50 as 200 seems to make GKE
cluster API unresponsive, causing nodes to be recreated.

We have also made the timeout in the org repo longer. It uses the same
timeout as used for waiting for the subnamespaceanchor to be ready.

Since the average time for propagation to complete is around 8 seconds
during heavy load on GKE during e2e tests, we have decided not to use
exponential backoff. This was missing a check at around 6 seconds then
having to wait until 12 seconds to succeed. Simply checking every 500ms
seems to provide better results.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es more stable

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
