### PR TITLE
Make cert/token creation thread safe

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -7,3 +7,35 @@ retry() {
   done
   echo
 }
+
+createCert() {
+  username=${1:-}
+  priv_key_file=${2:-}
+  cert_file=${3:-}
+  csr_file="$(mktemp)"
+  trap "rm -f $csr_file" EXIT
+  csr_name="$(echo ${RANDOM} | shasum | head -c 40)"
+
+  openssl req -new -newkey rsa:4096 \
+    -keyout "${priv_key_file}" \
+    -out "${csr_file}" \
+    -nodes \
+    -subj "/CN=${username}"
+
+  cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csr_name}
+spec:
+  signerName: "kubernetes.io/kube-apiserver-client"
+  request: "$(base64 -w0 "${csr_file}")"
+  usages:
+  - client auth
+EOF
+
+  kubectl certificate approve "${csr_name}"
+  kubectl wait --for=condition=Approved "csr/${csr_name}"
+  kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}' | base64 --decode >$cert_file
+  kubectl delete csr "${csr_name}"
+}


### PR DESCRIPTION

## Is there a related GitHub Issue?
No

## What is this change about?
Move common cert creation into common.sh and call from run-tests and create-new-user scripts.


## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es are more stable and don't fail with cert decoding errors

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
