### PR TITLE
Extract user/service account creation from run-tests script

### DIFF
--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+if [[ -n "$1" ]]; then
+  SCRIPT_DIR="$1"
+fi
+
+source "$SCRIPT_DIR/common.sh"
+
+getToken() {
+  local name namespace secret
+  name=${1:?}
+  namespace=${2:?}
+  secretName="$(kubectl get serviceaccounts -n "$namespace" "$name" -ojsonpath='{.secrets[0].name}')"
+  if [[ -n "$secretName" ]]; then
+    kubectl get secrets -n "$namespace" "$secretName" -ojsonpath='{.data.token}' | base64 -d
+  fi
+}
+
+if [[ -n "$GINKGO_NODES" ]]; then
+  extra_args+=("--procs=${GINKGO_NODES}")
+fi
+
+pushd "$SCRIPT_DIR/assets/ginkgo_parallel_count"
+{
+  usersToCreate="$(ginkgo -p "${extra_args[@]}" | awk '/ParallelNodes:/ { print $2 }' | head -n1)"
+}
+popd
+
+tmp="$(mktemp -d)"
+trap "rm -rf $tmp" EXIT
+if [[ -z "${E2E_USER_NAMES:=}" ]]; then
+  E2E_USER_PEMS=
+  for n in $(seq 1 $usersToCreate); do
+    createCert "e2e-cert-user-$n" "$tmp/key-$n.pem" "$tmp/cert-$n.pem" &
+  done
+  wait
+
+  export E2E_USER_NAMES E2E_USER_PEMS
+  for n in $(seq 1 $usersToCreate); do
+    E2E_USER_NAMES="$E2E_USER_NAMES e2e-cert-user-$n"
+    pem="$(cat $tmp/cert-${n}.pem $tmp/key-${n}.pem | base64 -w0)"
+    E2E_USER_PEMS="$E2E_USER_PEMS $pem"
+  done
+fi
+
+if [[ -z "${E2E_SERVICE_ACCOUNTS:=}" ]]; then
+  E2E_SERVICE_ACCOUNT_TOKENS=
+  for n in $(seq 1 $usersToCreate); do
+    (
+      kubectl delete serviceaccount -n "$ROOT_NAMESPACE" "e2e-service-account-$n" &>/dev/null || true
+      kubectl create serviceaccount -n "$ROOT_NAMESPACE" "e2e-service-account-$n"
+    ) &
+  done
+  wait
+
+  export E2E_SERVICE_ACCOUNTS E2E_SERVICE_ACCOUNT_TOKENS
+  for n in $(seq 1 $usersToCreate); do
+    E2E_SERVICE_ACCOUNTS="$E2E_SERVICE_ACCOUNTS e2e-service-account-$n"
+    token=""
+    while [ -z "$token" ]; do
+      token="$(getToken "e2e-service-account-$n" "$ROOT_NAMESPACE")"
+      sleep 0.5
+    done
+    E2E_SERVICE_ACCOUNT_TOKENS="$E2E_SERVICE_ACCOUNT_TOKENS $token"
+  done
+fi
+
+if [[ -z "${CF_ADMIN_CERT:=}" ]]; then
+  createCert "cf-admin" "$tmp/cf-admin-key.pem" "$tmp/cf-admin-cert.pem"
+  CF_ADMIN_KEY="$(base64 -w0 $tmp/cf-admin-key.pem)"
+  CF_ADMIN_CERT="$(base64 -w0 $tmp/cf-admin-cert.pem)"
+  export CF_ADMIN_CERT CF_ADMIN_KEY
+fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,6 +36,11 @@ EOF
 
   kubectl certificate approve "${csr_name}"
   kubectl wait --for=condition=Approved "csr/${csr_name}"
-  kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}' | base64 --decode >$cert_file
+  cert=
+  while [[ -z "$cert" ]]; do
+    cert="$(kubectl get csr "${csr_name}" -o jsonpath='{.status.certificate}')"
+  done
+
+  base64 --decode <<<$cert >$cert_file
   kubectl delete csr "${csr_name}"
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,16 +8,6 @@ source "$SCRIPT_DIR/common.sh"
 ENVTEST_ASSETS_DIR="${SCRIPT_DIR}/../testbin"
 mkdir -p "${ENVTEST_ASSETS_DIR}"
 
