### PR TITLE
Fix the scripts to work on Macs

### DIFF
--- a/scripts/account-creation.sh
+++ b/scripts/account-creation.sh
@@ -38,7 +38,7 @@ if [[ -z "${E2E_USER_NAMES:=}" ]]; then
   export E2E_USER_NAMES E2E_USER_PEMS
   for n in $(seq 1 $usersToCreate); do
     E2E_USER_NAMES="$E2E_USER_NAMES e2e-cert-user-$n"
-    pem="$(cat $tmp/cert-${n}.pem $tmp/key-${n}.pem | base64 -w0)"
+    pem="$(cat $tmp/cert-${n}.pem $tmp/key-${n}.pem | base64 | tr -d "\n\r")"
     E2E_USER_PEMS="$E2E_USER_PEMS $pem"
   done
 fi
@@ -67,7 +67,7 @@ fi
 
 if [[ -z "${CF_ADMIN_CERT:=}" ]]; then
   createCert "cf-admin" "$tmp/cf-admin-key.pem" "$tmp/cf-admin-cert.pem"
-  CF_ADMIN_KEY="$(base64 -w0 $tmp/cf-admin-key.pem)"
-  CF_ADMIN_CERT="$(base64 -w0 $tmp/cf-admin-cert.pem)"
+  CF_ADMIN_KEY="$(base64 $tmp/cf-admin-key.pem | tr -d "\n\r")"
+  CF_ADMIN_CERT="$(base64 $tmp/cf-admin-cert.pem | tr -d "\n\r")"
   export CF_ADMIN_CERT CF_ADMIN_KEY
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -29,7 +29,7 @@ metadata:
   name: ${csr_name}
 spec:
   signerName: "kubernetes.io/kube-apiserver-client"
-  request: "$(base64 -w0 "${csr_file}")"
+  request: "$(base64 "${csr_file}" | tr -d "\n\r")"
   usages:
   - client auth
 EOF


### PR DESCRIPTION
## Is there a related GitHub Issue?
<!-- _If there is a corresponding GitHub Issue, please link it here._ --> No

## What is this change about?
<!-- _Please describe the change here._ -->
After recent changes to the scripts, they no longer run successfully on Mac computers due to different flags for `base64`. This PR accomplishes the same output in a way that works on both Mac and Linux.

## Does this PR introduce a breaking change?
<!-- _Please let us know if we should expect breaking changes in this PR._ -->No

## Acceptance Steps
<!-- _Please replace this with a series of instructions (e.g.: kubectl, make) for how we can verify that your changes were properly integrated._ -->Run the `./scripts/deploy-on-kind.sh` script locally and see that it succeeds

## Tag your pair, your PM, and/or team
<!-- _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._ -->

## Things to remember
<!--
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- This project follows the Cloud Foundry [Code of Conduct](https://www.cloudfoundry.org/code-of-conduct/)
-->
