### PR TITLE
Fix flakey behaviour with creating cfspace

### DIFF
--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -229,13 +229,14 @@ func createSpaceAnchorAndNamespace(ctx context.Context, orgName, name string) *h
 	return space
 }
 
-func createNamespace(ctx context.Context, orgName, name string) *corev1.Namespace {
+func createNamespace(ctx context.Context, orgName, name string, labels map[string]string) *corev1.Namespace {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
 				hnsv1alpha2.SubnamespaceOf: orgName,
 			},
+			Labels: labels,
 		},
 	}
 	Expect(k8sClient.Create(ctx, namespace)).To(Succeed())


### PR DESCRIPTION
## Is there a related GitHub Issue?
No, but related to #928

## What is this change about?
- We ran into an issues with creating cf-spaces where the creation would fail with cf-org not found error.

- Having a check to see if the user is able to list apps after creation of orgs and spaces would not work the way we expect if the user is a k8s "cluster-admin". The cluster-admins have permissions to list any object.

- Added a better check to make sure that the role binding exists for the current user in the newly created namespace before returning success on create orgs and spaces

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->
No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->
- `make test-e2e` should pass
- smoke tests should pass consistently

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->
@gnovv @clintyoshimura 
