### PR TITLE
Remove Eventually statements from api related tests

### DIFF
--- a/api/apis/integration/app_test.go
+++ b/api/apis/integration/app_test.go
@@ -199,9 +199,7 @@ var _ = Describe("App Handler", func() {
 					Namespace: spaceGUID,
 				}
 				var appRecord workloads.CFApp
-				Eventually(func() error {
-					return k8sClient.Get(ctx, appNSName, &appRecord)
-				}).Should(Succeed())
+				Expect(k8sClient.Get(ctx, appNSName, &appRecord)).To(Succeed())
 
 				Expect(appRecord.Spec.Name).To(Equal("my-test-app"))
 				Expect(appRecord.Spec.DesiredState).To(BeEquivalentTo("STOPPED"))
@@ -212,9 +210,7 @@ var _ = Describe("App Handler", func() {
 					Namespace: spaceGUID,
 				}
 				var secretCR corev1.Secret
-				Eventually(func() error {
-					return k8sClient.Get(ctx, secretNSName, &secretCR)
-				}).Should(Succeed())
+				Expect(k8sClient.Get(ctx, secretNSName, &secretCR)).To(Succeed())
 
 				Expect(secretCR.Data).To(MatchAllKeys(Keys{
 					"foo": BeEquivalentTo(testEnvironmentVariables["foo"]),

--- a/api/apis/integration/apply_manifest_test.go
+++ b/api/apis/integration/apply_manifest_test.go
@@ -506,7 +506,7 @@ var _ = Describe("POST /v3/spaces/<space-guid>/actions/apply_manifest endpoint",
 				var app1 workloadsv1alpha1.CFApp
 				By("confirming that the app fields are unchanged", func() {
 					var appList workloadsv1alpha1.CFAppList
-					Eventually(func() []workloadsv1alpha1.CFApp {
+					Consistently(func() []workloadsv1alpha1.CFApp {
 						Expect(
 							k8sClient.List(context.Background(), &appList, client.InNamespace(namespace.Name)),
 						).To(Succeed())

--- a/api/apis/integration/integration_suite_test.go
+++ b/api/apis/integration/integration_suite_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -212,9 +211,6 @@ func createRoleBinding(ctx context.Context, userName, roleName, namespace string
 		},
 	}
 	Expect(k8sClient.Create(ctx, &roleBinding)).To(Succeed())
-	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: roleBinding.Name, Namespace: namespace}, &rbacv1.RoleBinding{})
-	}).Should(Succeed())
 }
 
 func createAnchorAndNamespace(ctx context.Context, inNamespace, name, orgSpaceLabel string) (*hnsv1alpha2.SubnamespaceAnchor, *corev1.Namespace) {

--- a/api/repositories/domain_repository_test.go
+++ b/api/repositories/domain_repository_test.go
@@ -288,12 +288,9 @@ var _ = Describe("DomainRepository", func() {
 						}
 					})
 
-					It("eventually returns a list of domainRecords for each CFDomain CR that matches the key with value", func() {
-						var domainRecords []DomainRecord
-						Eventually(func() []DomainRecord {
-							domainRecords, _ = domainRepo.ListDomains(testCtx, authInfo, domainListMessage)
-							return domainRecords
-						}, timeCheckThreshold*time.Second).Should(HaveLen(2), "returned records count should equal number of created CRs")
+					It("returns a list of domainRecords for each CFDomain CR that matches the key with value", func() {
+						domainRecords, err := domainRepo.ListDomains(testCtx, authInfo, domainListMessage)
+						Expect(err).NotTo(HaveOccurred())
 
 						var domain1, domain2 DomainRecord
 						for _, domainRecord := range domainRecords {

--- a/api/repositories/org_repository_test.go
+++ b/api/repositories/org_repository_test.go
@@ -265,15 +265,8 @@ var _ = Describe("OrgRepository", func() {
 
 					By("Creating ServiceAccounts in the Space namespace", func() {
 						serviceAccountList := corev1.ServiceAccountList{}
-						var err error
-						Eventually(func() []corev1.ServiceAccount {
-							err = k8sClient.List(ctx, &serviceAccountList, client.InNamespace(space.GUID))
-							if err != nil {
-								return []corev1.ServiceAccount{}
-							}
-							return serviceAccountList.Items
-						}, timeCheckThreshold*time.Second, 250*time.Millisecond).Should(HaveLen(2), "could not find the service accounts created by the repo")
-						Expect(err).NotTo(HaveOccurred())
+						Expect(k8sClient.List(ctx, &serviceAccountList, client.InNamespace(space.GUID))).To(Succeed())
+						Expect(serviceAccountList.Items).To(HaveLen(2))
 
 						sort.Slice(serviceAccountList.Items, func(i, j int) bool {
 							return serviceAccountList.Items[i].Name < serviceAccountList.Items[j].Name
@@ -738,10 +731,9 @@ var _ = Describe("OrgRepository", func() {
 						})
 						Expect(err).NotTo(HaveOccurred())
 
-						Eventually(func() error {
-							anchor := &hncv1alpha2.SubnamespaceAnchor{}
-							return k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNamespace, Name: orgAnchor.Name}, anchor)
-						}).Should(MatchError(ContainSubstring("not found")))
+						anchor := &hncv1alpha2.SubnamespaceAnchor{}
+						err = k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNamespace, Name: orgAnchor.Name}, anchor)
+						Expect(err).To(MatchError(ContainSubstring("not found")))
 					})
 				})
 
@@ -794,10 +786,9 @@ var _ = Describe("OrgRepository", func() {
 					})
 					Expect(err).NotTo(HaveOccurred())
 
-					Eventually(func() error {
-						anchor := &hncv1alpha2.SubnamespaceAnchor{}
-						return k8sClient.Get(ctx, client.ObjectKey{Namespace: orgAnchor.Name, Name: spaceAnchor.Name}, anchor)
-					}).Should(MatchError(ContainSubstring("not found")))
+					anchor := &hncv1alpha2.SubnamespaceAnchor{}
+					err = k8sClient.Get(ctx, client.ObjectKey{Namespace: orgAnchor.Name, Name: spaceAnchor.Name}, anchor)
+					Expect(err).To(MatchError(ContainSubstring("not found")))
 				})
 
 				When("the space doesn't exist", func() {

--- a/api/repositories/package_repository_test.go
+++ b/api/repositories/package_repository_test.go
@@ -89,10 +89,7 @@ var _ = Describe("PackageRepository", func() {
 
 				packageNSName := types.NamespacedName{Name: packageGUID, Namespace: space.Name}
 				createdCFPackage := new(workloadsv1alpha1.CFPackage)
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, packageNSName, createdCFPackage)
-					return err == nil
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				Expect(k8sClient.Get(ctx, packageNSName, createdCFPackage)).To(Succeed())
 
 				Expect(createdCFPackage.Name).To(Equal(packageGUID))
 				Expect(createdCFPackage.Namespace).To(Equal(space.Name))
@@ -490,17 +487,14 @@ var _ = Describe("PackageRepository", func() {
 
 			It("updates only the Registry field of the existing CFPackage", func() {
 				packageNSName := types.NamespacedName{Name: packageGUID, Namespace: space.Name}
-				createdCFPackage := new(workloadsv1alpha1.CFPackage)
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, packageNSName, createdCFPackage)
-					return err == nil
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				updatedCFPackage := new(workloadsv1alpha1.CFPackage)
+				Expect(k8sClient.Get(ctx, packageNSName, updatedCFPackage)).To(Succeed())
 
-				Expect(createdCFPackage.Name).To(Equal(existingCFPackage.Name))
-				Expect(createdCFPackage.Namespace).To(Equal(existingCFPackage.Namespace))
-				Expect(createdCFPackage.Spec.Type).To(Equal(existingCFPackage.Spec.Type))
-				Expect(createdCFPackage.Spec.AppRef).To(Equal(existingCFPackage.Spec.AppRef))
-				Expect(createdCFPackage.Spec.Source.Registry).To(Equal(workloadsv1alpha1.Registry{
+				Expect(updatedCFPackage.Name).To(Equal(existingCFPackage.Name))
+				Expect(updatedCFPackage.Namespace).To(Equal(existingCFPackage.Namespace))
+				Expect(updatedCFPackage.Spec.Type).To(Equal(existingCFPackage.Spec.Type))
+				Expect(updatedCFPackage.Spec.AppRef).To(Equal(existingCFPackage.Spec.AppRef))
+				Expect(updatedCFPackage.Spec.Source.Registry).To(Equal(workloadsv1alpha1.Registry{
 					Image:            packageSourceImageRef,
 					ImagePullSecrets: []corev1.LocalObjectReference{{Name: packageRegistrySecretName}},
 				}))

--- a/api/repositories/process_repository_test.go
+++ b/api/repositories/process_repository_test.go
@@ -527,12 +527,8 @@ var _ = Describe("ProcessRepo", func() {
 						Expect(updatedProcessRecord.DiskQuotaMB).To(Equal(*message.DiskQuotaMB))
 
 						var process workloadsv1alpha1.CFProcess
-						Eventually(func() workloadsv1alpha1.CFProcessSpec {
-							Expect(
-								k8sClient.Get(ctx, types.NamespacedName{Name: process1GUID, Namespace: space.Name}, &process),
-							).To(Succeed())
-							return process.Spec
-						}).Should(Equal(workloadsv1alpha1.CFProcessSpec{
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: process1GUID, Namespace: space.Name}, &process)).To(Succeed())
+						Expect(process.Spec).To(Equal(workloadsv1alpha1.CFProcessSpec{
 							AppRef:      corev1.LocalObjectReference{Name: app1GUID},
 							ProcessType: "web",
 							Command:     "start-web",
@@ -579,12 +575,9 @@ var _ = Describe("ProcessRepo", func() {
 						Expect(updatedProcessRecord.DiskQuotaMB).To(Equal(cfProcess.Spec.DiskQuotaMB))
 
 						var process workloadsv1alpha1.CFProcess
-						Eventually(func() workloadsv1alpha1.CFProcessSpec {
-							Expect(
-								k8sClient.Get(ctx, types.NamespacedName{Name: process1GUID, Namespace: space.Name}, &process),
-							).To(Succeed())
-							return process.Spec
-						}).Should(Equal(workloadsv1alpha1.CFProcessSpec{
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: process1GUID, Namespace: space.Name}, &process)).To(Succeed())
+
+						Expect(process.Spec).To(Equal(workloadsv1alpha1.CFProcessSpec{
 							AppRef:      corev1.LocalObjectReference{Name: app1GUID},
 							ProcessType: "web",
 							Command:     "new-command",

--- a/api/repositories/repositories_suite_test.go
+++ b/api/repositories/repositories_suite_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -259,9 +258,6 @@ func createRoleBinding(ctx context.Context, userName, roleName, namespace string
 		},
 	}
 	Expect(k8sClient.Create(ctx, &roleBinding)).To(Succeed())
-	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: roleBinding.Name, Namespace: namespace}, &rbacv1.RoleBinding{})
-	}).Should(Succeed())
 }
 
 func createClusterRoleBinding(ctx context.Context, userName, roleName string) {
@@ -279,9 +275,6 @@ func createClusterRoleBinding(ctx context.Context, userName, roleName string) {
 		},
 	}
 	Expect(k8sClient.Create(ctx, &clusterRoleBinding)).To(Succeed())
-	Eventually(func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: clusterRoleBinding.Name}, &rbacv1.ClusterRoleBinding{})
-	}).Should(Succeed())
 }
 
 func createClusterRole(ctx context.Context, filename string) *rbacv1.ClusterRole {

--- a/api/tests/e2e/service_instances_test.go
+++ b/api/tests/e2e/service_instances_test.go
@@ -64,14 +64,11 @@ var _ = Describe("Service Instances", func() {
 				Expect(httpError).NotTo(HaveOccurred())
 				Expect(httpResp).To(HaveRestyStatusCode(http.StatusCreated))
 
-				Eventually(func(g Gomega) {
-					serviceInstances := listServiceInstances()
-					g.Expect(serviceInstances.Resources).To(ContainElement(
-						MatchFields(IgnoreExtras, Fields{
-							"Name": Equal(instanceName),
-						})),
-					)
-				}).Should(Succeed())
+				Expect(listServiceInstances().Resources).To(ContainElement(
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal(instanceName),
+					})),
+				)
 			})
 		})
 
@@ -120,9 +117,7 @@ var _ = Describe("Service Instances", func() {
 			})
 
 			It("deletes the service instance", func() {
-				Eventually(func() []resource {
-					return listServiceInstances().Resources
-				}).ShouldNot(ContainElement(
+				Expect(listServiceInstances().Resources).NotTo(ContainElement(
 					MatchFields(IgnoreExtras, Fields{
 						"Name": Equal(existingInstanceName),
 						"GUID": Equal(existingInstanceGUID),

--- a/api/tests/integration/token_reviewer_test.go
+++ b/api/tests/integration/token_reviewer_test.go
@@ -30,11 +30,9 @@ var _ = Describe("TokenReviewer", func() {
 	})
 
 	JustBeforeEach(func() {
-		Eventually(func() error {
-			var err error
-			id, err = tokenReviewer.WhoAmI(ctx, token)
-			return err
-		}).Should(passErrConstraints)
+		var err error
+		id, err = tokenReviewer.WhoAmI(ctx, token)
+		Expect(err).To(passErrConstraints)
 	})
 
 	It("extracts identity from a valid token", func() {


### PR DESCRIPTION
Some Eventually's that make sense have been left in place. This is
usually the case for resources that are not directly created by the
client (e.g. process, droplet, etc). When the API has async contract by
returning a 202 with a Location header, the same applies. In all other
cases we assume that resources should be directly available to the
client.

The goal is to expose any potential flakes due to the async nature of
k8s, evaluate how critical they are and decide how to best handle them,
rather than the current approach of hiding this information.