-getToken() {
-  local name namespace secret
-  name=${1:?}
-  namespace=${2:?}
-  secretName="$(kubectl get serviceaccounts -n "$namespace" "$name" -ojsonpath='{.secrets[0].name}')"
-  if [[ -n "$secretName" ]]; then
-    kubectl get secrets -n "$namespace" "$secretName" -ojsonpath='{.data.token}' | base64 -d
-  fi
-}
-
 extra_args=()
 if ! egrep -q e2e <(echo "$@"); then
   test -f "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" || curl -sSLo "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
@@ -27,7 +17,7 @@ if ! egrep -q e2e <(echo "$@"); then
   extra_args+=("--skip-package=e2e" "--coverprofile=cover.out" "--coverpkg=code.cloudfoundry.org/cf-k8s-controllers/...")
 
 else
-  export ROOT_NAMESPACE=cf
+  export ROOT_NAMESPACE="${ROOT_NAMESPACE:-cf}"
 
   if [[ -z "${APP_FQDN}" ]]; then
     export APP_FQDN=vcap.me
@@ -53,53 +43,8 @@ else
     extra_args+=("--procs=${GINKGO_NODES}")
   fi
 
-  pushd "$SCRIPT_DIR/assets/ginkgo_parallel_count"
-  {
-    usersToCreate="$(ginkgo -p "${extra_args[@]}" | awk '/ParallelNodes:/ { print $2 }' | head -n1)"
-  }
-  popd
-
-  tmp="$(mktemp -d)"
-  trap "rm -rf $tmp" EXIT
-  if [[ -z "$E2E_USER_NAMES" ]]; then
-    for n in $(seq 1 $usersToCreate); do
-      createCert "e2e-cert-user-$n" "$tmp/key-$n.pem" "$tmp/cert-$n.pem" &
-    done
-    wait
-
-    export E2E_USER_NAMES E2E_USER_PEMS
-    for n in $(seq 1 $usersToCreate); do
-      E2E_USER_NAMES="$E2E_USER_NAMES e2e-cert-user-$n"
-      pem="$(cat $tmp/cert-${n}.pem $tmp/key-${n}.pem | base64 -w0)"
-      E2E_USER_PEMS="$E2E_USER_PEMS $pem"
-    done
-  fi
-
-  if [[ -z "$E2E_SERVICE_ACCOUNTS" ]]; then
-    for n in $(seq 1 $usersToCreate); do
-      (
-        kubectl delete serviceaccount -n "$ROOT_NAMESPACE" "e2e-service-account-$n" &>/dev/null || true
-        kubectl create serviceaccount -n "$ROOT_NAMESPACE" "e2e-service-account-$n"
-      ) &
-    done
-    wait
-
-    export E2E_SERVICE_ACCOUNTS E2E_SERVICE_ACCOUNT_TOKENS
-    for n in $(seq 1 $usersToCreate); do
-      E2E_SERVICE_ACCOUNTS="$E2E_SERVICE_ACCOUNTS e2e-service-account-$n"
-      token=""
-      while [ -z "$token" ]; do
-        token="$(getToken "e2e-service-account-$n" "$ROOT_NAMESPACE")"
-        sleep 0.5
-      done
-      E2E_SERVICE_ACCOUNT_TOKENS="$E2E_SERVICE_ACCOUNT_TOKENS $token"
-    done
-  fi
-
-  createCert "cf-admin" "$tmp/cf-admin-key.pem" "$tmp/cf-admin-cert.pem"
-  CF_ADMIN_KEY="$(base64 -w0 $tmp/cf-admin-key.pem)"
-  CF_ADMIN_CERT="$(base64 -w0 $tmp/cf-admin-cert.pem)"
-  export CF_ADMIN_CERT CF_ADMIN_KEY
+  # creates user keys/certs and service accounts and exports vars for them
+  source "$SCRIPT_DIR/account-creation.sh" "$SCRIPT_DIR"
 
   extra_args+=("--slow-spec-threshold=30s")
 fi


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
Extract creation of user certs/keys and service accounts/tokens from the run-tests script. Place it in a separate file that can be sourced from run-tests and in a concourse task

## Does this PR introduce a breaking change?
No

## Acceptance Steps
e2es green

## Tag your pair, your PM, and/or team
@georgethebeatle 

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
