### PR TITLE
Update exploration issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/explore.yaml
+++ b/.github/ISSUE_TEMPLATE/explore.yaml
@@ -25,7 +25,9 @@ body:
   - type: textarea
     id: timebox
     attributes:
-      label: Number of days this exploration is expected to take. This is what is “pointed”.
+      label: Timebox
+      description: Is there a timebox for this exploration? If so, record how many days we plan on spending on this.
+      value: No timebox
   - type: textarea
     id: dev-notes
     attributes:


### PR DESCRIPTION
## Is there a related GitHub Issue?
No

## What is this change about?
We talked as a team about how we've been using the "days to checkin" discussion during IPM just to discuss complexity and not to actually determine a timebox. Updating this template to make it more clear that this is optional and can be included if we decide an explicit timebox is helpful.

## Does this PR introduce a breaking change?
No

## Acceptance Steps
Create a new explore issue and make sure it looks good.

## Tag your pair, your PM, and/or team
@davewalter @Birdrock 
