### PR TITLE
Move default domain creation to deploy script

### DIFF
--- a/api/tests/e2e/domains_test.go
+++ b/api/tests/e2e/domains_test.go
@@ -20,13 +20,7 @@ var _ = Describe("Domain", func() {
 		var (
 			result responseResourceList
 			resp   *resty.Response
-
-			domainGUID string
 		)
-
-		BeforeEach(func() {
-			domainGUID = mustHaveEnv("APP_DOMAIN_GUID")
-		})
 
 		JustBeforeEach(func() {
 			var err error
@@ -40,7 +34,7 @@ var _ = Describe("Domain", func() {
 			It("returns a list of domains that includes the created domains", func() {
 				Expect(resp).To(HaveRestyStatusCode(http.StatusOK))
 				Expect(result.Resources).To(ContainElements(
-					MatchFields(IgnoreExtras, Fields{"GUID": Equal(domainGUID)}),
+					MatchFields(IgnoreExtras, Fields{"Name": Equal(appFQDN)}),
 				))
 			})
 		})

--- a/api/tests/e2e/routes_test.go
+++ b/api/tests/e2e/routes_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Routes", func() {
 		spaceGUID = createSpace(generateGUID("space"), commonTestOrgGUID)
 
 		domainName = mustHaveEnv("APP_FQDN")
-		domainGUID = mustHaveEnv("APP_DOMAIN_GUID")
+		domainGUID = getDomainGUID(domainName)
 
 		host = generateGUID("myapp")
 		path = generateGUID("/some-path")
@@ -273,10 +273,8 @@ var _ = Describe("Routes", func() {
 					domainName = "inv@liddom@in"
 				)
 
-				var (
-					// we need a K8s client for this test case for when the default domain name is not compliant
-					k8sClient k8sclient.WithWatch
-				)
+				// we need a K8s client for this test case for when the default domain name is not compliant
+				var k8sClient k8sclient.WithWatch
 
 				BeforeEach(func() {
 					config, err := controllerruntime.GetConfig()
@@ -359,7 +357,7 @@ var _ = Describe("Routes", func() {
 		BeforeEach(func() {
 			routeGUID = ""
 			host = generateGUID("host")
-			routeGUID = createRoute(host, "", spaceGUID, appDomainGUID)
+			routeGUID = createRoute(host, "", spaceGUID, domainGUID)
 			errResp = cfErrs{}
 		})
 

--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -283,7 +283,7 @@ function deploy_cf_k8s_controllers() {
   kubectl rollout status deployment/cf-k8s-controllers-controller-manager -w -n cf-k8s-controllers-system
 
   if [[ -n "${default_domain}" ]]; then
-    kubectl apply -f "${CONTROLLER_DIR}/config/samples/cfdomain.yaml"
+    sed 's/vcap\.me/'${APP_FQDN:-vcap.me}'/' ${CONTROLLER_DIR}/config/samples/cfdomain.yaml | kubectl apply -f-
   fi
 }
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,17 +36,11 @@ else
   export KUBECONFIG="${KUBECONFIG:-$HOME/kube/e2e.yml}"
 
   if [ -z "${SKIP_DEPLOY}" ]; then
-    "${SCRIPT_DIR}/deploy-on-kind.sh" -l e2e
+    "${SCRIPT_DIR}/deploy-on-kind.sh" -l -d e2e
   fi
 
   if [[ -z "${API_SERVER_ROOT}" ]]; then
     export API_SERVER_ROOT=https://localhost
-  fi
-
-  if [[ -z "${APP_DOMAIN_GUID}" ]]; then
-    sed 's/vcap\.me/'$APP_FQDN'/' $SCRIPT_DIR/../controllers/config/samples/cfdomain.yaml | kubectl apply -f-
-    APP_DOMAIN_GUID="$(awk '/name:/ { print $2 }' $SCRIPT_DIR/../controllers/config/samples/cfdomain.yaml | head -n1)"
-    export APP_DOMAIN_GUID
   fi
 
   if [[ -n "$GINKGO_NODES" ]]; then


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
This simplifies the deployment process to help running tests on concourse.

Creating the default domain is the responsibility of the deployment rather than running tests, so move the creation there.

Since the GUID can be determined via the API, stop passing this in as an env var to the tests.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es green

## Tag your pair, your PM, and/or team
@georgethebeatle 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
